### PR TITLE
Annotation persistence (Rust core) + shell UI overhaul (RR6/RR7/RR10/RR16/RR17/RR20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkread-ink"
+version = "0.1.0"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,9 +535,12 @@ name = "reader-core"
 version = "0.1.0"
 dependencies = [
  "device-eink",
+ "inkread-ink",
  "jni",
  "pdfium-render",
  "rusqlite",
+ "serde",
+ "serde_json",
  "tiny-skia",
 ]
 
@@ -586,6 +595,49 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "shlex"
@@ -897,6 +949,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ reader-core = { path = "reader-core" }
 pdfium-render = { version = "0.9.1", features = ["thread_safe"] }
 tiny-skia = "0.11"
 jni = "0.22.4"
+# serde + serde_json (both MIT/Apache, AGPL-compatible — auto-passes check-licenses.sh) back the
+# portable sidecar `metadata.json` (RR10-FR5 JSON interop). Pure Rust; the host build stays hermetic.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 # rusqlite with `bundled` SQLite (compiled from source) so the host build is hermetic and the
 # Android cdylib cross-compiles the same engine — no system-library dependency (ADR Decision 4).
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 # RR1-AC3: bare `cargo test -p reader-core` builds with `jni` absent from the resolved graph.
 [workspace]
 resolver = "2"
-members = ["device-eink", "reader-core", "reader-desktop"]
+members = ["device-eink", "inkread-ink", "reader-core", "reader-desktop"]
 
 [workspace.package]
 version = "0.1.0"
@@ -20,6 +20,7 @@ repository = "https://github.com/jraghavan/inkread"
 [workspace.dependencies]
 # Internal crates.
 device-eink = { path = "device-eink" }
+inkread-ink = { path = "inkread-ink" }
 reader-core = { path = "reader-core" }
 
 # External — versions verified against docs.rs at implementation time.

--- a/LICENSES-3RDPARTY.md
+++ b/LICENSES-3RDPARTY.md
@@ -9,11 +9,12 @@ the dependency set changes.
 
 - **pdfium** (`libpdfium.so`/`.dylib`, bblanchon prebuilt, pinned `chromium/7881` = PDFium 151.0.7881.0) — **BSD-3-Clause** (PDFium) — clean; bundled under `app/src/main/jniLibs/` on device and bound via `PDFIUM_DYNAMIC_LIB_PATH` on the host (RR5-FR1/FR5). Attribution: see the PDFium and bblanchon/pdfium-binaries notices.
 
-## Rust dependencies (87 crates, all features)
+## Rust dependencies (106 crates, all features)
 
 | Crate | Version | License (SPDX) |
 |---|---|---|
 | adler2 | 2.0.1 | 0BSD OR MIT OR Apache-2.0 |
+| ahash | 0.8.12 | MIT OR Apache-2.0 |
 | android_system_properties | 0.1.5 | MIT/Apache-2.0 |
 | arrayref | 0.3.9 | BSD-2-Clause |
 | arrayvec | 0.7.6 | MIT OR Apache-2.0 |
@@ -34,16 +35,21 @@ the dependency set changes.
 | core-foundation-sys | 0.8.7 | MIT OR Apache-2.0 |
 | crc32fast | 1.5.0 | MIT OR Apache-2.0 |
 | either | 1.16.0 | MIT OR Apache-2.0 |
+| fallible-iterator | 0.3.0 | MIT/Apache-2.0 |
+| fallible-streaming-iterator | 0.1.9 | MIT/Apache-2.0 |
 | fdeflate | 0.3.7 | MIT OR Apache-2.0 |
 | find-msvc-tools | 0.1.9 | MIT OR Apache-2.0 |
 | flate2 | 1.1.9 | MIT OR Apache-2.0 |
 | futures-core | 0.3.32 | MIT OR Apache-2.0 |
 | futures-task | 0.3.32 | MIT OR Apache-2.0 |
 | futures-util | 0.3.32 | MIT OR Apache-2.0 |
+| hashbrown | 0.14.5 | MIT OR Apache-2.0 |
+| hashlink | 0.9.1 | MIT OR Apache-2.0 |
 | iana-time-zone | 0.1.65 | MIT OR Apache-2.0 |
 | iana-time-zone-haiku | 0.1.2 | MIT OR Apache-2.0 |
 | image | 0.25.10 | MIT OR Apache-2.0 |
 | itertools | 0.14.0 | MIT OR Apache-2.0 |
+| itoa | 1.0.18 | MIT OR Apache-2.0 |
 | jni | 0.22.4 | MIT OR Apache-2.0 |
 | jni-macros | 0.22.4 | MIT OR Apache-2.0 |
 | jni-sys | 0.4.1 | MIT OR Apache-2.0 |
@@ -51,6 +57,7 @@ the dependency set changes.
 | js-sys | 0.3.100 | MIT OR Apache-2.0 |
 | libc | 0.2.186 | MIT OR Apache-2.0 |
 | libloading | 0.9.0 | ISC |
+| libsqlite3-sys | 0.30.1 | MIT |
 | log | 0.4.32 | MIT OR Apache-2.0 |
 | maybe-owned | 0.3.4 | MIT OR Apache-2.0 |
 | memchr | 2.8.1 | Unlicense OR MIT |
@@ -61,19 +68,26 @@ the dependency set changes.
 | pdfium-render | 0.9.1 | MIT OR Apache-2.0 |
 | pin-project-lite | 0.2.17 | Apache-2.0 OR MIT |
 | piston-float | 1.0.1 | MIT |
+| pkg-config | 0.3.33 | MIT OR Apache-2.0 |
 | png | 0.17.16 | MIT OR Apache-2.0 |
 | proc-macro2 | 1.0.106 | MIT OR Apache-2.0 |
 | pxfm | 0.1.29 | BSD-3-Clause OR Apache-2.0 |
 | quote | 1.0.45 | MIT OR Apache-2.0 |
+| rusqlite | 0.32.1 | MIT |
 | rustc_version | 0.4.1 | MIT OR Apache-2.0 |
 | rustversion | 1.0.22 | MIT OR Apache-2.0 |
 | same-file | 1.0.6 | Unlicense/MIT |
 | semver | 1.0.28 | MIT OR Apache-2.0 |
+| serde | 1.0.228 | MIT OR Apache-2.0 |
+| serde_core | 1.0.228 | MIT OR Apache-2.0 |
+| serde_derive | 1.0.228 | MIT OR Apache-2.0 |
+| serde_json | 1.0.150 | MIT OR Apache-2.0 |
 | shlex | 2.0.1 | MIT OR Apache-2.0 |
 | simd-adler32 | 0.3.9 | MIT |
 | simd_cesu8 | 1.1.1 | Apache-2.0 OR MIT |
 | simdutf8 | 0.1.5 | MIT OR Apache-2.0 |
 | slab | 0.4.12 | MIT |
+| smallvec | 1.15.2 | MIT OR Apache-2.0 |
 | strict-num | 0.1.1 | MIT |
 | syn | 2.0.117 | MIT OR Apache-2.0 |
 | thiserror | 2.0.18 | MIT OR Apache-2.0 |
@@ -82,7 +96,9 @@ the dependency set changes.
 | tiny-skia-path | 0.11.4 | BSD-3-Clause |
 | unicode-ident | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |
 | utf16string | 0.2.0 | MIT OR Apache-2.0 |
+| vcpkg | 0.2.15 | MIT/Apache-2.0 |
 | vecmath | 1.0.0 | MIT |
+| version_check | 0.9.5 | MIT/Apache-2.0 |
 | walkdir | 2.5.0 | Unlicense/MIT |
 | wasm-bindgen | 0.2.123 | MIT OR Apache-2.0 |
 | wasm-bindgen-futures | 0.4.73 | MIT OR Apache-2.0 |
@@ -98,6 +114,9 @@ the dependency set changes.
 | windows-result | 0.4.1 | MIT OR Apache-2.0 |
 | windows-strings | 0.5.1 | MIT OR Apache-2.0 |
 | windows-sys | 0.61.2 | MIT OR Apache-2.0 |
+| zerocopy | 0.8.52 | BSD-2-Clause OR Apache-2.0 OR MIT |
+| zerocopy-derive | 0.8.52 | BSD-2-Clause OR Apache-2.0 OR MIT |
+| zmij | 1.0.21 | MIT |
 | zune-core | 0.5.1 | MIT OR Apache-2.0 OR Zlib |
 | zune-jpeg | 0.5.15 | MIT OR Apache-2.0 OR Zlib |
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,12 +7,13 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:label="inkread"
+        android:label="InkRead"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
 
+        <!-- Home screen + launcher: brand and entry points (Open / Library / Continue). -->
         <activity
-            android:name=".ReaderActivity"
+            android:name=".HomeActivity"
             android:exported="true"
             android:configChanges="orientation|screenSize|keyboardHidden">
             <intent-filter>
@@ -20,5 +21,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- The reader; launched from Home with a book / pick / resume extra (not exported). -->
+        <activity
+            android:name=".ReaderActivity"
+            android:exported="false"
+            android:configChanges="orientation|screenSize|keyboardHidden" />
     </application>
 </manifest>

--- a/app/src/main/java/dev/jraghavan/inkread/Bookmarks.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Bookmarks.kt
@@ -1,0 +1,61 @@
+package dev.jraghavan.inkread
+
+import android.util.Log
+import org.json.JSONArray
+import java.io.File
+
+/**
+ * Per-book bookmarks (RR16/RR12): a sorted set of 0-based page indices persisted to a small JSON
+ * sidecar so they survive page turns and restarts. Mirrors [InkStore]'s interim Kotlin-side
+ * persistence; the canonical model is destined for `reader-core`. Engine-thread only (RR21).
+ */
+class Bookmarks(private val file: File) {
+
+    private val pages = sortedSetOf<Int>()
+
+    /** Load the sidecar (if present); a corrupt/missing file yields an empty set, never throws. */
+    fun load() {
+        pages.clear()
+        if (!file.exists()) return
+        try {
+            val arr = JSONArray(file.readText())
+            for (i in 0 until arr.length()) pages.add(arr.getInt(i))
+        } catch (e: Exception) {
+            Log.w(TAG, "bookmarks load failed (${file.name}): ${e.message}")
+            pages.clear()
+        }
+    }
+
+    /** Bookmarked pages, ascending. */
+    fun pages(): List<Int> = pages.toList()
+
+    fun has(page: Int): Boolean = pages.contains(page)
+
+    /** Toggle `page`; returns true if it is now bookmarked. Persists immediately. */
+    fun toggle(page: Int): Boolean {
+        val added = if (pages.contains(page)) {
+            pages.remove(page)
+            false
+        } else {
+            pages.add(page)
+            true
+        }
+        save()
+        return added
+    }
+
+    private fun save() {
+        try {
+            val arr = JSONArray()
+            for (p in pages) arr.put(p)
+            file.parentFile?.mkdirs()
+            file.writeText(arr.toString())
+        } catch (e: Exception) {
+            Log.w(TAG, "bookmarks save failed (${file.name}): ${e.message}")
+        }
+    }
+
+    private companion object {
+        const val TAG = "Bookmarks"
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -1,0 +1,126 @@
+package dev.jraghavan.inkread
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.provider.OpenableColumns
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * A minimal on-device book library (RR17) for the shell: imported PDFs live under
+ * `filesDir/books/` (kept, not overwritten) so [HomeActivity] and the reader's Library popup can
+ * list and reopen them. The Rust core owns reading state per book id; here a book's **file name**
+ * is its stable id.
+ */
+object Books {
+    /** The books directory (created on demand). */
+    fun dir(context: Context): File = File(context.filesDir, "books").apply { mkdirs() }
+
+    /** Every imported PDF, sorted by name (case-insensitive). */
+    fun list(context: Context): List<File> =
+        dir(context)
+            .listFiles { f -> f.isFile && f.extension.equals("pdf", ignoreCase = true) }
+            ?.sortedBy { it.name.lowercase() }
+            ?: emptyList()
+
+    /**
+     * Copy a SAF-picked PDF into the books dir under a sanitized name derived from its display
+     * name, returning the stored file (or null on failure). A re-import of the same display name
+     * overwrites — the name is the book's identity. Runs IO; call off the UI thread.
+     */
+    fun importFrom(context: Context, uri: Uri): File? {
+        val base = sanitize(queryName(context, uri) ?: "document")
+        val dest = File(dir(context), "$base.pdf")
+        return try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                dest.outputStream().use { out -> input.copyTo(out) }
+            } ?: return null
+            dest
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** A human title for a stored book file (drop the `.pdf`). */
+    fun title(file: File): String = file.nameWithoutExtension
+
+    // ---- first-page thumbnails (RR17-FR5) ----
+
+    private fun thumbsDir(context: Context): File = File(context.filesDir, "thumbnails").apply { mkdirs() }
+
+    /** The cached first-page thumbnail PNG for book `id` (may not exist yet). */
+    fun thumbFile(context: Context, id: String): File = File(thumbsDir(context), "${id.hashCode()}.png")
+
+    /** Scale a rendered page down and cache it as the book's first-page thumbnail. Best-effort. */
+    fun saveThumbnail(context: Context, id: String, page: Bitmap) {
+        if (page.width <= 0 || page.height <= 0) return
+        try {
+            val w = THUMB_W
+            val h = (page.height.toFloat() / page.width * w).toInt().coerceAtLeast(1)
+            val thumb = Bitmap.createScaledBitmap(page, w, h, true)
+            thumbFile(context, id).outputStream().use { thumb.compress(Bitmap.CompressFormat.PNG, 90, it) }
+        } catch (e: Exception) {
+            // a missing thumbnail just shows a placeholder — never fatal.
+        }
+    }
+
+    /** Load a book's cached thumbnail, or null if none. */
+    fun loadThumbnail(context: Context, id: String): Bitmap? {
+        val f = thumbFile(context, id)
+        return if (f.exists()) BitmapFactory.decodeFile(f.absolutePath) else null
+    }
+
+    // ---- recently opened (RR17) ----
+
+    /** A recently-opened book: its stable id (file name) and current stored path. */
+    data class Recent(val id: String, val path: String) {
+        val title: String get() = File(path).nameWithoutExtension
+    }
+
+    private fun recentsFile(context: Context): File = File(context.filesDir, "recents.json")
+
+    /** Recently-opened books, most-recent first, skipping any whose file no longer exists. */
+    fun recents(context: Context): List<Recent> {
+        val f = recentsFile(context)
+        if (!f.exists()) return emptyList()
+        return try {
+            val arr = JSONArray(f.readText())
+            (0 until arr.length()).mapNotNull {
+                val o = arr.getJSONObject(it)
+                val path = o.optString("path")
+                val id = o.optString("id")
+                if (path.isNotEmpty() && File(path).exists()) Recent(id, path) else null
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    /** Record a book as most-recently opened (dedup by path, capped). */
+    fun pushRecent(context: Context, id: String, path: String) {
+        val updated = (listOf(Recent(id, path)) + recents(context).filterNot { it.path == path }).take(RECENTS_MAX)
+        try {
+            val arr = JSONArray()
+            for (r in updated) arr.put(JSONObject().put("id", r.id).put("path", r.path))
+            recentsFile(context).writeText(arr.toString())
+        } catch (e: Exception) {
+            // a lost recents entry is cosmetic.
+        }
+    }
+
+    private const val THUMB_W = 360
+    private const val RECENTS_MAX = 12
+
+    private fun queryName(context: Context, uri: Uri): String? =
+        context.contentResolver
+            .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { c -> if (c.moveToFirst()) c.getString(0) else null }
+
+    private fun sanitize(name: String): String {
+        val stem = name.substringBeforeLast('.').ifBlank { "document" }
+        return stem.replace(Regex("[^A-Za-z0-9 ._-]"), "_").trim().take(80).ifBlank { "document" }
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -1,0 +1,188 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import android.widget.Toast
+
+/**
+ * The InkRead home screen and launcher (RR16/RR17/RR26): brand (icon · name · version · tagline),
+ * a **Recently opened** shelf with first-page thumbnails, and entry points (Open a PDF, Library).
+ * A plain framework Activity to match the shell's no-AppCompat, programmatic-UI style.
+ */
+class HomeActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(buildView())
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Rebuild so the recents shelf + thumbnails refresh after returning from the reader.
+        setContentView(buildView())
+    }
+
+    private fun buildView(): View {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            setBackgroundColor(Color.WHITE)
+            setPadding(dp(32), dp(40), dp(32), dp(40))
+        }
+
+        // Brand.
+        root.addView(
+            ImageView(this).apply { setImageResource(R.mipmap.ic_launcher) },
+            LinearLayout.LayoutParams(dp(96), dp(96)),
+        )
+        root.addView(
+            TextView(this).apply {
+                text = "InkRead"
+                setTextColor(Color.BLACK)
+                textSize = 36f
+                typeface = Typeface.DEFAULT_BOLD
+                gravity = Gravity.CENTER
+                setPadding(0, dp(12), 0, 0)
+            },
+        )
+        root.addView(
+            TextView(this).apply {
+                text = "v${versionName()}"
+                setTextColor(Color.DKGRAY)
+                textSize = 13f
+                gravity = Gravity.CENTER
+            },
+        )
+        root.addView(
+            TextView(this).apply {
+                text = "A better reader."
+                setTextColor(Color.DKGRAY)
+                textSize = 17f
+                setTypeface(typeface, Typeface.ITALIC)
+                gravity = Gravity.CENTER
+                setPadding(0, dp(6), 0, dp(28))
+            },
+        )
+
+        // Recently opened shelf.
+        val recents = Books.recents(this)
+        if (recents.isNotEmpty()) {
+            root.addView(
+                TextView(this).apply {
+                    text = "Recently opened"
+                    setTextColor(Color.DKGRAY)
+                    textSize = 13f
+                    typeface = Typeface.DEFAULT_BOLD
+                    setPadding(0, 0, 0, dp(6))
+                },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT),
+            )
+            for (r in recents.take(5)) root.addView(recentCard(r))
+            root.addView(View(this), LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(20)))
+        }
+
+        fun button(label: String, onClick: () -> Unit) {
+            root.addView(
+                Button(this).apply {
+                    text = label
+                    isAllCaps = false
+                    textSize = 18f
+                    setOnClickListener { onClick() }
+                },
+                LinearLayout.LayoutParams(dp(280), dp(60)).apply { topMargin = dp(10) },
+            )
+        }
+        button("📂   Open a PDF") { openReader(Intent().putExtra(ReaderActivity.EXTRA_PICK, true)) }
+        button("📚   Library") { showLibrary() }
+
+        return ScrollView(this).apply {
+            setBackgroundColor(Color.WHITE)
+            addView(root)
+        }
+    }
+
+    /** A recent-book row: first-page thumbnail + title, tappable to open. */
+    private fun recentCard(r: Books.Recent): View {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(6), dp(8), dp(6), dp(8))
+            isClickable = true
+            setOnClickListener {
+                openReader(
+                    Intent()
+                        .putExtra(ReaderActivity.EXTRA_BOOK_PATH, r.path)
+                        .putExtra(ReaderActivity.EXTRA_BOOK_ID, r.id),
+                )
+            }
+        }
+        row.addView(
+            ImageView(this).apply {
+                scaleType = ImageView.ScaleType.CENTER_CROP
+                val bmp = Books.loadThumbnail(this@HomeActivity, r.id)
+                if (bmp != null) setImageBitmap(bmp) else setBackgroundColor(Color.parseColor("#EEEEEE"))
+            },
+            LinearLayout.LayoutParams(dp(84), dp(112)).apply { marginEnd = dp(14) },
+        )
+        row.addView(
+            TextView(this).apply {
+                text = r.title
+                setTextColor(Color.BLACK)
+                textSize = 17f
+                maxLines = 2
+            },
+        )
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(row, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+        }
+    }
+
+    private fun openReader(extras: Intent) {
+        startActivity(Intent(this, ReaderActivity::class.java).putExtras(extras))
+    }
+
+    private fun showLibrary() {
+        val books = Books.list(this)
+        if (books.isEmpty()) {
+            Toast.makeText(this, "No books yet — open a PDF first", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val labels = books.map { Books.title(it) }.toTypedArray()
+        AlertDialog.Builder(this)
+            .setTitle("Library")
+            .setItems(labels) { _, which ->
+                val f = books[which]
+                openReader(
+                    Intent()
+                        .putExtra(ReaderActivity.EXTRA_BOOK_PATH, f.absolutePath)
+                        .putExtra(ReaderActivity.EXTRA_BOOK_ID, f.name),
+                )
+            }
+            .show()
+    }
+
+    private fun versionName(): String =
+        try {
+            packageManager.getPackageInfo(packageName, 0).versionName ?: ""
+        } catch (e: Exception) {
+            ""
+        }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -18,6 +18,16 @@ import android.view.MotionEvent
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.widget.Toast
+import android.app.Dialog
+import android.text.InputType
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.SeekBar
+import android.widget.TextView
 import dev.jraghavan.inkread.eink.EinkAdapter
 import dev.jraghavan.inkread.eink.SupernoteEinkAdapter
 import dev.jraghavan.inkread.eink.SupernoteInk
@@ -74,11 +84,35 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private var inkStore: InkStore? = null
     /** 0-based page the strokes are keyed to; set on the engine thread after each render. */
     private var currentPage = 0
+    /** Per-book bookmarks (RR16); engine-thread only. */
+    private var bookmarks: Bookmarks? = null
+    /** Total pages in the open doc; cached so the bottom-bar slider can read it on the UI thread. */
+    @Volatile private var pageCount = 0
+    /** Stable id of the open book (its file name); keys thumbnails + the bookmarks file. */
+    @Volatile private var currentBookId = ""
     /** The in-progress stroke as interleaved view-px x,y; UI-thread only. */
     private val strokeBuf = ArrayList<Float>()
     private val mainHandler = Handler(Looper.getMainLooper())
     /** Safety net for a swallowed stylus ACTION_UP: commit the stroke after a brief pen pause. */
     private val strokeFinalize = Runnable { finalizeStroke() }
+
+    /** A finger tap is acted on only after a short confirm window with NO stylus activity — a palm
+     *  resting before a pen stroke is cancelled the moment the stylus event (touch or hover)
+     *  arrives (forward-looking palm rejection, RR19/RR25). UI-thread only. */
+    private var pendingTapX = 0f
+    private var pendingTapY = 0f
+    private val pendingTap = Runnable {
+        if (SystemClock.uptimeMillis() - lastStylusMs > PALM_REJECT_MS && strokeBuf.isEmpty()) {
+            handleTap(pendingTapX, pendingTapY)
+        } else {
+            Log.i(TAG, "DIAG tap suppressed at fire (stylus active → palm)")
+        }
+    }
+
+    // ---- launch intent (from HomeActivity), read on the UI thread, consumed on the engine thread ----
+    @Volatile private var requestPick = false
+    @Volatile private var requestedPath: String? = null
+    @Volatile private var requestedId: String? = null
 
     private val inkPaint = Paint().apply {
         color = Color.BLACK
@@ -89,6 +123,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         isAntiAlias = true
     }
     private val inkDotPaint = Paint().apply { color = Color.BLACK; style = Paint.Style.FILL; isAntiAlias = true }
+    private val bookmarkPaint = Paint().apply { color = Color.BLACK; style = Paint.Style.FILL; isAntiAlias = true }
 
     private val loadingBg = Paint().apply { color = Color.WHITE }
     private val loadingText = Paint().apply {
@@ -106,6 +141,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // Prove the JNI boundary up front (RR1-AC2). Cheap; fine on the UI thread.
         Log.i(TAG, "core: ${NativeBridge.nativeHello()}")
 
+        // What did HomeActivity ask us to open? (a specific book / the picker / else resume.)
+        requestPick = intent.getBooleanExtra(EXTRA_PICK, false)
+        requestedPath = intent.getStringExtra(EXTRA_BOOK_PATH)
+        requestedId = intent.getStringExtra(EXTRA_BOOK_ID)
+
         surfaceView = SurfaceView(this)
         surfaceView.holder.addCallback(this)
         // Input model (RR19/RR25): the STYLUS inks (the firmware paints it — the app never
@@ -118,16 +158,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             val tool = event.getToolType(0)
             if (tool == MotionEvent.TOOL_TYPE_STYLUS || tool == MotionEvent.TOOL_TYPE_ERASER) {
                 // The firmware paints the live ink; the app captures the same points to bake +
-                // persist them (RR19). The app never navigates on the pen.
+                // persist them (RR19). The app never navigates on the pen — and a stylus event
+                // cancels any pending finger tap (that finger was a resting palm).
                 lastStylusMs = SystemClock.uptimeMillis()
+                mainHandler.removeCallbacks(pendingTap)
                 captureStylus(event)
             } else if (event.actionMasked == MotionEvent.ACTION_DOWN &&
-                event.pointerCount == 1 &&
-                tool == MotionEvent.TOOL_TYPE_FINGER &&
-                SystemClock.uptimeMillis() - lastStylusMs > PALM_REJECT_MS
+                tool == MotionEvent.TOOL_TYPE_FINGER
             ) {
-                Log.i(TAG, "DIAG tap-down finger x=${event.x} y=${event.y}")
-                handleTap(event.x, event.y)
+                maybeScheduleTap(event)
             }
             true
         }
@@ -179,6 +218,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     override fun onPause() {
         super.onPause()
+        mainHandler.removeCallbacks(pendingTap) // drop any deferred tap when we leave the foreground
         ink.teardown() // release the firmware ink claim + clear the overlay
         // Persist the reading position when backgrounded (RR27) — async on the engine thread.
         engine.execute { savePosition() }
@@ -235,14 +275,36 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     private fun openDocumentIfNeeded() {
         if (docHandle != 0L) return
-        val book = resolveBook()
-        if (book == null) {
-            // Nothing to resume → open the file picker straight away (no dead "Loading…" screen).
-            Log.i(TAG, "no book to resume; opening the file picker (RR22)")
-            runOnUiThread { openPicker() }
-            return
+        val path = requestedPath
+        val id = requestedId
+        when {
+            // 1) An explicit book chosen on Home / in the Library.
+            path != null && id != null -> {
+                rememberBook(path, id)
+                openBook(path, id)
+            }
+            // 2) Home asked for the file picker.
+            requestPick -> {
+                requestPick = false
+                Log.i(TAG, "launch: opening the file picker (RR22)")
+                runOnUiThread { openPicker() }
+            }
+            // 3) Default: resume the last book (or the bring-up sample), else pick.
+            else -> {
+                val book = resolveBook()
+                if (book == null) {
+                    Log.i(TAG, "no book to resume; opening the file picker (RR22)")
+                    runOnUiThread { openPicker() }
+                } else {
+                    openBook(book.first, book.second)
+                }
+            }
         }
-        openBook(book.first, book.second)
+    }
+
+    /** Remember the current book so Home's "Continue" and a relaunch resume it (RR27). */
+    private fun rememberBook(path: String, id: String) {
+        prefs.edit().putString(KEY_BOOK_PATH, path).putString(KEY_BOOK_ID, id).apply()
     }
 
     /**
@@ -279,13 +341,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             0L
         }
         if (docHandle != 0L) {
-            // Per-book handwriting sidecar (RR19); the book id is a content URI, so hash it for a
-            // filesystem-safe name.
+            // Per-book sidecars (RR19/RR16): handwriting + bookmarks, keyed by the book id.
             inkStore = InkStore(File(filesDir, "ink/${bookId.hashCode()}.json")).also { it.load() }
+            bookmarks = Bookmarks(File(filesDir, "bookmarks/${bookId.hashCode()}.json")).also { it.load() }
+            currentBookId = bookId
+            pageCount = NativeBridge.nativePageCount(docHandle)
+            Books.pushRecent(this, bookId, path)
             Log.i(
                 TAG,
-                "opened $bookId: ${NativeBridge.nativePageCount(docHandle)} pages, " +
-                    "resumed at page ${NativeBridge.nativeCurrentPage(docHandle)}",
+                "opened $bookId: $pageCount pages, resumed at page ${NativeBridge.nativeCurrentPage(docHandle)}",
             )
         }
     }
@@ -297,29 +361,28 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
      * resumes per document even though the bytes are re-copied to a fixed path.
      */
     private fun importAndOpen(uri: Uri) {
-        val dest = File(filesDir, "current.pdf")
-        try {
-            contentResolver.openInputStream(uri)?.use { input ->
-                dest.outputStream().use { out -> input.copyTo(out) }
-            } ?: run {
-                Log.e(TAG, "cannot open stream for $uri")
-                return
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "import failed: ${e.message}")
+        val dest = Books.importFrom(this, uri)
+        if (dest == null) {
+            Log.e(TAG, "import failed for $uri")
+            runOnUiThread { Toast.makeText(this, "Couldn't open that PDF", Toast.LENGTH_SHORT).show() }
             return
         }
-        val bookId = uri.toString().take(BOOK_ID_MAX)
-        prefs.edit()
-            .putString(KEY_BOOK_PATH, dest.absolutePath)
-            .putString(KEY_BOOK_ID, bookId)
-            .apply()
+        openSwap(dest.absolutePath, dest.name)
+    }
 
+    /** Swap the open document to (`path`, `id`) on the engine thread: remember, close, open, render. */
+    private fun openSwap(path: String, id: String) {
+        rememberBook(path, id)
         closeDocument() // saves + closes the previous book before swapping
         drawLoading()
-        openBook(dest.absolutePath, bookId)
+        openBook(path, id)
         renderAndBlit()
-        adapter.refreshFull() // imported book's first page has no command stream → refresh
+        adapter.refreshFull() // the new book's first page has no command stream → refresh
+    }
+
+    /** Open a Library book in place (invoked from the reader popup; engine thread). */
+    private fun openFromLibrary(file: File) {
+        engine.execute { openSwap(file.absolutePath, file.name) }
     }
 
     private fun renderAndBlit() {
@@ -339,9 +402,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         bmp.copyPixelsFromBuffer(buf)
         currentPage = NativeBridge.nativeCurrentPage(handle)
         // Bake this page's saved handwriting onto the rendered page (RR19) before blitting.
-        inkStore?.let { store ->
-            val cv = Canvas(bmp)
-            for (s in store.strokesFor(currentPage)) drawStroke(cv, s)
+        val cv = Canvas(bmp)
+        inkStore?.let { store -> for (s in store.strokesFor(currentPage)) drawStroke(cv, s) }
+        // A small dog-ear marks a bookmarked page (RR16).
+        if (bookmarks?.has(currentPage) == true) drawBookmarkCorner(cv)
+        // Cache the first page as the book's thumbnail, once (RR17-FR5).
+        if (currentPage == 0 && currentBookId.isNotEmpty() && !Books.thumbFile(this, currentBookId).exists()) {
+            Books.saveThumbnail(this, currentBookId, bmp)
         }
         blit { canvas -> canvas.drawBitmap(bmp, 0f, 0f, null) }
         // Cache this page's links for tap hit-testing (RR11-FR3). Cheap; pdfium caches per page.
@@ -455,6 +522,45 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         canvas.drawPath(path, inkPaint)
     }
 
+    /** A small filled dog-ear in the top-right corner marking a bookmarked page (RR16). */
+    private fun drawBookmarkCorner(canvas: Canvas) {
+        val w = viewW.toFloat()
+        val s = viewW * 0.045f
+        val path = Path().apply {
+            moveTo(w - s, 0f)
+            lineTo(w, 0f)
+            lineTo(w, s)
+            close()
+        }
+        canvas.drawPath(path, bookmarkPaint)
+    }
+
+    /**
+     * Decide whether a finger ACTION_DOWN is a deliberate navigation tap or a resting palm
+     * (RR19/RR25). Reject obvious palms immediately — multi-touch, a large contact patch, a recent
+     * or in-progress stylus, or an active stroke — and otherwise **defer** the tap by
+     * [TAP_CONFIRM_MS]: any stylus event (incl. pen hover) inside that window cancels it, so the
+     * common "rest the hand, then write" sequence never registers as a tap.
+     */
+    private fun maybeScheduleTap(e: MotionEvent) {
+        val recentStylus = SystemClock.uptimeMillis() - lastStylusMs <= PALM_REJECT_MS
+        val major = e.getTouchMajor(0)
+        val vh = surfaceView.height
+        val largeContact = vh > 0 && major >= vh * PALM_TOUCH_MAJOR_FRAC
+        if (e.pointerCount != 1 || recentStylus || largeContact || strokeBuf.isNotEmpty()) {
+            Log.i(
+                TAG,
+                "DIAG palm-reject down pc=${e.pointerCount} recent=$recentStylus " +
+                    "major=$major large=$largeContact stroke=${strokeBuf.isNotEmpty()}",
+            )
+            return
+        }
+        pendingTapX = e.x
+        pendingTapY = e.y
+        mainHandler.removeCallbacks(pendingTap)
+        mainHandler.postDelayed(pendingTap, TAP_CONFIRM_MS)
+    }
+
     private fun handleTap(x: Float, y: Float) {
         val w = surfaceView.width.toFloat()
         val h = surfaceView.height.toFloat()
@@ -472,7 +578,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         when (zone) {
             "PREV" -> postGesture(Gesture.PREV_PAGE)
             "NEXT" -> postGesture(Gesture.NEXT_PAGE)
-            else -> openTocMenu()
+            else -> showBottomBar()
         }
     }
 
@@ -534,44 +640,208 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
     }
 
-    /** Fetch the TOC on the engine thread, then show the chooser on the UI thread (RR11-FR2). */
-    private fun openTocMenu() {
-        engine.execute {
-            // No document open yet → go straight to the picker.
-            if (docHandle == 0L) {
-                runOnUiThread { openPicker() }
-                return@execute
+    /**
+     * The reader's bottom control bar (RR16/RR25), KOReader-style: a thin panel **hugging the
+     * bottom edge** — a page slider with a tappable page indicator, above a flat row of controls
+     * (Home · Library · Bookmark · Marks · Contents · Open). Built programmatically, high-contrast
+     * for e-ink; uses the cached page state so showing it needs no engine round-trip.
+     */
+    private fun showBottomBar() {
+        if (docHandle == 0L) {
+            openPicker()
+            return
+        }
+        val total = pageCount.coerceAtLeast(1)
+        val cur = currentPage.coerceIn(0, total - 1)
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+
+        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+        val container = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.WHITE)
+        }
+        // Hairline top divider so the bar reads as a surface, not a floating box.
+        container.addView(
+            View(this).apply { setBackgroundColor(Color.parseColor("#33000000")) },
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(1).coerceAtLeast(1)),
+        )
+
+        // Page-slider row:  [N / Total]  ────────●────────
+        val pageLabel = TextView(this).apply {
+            text = "${cur + 1} / $total"
+            setTextColor(Color.BLACK)
+            textSize = 14f
+            setPadding(0, 0, dp(14), 0)
+            setOnClickListener { dialog.dismiss(); showPageEntry(total) }
+        }
+        val seek = SeekBar(this).apply {
+            max = total - 1
+            progress = cur
+            setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(sb: SeekBar, p: Int, fromUser: Boolean) {
+                    if (fromUser) pageLabel.text = "${p + 1} / $total"
+                }
+                override fun onStartTrackingTouch(sb: SeekBar) {}
+                override fun onStopTrackingTouch(sb: SeekBar) { dialog.dismiss(); postJump(sb.progress) }
+            })
+        }
+        container.addView(
+            LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(dp(16), dp(10), dp(16), dp(4))
+                addView(pageLabel)
+                addView(seek, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            },
+        )
+
+        // Control row: flat, evenly-weighted icon+label cells.
+        val controls = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setPadding(dp(2), dp(2), dp(2), dp(10))
+        }
+        fun control(label: String, onClick: () -> Unit) {
+            controls.addView(
+                TextView(this).apply {
+                    text = label
+                    setTextColor(Color.BLACK)
+                    textSize = 11f
+                    gravity = Gravity.CENTER
+                    setPadding(0, dp(8), 0, dp(8))
+                    isClickable = true
+                    setOnClickListener { dialog.dismiss(); onClick() }
+                },
+                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+            )
+        }
+        val marked = bookmarks?.has(cur) == true
+        control("🏠\nHome") { goHome() }
+        control("📚\nLibrary") { showLibraryDialog() }
+        control(if (marked) "🔖\nRemove" else "🔖\nBookmark") { toggleBookmark() }
+        control("📑\nMarks") { showBookmarks() }
+        control("📄\nContents") { showContentsLazy() }
+        control("📂\nOpen") { openPicker() }
+        container.addView(controls)
+
+        dialog.setContentView(container)
+        dialog.window?.apply {
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            setGravity(Gravity.BOTTOM)
+            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.WHITE))
+        }
+        dialog.show()
+    }
+
+    /** A "go to page" text-entry dialog (RR11-FR1): type a 1-based page number to jump. */
+    private fun showPageEntry(total: Int) {
+        val input = EditText(this).apply {
+            inputType = InputType.TYPE_CLASS_NUMBER
+            hint = "1 – $total"
+        }
+        AlertDialog.Builder(this)
+            .setTitle("Go to page")
+            .setView(input)
+            .setPositiveButton("Go") { _, _ ->
+                val n = input.text.toString().toIntOrNull()
+                if (n != null && n in 1..total) {
+                    postJump(n - 1)
+                } else {
+                    Toast.makeText(this, "Enter a page from 1 to $total", Toast.LENGTH_SHORT).show()
+                }
             }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    /** Toggle a bookmark on the current page (RR16); redraw so the dog-ear appears/disappears. */
+    private fun toggleBookmark() {
+        engine.execute {
+            val bm = bookmarks ?: return@execute
+            val page = currentPage
+            val now = bm.toggle(page)
+            runOnUiThread {
+                val msg = if (now) "Bookmarked page ${page + 1}" else "Bookmark removed"
+                Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+            }
+            renderAndBlit()
+            adapter.refreshFull()
+        }
+    }
+
+    /** List the bookmarked pages (RR16); tap one to jump. */
+    private fun showBookmarks() {
+        engine.execute {
+            val marks = bookmarks?.pages() ?: emptyList()
+            runOnUiThread {
+                if (marks.isEmpty()) {
+                    Toast.makeText(this, "No bookmarks yet — tap Bookmark to add one", Toast.LENGTH_SHORT).show()
+                    return@runOnUiThread
+                }
+                val labels = marks.map { "Page ${it + 1}" }.toTypedArray()
+                AlertDialog.Builder(this)
+                    .setTitle("Bookmarks")
+                    .setItems(labels) { _, which -> postJump(marks[which]) }
+                    .show()
+            }
+        }
+    }
+
+    /** Fetch the TOC on the engine thread, then show it (RR11-FR2). */
+    private fun showContentsLazy() {
+        engine.execute {
+            if (docHandle == 0L) return@execute
             val toc = try {
                 WireCodec.decodeToc(NativeBridge.nativeToc(docHandle))
             } catch (e: RuntimeException) {
                 Log.e(TAG, "toc failed: ${e.message}")
                 emptyList()
             }
-            runOnUiThread { showReaderMenu(toc) }
+            runOnUiThread {
+                if (toc.isEmpty()) {
+                    Toast.makeText(this, "No contents in this document", Toast.LENGTH_SHORT).show()
+                } else {
+                    showContents(toc)
+                }
+            }
         }
     }
 
-    /**
-     * The center-tap reader menu: "Open another PDF…" first (this replaces the old long-press,
-     * which collided with slow stylus taps), then the document's contents (RR11-FR2).
-     */
-    private fun showReaderMenu(toc: List<TocItem>) {
-        // Indent TOC entries by depth; show the 1-based page for resolvable entries.
-        val tocLabels = toc.map { item ->
+    /** The document's table of contents (RR11-FR2), shown as a scrollable list from the popup. */
+    private fun showContents(toc: List<TocItem>) {
+        if (toc.isEmpty()) return
+        val labels = toc.map { item ->
             val indent = "    ".repeat(item.depth)
             val page = item.targetPage?.let { "  ·  p${it + 1}" } ?: ""
             indent + item.title + page
-        }
-        val labels = (listOf("📂  Open another PDF…") + tocLabels).toTypedArray()
-
+        }.toTypedArray()
         AlertDialog.Builder(this)
-            .setTitle(if (toc.isEmpty()) "Menu" else "Contents")
-            .setItems(labels) { _, which ->
-                if (which == 0) openPicker()
-                else toc[which - 1].targetPage?.let { postJump(it) } // label-only entries don't navigate
-            }
+            .setTitle("Contents")
+            .setItems(labels) { _, which -> toc[which].targetPage?.let { postJump(it) } }
             .show()
+    }
+
+    /** The on-device library (RR17): pick a stored book to open it in place. */
+    private fun showLibraryDialog() {
+        val books = Books.list(this)
+        if (books.isEmpty()) {
+            Toast.makeText(this, "No books yet — open a PDF first", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val labels = books.map { Books.title(it) }.toTypedArray()
+        AlertDialog.Builder(this)
+            .setTitle("Library")
+            .setItems(labels) { _, which -> openFromLibrary(books[which]) }
+            .show()
+    }
+
+    /** Return to the home screen (RR16), leaving the reader. */
+    private fun goHome() {
+        startActivity(
+            Intent(this, HomeActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+        )
+        finish()
     }
 
     /** Persist the current reading position (RR12-FR3 / RR27); store-less / closed = no-op. */
@@ -586,6 +856,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     private fun closeDocument() {
         inkStore = null // strokes are already persisted per-stroke; drop the per-book store
+        bookmarks = null // bookmarks are persisted on toggle; drop the per-book store
         val h = docHandle
         docHandle = 0L // zero BEFORE the call so a re-entrant close is a no-op (Amendment 2)
         if (h == 0L) return
@@ -597,16 +868,22 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         NativeBridge.nativeCloseDocument(h)
     }
 
-    private companion object {
+    companion object {
         const val TAG = "ReaderActivity"
         const val DPI = 226 // Supernote-class panel density (approx); refined per device.
         const val REQ_OPEN_DOC = 1 // startActivityForResult request code for the PDF picker.
         const val PREFS = "inkread"
-        const val KEY_BOOK_PATH = "book_path" // copied PDF under app storage (RR27).
-        const val KEY_BOOK_ID = "book_id" // stable per-book identity (content URI, clamped).
-        const val BOOK_ID_MAX = 512 // mirrors BookId::MAX_LEN in the core.
-        const val PALM_REJECT_MS = 1000L // ignore a finger tap within this long of a stylus event.
+        const val KEY_BOOK_PATH = "book_path" // stored PDF under app storage (RR27).
+        const val KEY_BOOK_ID = "book_id" // stable per-book id (the stored file name).
+        const val PALM_REJECT_MS = 1000L // a finger tap within this long of a stylus event = palm.
         const val STROKE_PAUSE_MS = 600L // commit a stroke after this pen-pause (swallowed-UP net).
         const val INK_STROKE_WIDTH = 6f // baked-ink line width (px) tuned to match the firmware pen.
+        const val TAP_CONFIRM_MS = 300L // defer a finger tap; a stylus event in this window = palm.
+        const val PALM_TOUCH_MAJOR_FRAC = 0.12f // contact major ≥ 12% of view height ⇒ a palm.
+
+        // Launch extras from HomeActivity.
+        const val EXTRA_PICK = "inkread.pick" // open the file picker on launch.
+        const val EXTRA_BOOK_PATH = "inkread.book_path" // open this specific stored book…
+        const val EXTRA_BOOK_ID = "inkread.book_id" // …with this stable id.
     }
 }

--- a/inkread-ink/Cargo.toml
+++ b/inkread-ink/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "inkread-ink"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "The vector-ink domain model (RR6): Stroke/InkPoint/Tool/InkColor, per-page InkLayer with undo/redo, eraser hit-testing, and the .inkbin codec. Pure, dependency-free, host-testable; names no vendor (IR-7)."
+
+[lib]
+crate-type = ["rlib"]

--- a/inkread-ink/src/codec.rs
+++ b/inkread-ink/src/codec.rs
@@ -1,0 +1,266 @@
+//! The `.inkbin` codec — a compact, versioned, little-endian encoding of a page [`InkLayer`]
+//! (RR10-FR4). It mirrors `reader-core`'s wire codecs (`encode_links_wire`/`encode_toc_wire`):
+//! a magic + version prefix, little-endian fields, and **hardened decode** that returns
+//! [`InkError::BadEncoding`] on any malformed/truncated input rather than panicking or
+//! over-allocating (RR21-FR3).
+//!
+//! Layout (all integers/floats little-endian):
+//! ```text
+//! ["INKB"][ver: u8 = 1][stroke_count: u32]
+//! per stroke:
+//!   [id: u32][tool: u8][r u8][g u8][b u8][a u8][width: f32][created_at_ms: u64]
+//!   [point_count: u32]
+//!   per point:
+//!     [x: f32][y: f32][pressure: f32][flags: u8][tilt_x: f32?][tilt_y: f32?][ts: u32]
+//! ```
+//! `flags` bit 0 = a `tilt_x` field follows, bit 1 = a `tilt_y` field follows. Only the strokes
+//! persist — never the undo/redo history (RR20).
+
+use crate::model::{InkColor, InkError, InkLayer, InkPoint, InkResult, Stroke, StrokeId, Tool};
+
+/// Magic prefix identifying an `.inkbin` blob.
+const MAGIC: &[u8; 4] = b"INKB";
+/// Current `.inkbin` format version.
+pub const INKBIN_VERSION: u8 = 1;
+
+const FLAG_TILT_X: u8 = 0b0000_0001;
+const FLAG_TILT_Y: u8 = 0b0000_0010;
+
+/// Encode a layer's committed strokes to `.inkbin` bytes (RR10-FR4). Pure; never panics.
+#[must_use]
+pub fn encode_layer(layer: &InkLayer) -> Vec<u8> {
+    let strokes = layer.strokes();
+    let mut out = Vec::new();
+    out.extend_from_slice(MAGIC);
+    out.push(INKBIN_VERSION);
+    out.extend_from_slice(&(u32::try_from(strokes.len()).unwrap_or(u32::MAX)).to_le_bytes());
+    for s in strokes.iter().take(u32::MAX as usize) {
+        out.extend_from_slice(&s.id.0.to_le_bytes());
+        out.push(s.tool.code());
+        out.extend_from_slice(&[s.color.r, s.color.g, s.color.b, s.color.a]);
+        out.extend_from_slice(&s.width.to_le_bytes());
+        out.extend_from_slice(&s.created_at_ms.to_le_bytes());
+        let pcount = u32::try_from(s.points.len()).unwrap_or(u32::MAX);
+        out.extend_from_slice(&pcount.to_le_bytes());
+        for p in s.points.iter().take(pcount as usize) {
+            out.extend_from_slice(&p.x.to_le_bytes());
+            out.extend_from_slice(&p.y.to_le_bytes());
+            out.extend_from_slice(&p.pressure.to_le_bytes());
+            let mut flags = 0u8;
+            if p.tilt_x.is_some() {
+                flags |= FLAG_TILT_X;
+            }
+            if p.tilt_y.is_some() {
+                flags |= FLAG_TILT_Y;
+            }
+            out.push(flags);
+            if let Some(tx) = p.tilt_x {
+                out.extend_from_slice(&tx.to_le_bytes());
+            }
+            if let Some(ty) = p.tilt_y {
+                out.extend_from_slice(&ty.to_le_bytes());
+            }
+            out.extend_from_slice(&p.timestamp_ms.to_le_bytes());
+        }
+    }
+    out
+}
+
+/// Decode `.inkbin` bytes into an [`InkLayer`] (RR10-FR4). Returns [`InkError::BadEncoding`] on a
+/// bad magic, unknown version, unknown tool code, a zero-point stroke, or truncation — never
+/// panics and never pre-allocates from an untrusted count.
+pub fn decode_layer(bytes: &[u8]) -> InkResult<InkLayer> {
+    let mut c = Cursor::new(bytes);
+    if c.take(4)? != MAGIC {
+        return Err(InkError::BadEncoding("bad magic".into()));
+    }
+    let ver = c.u8()?;
+    if ver != INKBIN_VERSION {
+        return Err(InkError::BadEncoding(format!("unsupported version {ver}")));
+    }
+    let stroke_count = c.u32()?;
+    let mut strokes = Vec::new();
+    for _ in 0..stroke_count {
+        let id = StrokeId(c.u32()?);
+        let tool = Tool::from_code(c.u8()?)
+            .ok_or_else(|| InkError::BadEncoding("unknown tool code".into()))?;
+        let color = InkColor::rgba(c.u8()?, c.u8()?, c.u8()?, c.u8()?);
+        let width = c.f32()?;
+        let created_at_ms = c.u64()?;
+        let point_count = c.u32()?;
+        if point_count == 0 {
+            return Err(InkError::BadEncoding("stroke has no points".into()));
+        }
+        let mut points = Vec::new();
+        for _ in 0..point_count {
+            let x = c.f32()?;
+            let y = c.f32()?;
+            let pressure = c.f32()?;
+            let flags = c.u8()?;
+            let tilt_x = if flags & FLAG_TILT_X != 0 {
+                Some(c.f32()?)
+            } else {
+                None
+            };
+            let tilt_y = if flags & FLAG_TILT_Y != 0 {
+                Some(c.f32()?)
+            } else {
+                None
+            };
+            let timestamp_ms = c.u32()?;
+            points.push(InkPoint::new(x, y, pressure, tilt_x, tilt_y, timestamp_ms)?);
+        }
+        strokes.push(Stroke {
+            id,
+            tool,
+            color,
+            width,
+            points,
+            created_at_ms,
+        });
+    }
+    Ok(InkLayer::from_strokes(strokes))
+}
+
+/// A bounds-checked little-endian reader. Every read that would run past the end returns
+/// [`InkError::BadEncoding`] — the source of the codec's no-panic guarantee.
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> InkResult<&'a [u8]> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .filter(|&e| e <= self.buf.len())
+            .ok_or(InkError::BadEncoding(String::from(
+                "unexpected end of data",
+            )))?;
+        let slice = &self.buf[self.pos..end];
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> InkResult<u8> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u32(&mut self) -> InkResult<u32> {
+        let b = self.take(4)?;
+        Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    fn u64(&mut self) -> InkResult<u64> {
+        let b = self.take(8)?;
+        Ok(u64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+
+    fn f32(&mut self) -> InkResult<f32> {
+        let b = self.take(4)?;
+        Ok(f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_layer() -> InkLayer {
+        let mut l = InkLayer::new();
+        l.start_stroke(Tool::Pen, InkColor::rgba(10, 20, 30, 255), 0.012, 42)
+            .unwrap();
+        l.push_point(InkPoint::new(0.1, 0.2, 0.5, None, None, 0).unwrap())
+            .unwrap();
+        l.push_point(InkPoint::new(0.3, 0.4, 0.8, Some(0.1), Some(-0.2), 16).unwrap())
+            .unwrap();
+        l.finish_stroke().unwrap();
+        l.start_stroke(
+            Tool::Highlighter,
+            InkColor::rgba(255, 230, 0, 128),
+            0.03,
+            99,
+        )
+        .unwrap();
+        l.push_point(InkPoint::new(0.6, 0.6, 1.0, None, None, 0).unwrap())
+            .unwrap();
+        l.finish_stroke().unwrap();
+        l
+    }
+
+    #[test]
+    fn round_trip_preserves_strokes() {
+        let layer = sample_layer();
+        let bytes = encode_layer(&layer);
+        let back = decode_layer(&bytes).unwrap();
+        assert_eq!(back.strokes(), layer.strokes());
+    }
+
+    #[test]
+    fn empty_layer_round_trips() {
+        let layer = InkLayer::new();
+        let bytes = encode_layer(&layer);
+        let back = decode_layer(&bytes).unwrap();
+        assert!(back.is_empty());
+        // header only: magic(4) + ver(1) + count(4)
+        assert_eq!(bytes.len(), 9);
+    }
+
+    #[test]
+    fn decoded_layer_continues_ids_safely() {
+        let bytes = encode_layer(&sample_layer());
+        let mut back = decode_layer(&bytes).unwrap();
+        // sample has ids 0 and 1 → next must be 2
+        back.start_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0)
+            .unwrap();
+        back.push_point(InkPoint::new(0.5, 0.5, 1.0, None, None, 0).unwrap())
+            .unwrap();
+        assert_eq!(back.finish_stroke().unwrap(), StrokeId(2));
+    }
+
+    #[test]
+    fn bad_magic_is_rejected() {
+        let err = decode_layer(b"XXXX\x01\x00\x00\x00\x00").unwrap_err();
+        assert!(matches!(err, InkError::BadEncoding(_)));
+    }
+
+    #[test]
+    fn unknown_version_is_rejected() {
+        let mut bytes = encode_layer(&sample_layer());
+        bytes[4] = 0xFE; // corrupt the version byte
+        assert!(matches!(
+            decode_layer(&bytes),
+            Err(InkError::BadEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn truncation_is_rejected_not_panicked() {
+        let full = encode_layer(&sample_layer());
+        // Every shorter prefix (past the header) must error cleanly, never panic.
+        for len in 0..full.len() {
+            assert!(
+                decode_layer(&full[..len]).is_err(),
+                "prefix len {len} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_tool_code_is_rejected() {
+        let mut bytes = encode_layer(&sample_layer());
+        // first stroke's tool byte sits right after magic(4)+ver(1)+count(4)+id(4) = offset 13
+        bytes[13] = 0x7F;
+        assert!(matches!(
+            decode_layer(&bytes),
+            Err(InkError::BadEncoding(_))
+        ));
+    }
+}

--- a/inkread-ink/src/codec.rs
+++ b/inkread-ink/src/codec.rs
@@ -16,6 +16,8 @@
 //! `flags` bit 0 = a `tilt_x` field follows, bit 1 = a `tilt_y` field follows. Only the strokes
 //! persist — never the undo/redo history (RR20).
 
+use std::collections::HashSet;
+
 use crate::model::{InkColor, InkError, InkLayer, InkPoint, InkResult, Stroke, StrokeId, Tool};
 
 /// Magic prefix identifying an `.inkbin` blob.
@@ -67,8 +69,10 @@ pub fn encode_layer(layer: &InkLayer) -> Vec<u8> {
 }
 
 /// Decode `.inkbin` bytes into an [`InkLayer`] (RR10-FR4). Returns [`InkError::BadEncoding`] on a
-/// bad magic, unknown version, unknown tool code, a zero-point stroke, or truncation — never
-/// panics and never pre-allocates from an untrusted count.
+/// bad magic, unknown version, unknown tool code, a non-finite/non-positive width, a zero-point
+/// stroke, a duplicate stroke id, truncation, or trailing bytes — never panics and never
+/// pre-allocates from an untrusted count. Re-establishes every invariant the encoder enforced, so
+/// an untrusted blob can't smuggle in a value the in-memory model would reject (e.g. a NaN width).
 pub fn decode_layer(bytes: &[u8]) -> InkResult<InkLayer> {
     let mut c = Cursor::new(bytes);
     if c.take(4)? != MAGIC {
@@ -80,12 +84,22 @@ pub fn decode_layer(bytes: &[u8]) -> InkResult<InkLayer> {
     }
     let stroke_count = c.u32()?;
     let mut strokes = Vec::new();
+    let mut seen_ids = HashSet::new();
     for _ in 0..stroke_count {
         let id = StrokeId(c.u32()?);
+        if !seen_ids.insert(id.0) {
+            // Duplicate ids would make undo's `retain(|s| s.id != …)` remove both — reject.
+            return Err(InkError::BadEncoding("duplicate stroke id".into()));
+        }
         let tool = Tool::from_code(c.u8()?)
             .ok_or_else(|| InkError::BadEncoding("unknown tool code".into()))?;
         let color = InkColor::rgba(c.u8()?, c.u8()?, c.u8()?, c.u8()?);
         let width = c.f32()?;
+        if !width.is_finite() || width <= 0.0 {
+            return Err(InkError::BadEncoding(
+                "non-finite or non-positive width".into(),
+            ));
+        }
         let created_at_ms = c.u64()?;
         let point_count = c.u32()?;
         if point_count == 0 {
@@ -118,6 +132,11 @@ pub fn decode_layer(bytes: &[u8]) -> InkResult<InkLayer> {
             points,
             created_at_ms,
         });
+    }
+    if c.pos != bytes.len() {
+        return Err(InkError::BadEncoding(
+            "trailing bytes after last stroke".into(),
+        ));
     }
     Ok(InkLayer::from_strokes(strokes))
 }
@@ -258,6 +277,48 @@ mod tests {
         let mut bytes = encode_layer(&sample_layer());
         // first stroke's tool byte sits right after magic(4)+ver(1)+count(4)+id(4) = offset 13
         bytes[13] = 0x7F;
+        assert!(matches!(
+            decode_layer(&bytes),
+            Err(InkError::BadEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn non_finite_width_is_rejected() {
+        // The model rejects a NaN width on the way in; the decoder must re-establish that on the
+        // way back so a hostile .inkbin can't smuggle a NaN that breaks bounds() / round-trip eq.
+        let mut bytes = encode_layer(&sample_layer());
+        // width f32 sits after magic(4)+ver(1)+count(4)+id(4)+tool(1)+rgba(4) = offset 18.
+        bytes[18..22].copy_from_slice(&f32::NAN.to_le_bytes());
+        assert!(matches!(
+            decode_layer(&bytes),
+            Err(InkError::BadEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn trailing_bytes_are_rejected() {
+        let mut bytes = encode_layer(&sample_layer());
+        bytes.extend_from_slice(b"TRAILING-JUNK");
+        assert!(matches!(
+            decode_layer(&bytes),
+            Err(InkError::BadEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn duplicate_stroke_id_is_rejected() {
+        // Two single-point, no-tilt pen strokes → fixed 42-byte records; the 2nd id starts at
+        // header(9)+record(42) = 51. Overwrite its low byte so both strokes share id 0.
+        let mut l = InkLayer::new();
+        for _ in 0..2 {
+            l.start_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0).unwrap();
+            l.push_point(InkPoint::new(0.1, 0.1, 1.0, None, None, 0).unwrap())
+                .unwrap();
+            l.finish_stroke().unwrap();
+        }
+        let mut bytes = encode_layer(&l);
+        bytes[51] = 0;
         assert!(matches!(
             decode_layer(&bytes),
             Err(InkError::BadEncoding(_))

--- a/inkread-ink/src/lib.rs
+++ b/inkread-ink/src/lib.rs
@@ -1,0 +1,22 @@
+//! `inkread-ink` — the vector-ink domain (RR6 / ADR-INKREAD-0004).
+//!
+//! A pure, dependency-free model of handwritten ink: a [`Stroke`] is an ordered list of
+//! [`InkPoint`] samples with a [`Tool`], an [`InkColor`] (preserved even on grayscale panels —
+//! RR6-FR6), and a nominal width. An [`InkLayer`] holds all strokes on one page and owns the
+//! undo/redo history and eraser hit-testing (RR6-FR3).
+//!
+//! Coordinates are **normalized to the page** — `[0,1]` on both axes, top-left origin — exactly
+//! like `reader-core`'s `PageLink`, so ink is resolution-independent and survives a viewport
+//! change or a re-render at a different size. Pressure is normalized `[0,1]`.
+//!
+//! This crate is **host-only and names no vendor** (IR-7). It owns its own [`InkError`]; the
+//! `reader-core` boundary maps that to its `CoreError`. Time is never read here (no clock) — a
+//! stroke's `created_at_ms` is supplied by the caller so the model stays deterministic and
+//! host-testable.
+//!
+//! The on-disk `.inkbin` encoding will live in a `codec` module (added next), mirroring
+//! `reader-core`'s versioned, little-endian, saturating wire codecs.
+
+pub mod model;
+
+pub use model::{BBox, InkColor, InkError, InkLayer, InkPoint, Stroke, StrokeId, Tool};

--- a/inkread-ink/src/lib.rs
+++ b/inkread-ink/src/lib.rs
@@ -14,9 +14,11 @@
 //! stroke's `created_at_ms` is supplied by the caller so the model stays deterministic and
 //! host-testable.
 //!
-//! The on-disk `.inkbin` encoding will live in a `codec` module (added next), mirroring
-//! `reader-core`'s versioned, little-endian, saturating wire codecs.
+//! The on-disk `.inkbin` encoding lives in [`codec`]; it mirrors `reader-core`'s versioned,
+//! little-endian, saturating wire codecs.
 
+pub mod codec;
 pub mod model;
 
+pub use codec::{decode_layer, encode_layer, INKBIN_VERSION};
 pub use model::{BBox, InkColor, InkError, InkLayer, InkPoint, Stroke, StrokeId, Tool};

--- a/inkread-ink/src/model.rs
+++ b/inkread-ink/src/model.rs
@@ -260,7 +260,11 @@ impl InkLayer {
     /// the largest existing id so new strokes never collide.
     #[must_use]
     pub fn from_strokes(strokes: Vec<Stroke>) -> Self {
-        let next_id = strokes.iter().map(|s| s.id.0).max().map_or(0, |m| m + 1);
+        let next_id = strokes
+            .iter()
+            .map(|s| s.id.0)
+            .max()
+            .map_or(0, |m| m.saturating_add(1));
         Self {
             strokes,
             next_id,
@@ -616,5 +620,81 @@ mod tests {
     fn pressure_to_width_scales() {
         assert!((pressure_to_width(0.02, 0.0) - 0.01).abs() < 1e-6);
         assert!((pressure_to_width(0.02, 1.0) - 0.02).abs() < 1e-6);
+    }
+
+    fn ids(l: &InkLayer) -> Vec<StrokeId> {
+        l.strokes().iter().map(|s| s.id).collect()
+    }
+
+    #[test]
+    fn redo_of_erase_re_removes() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.10, 0.10), (0.20, 0.10)]);
+        drawn(&mut l, &[(0.10, 0.80), (0.20, 0.80)]);
+        l.erase_at(0.15, 0.10, 0.02); // remove S0
+        assert_eq!(ids(&l), vec![StrokeId(1)]);
+        assert!(l.undo()); // restore S0
+        assert_eq!(ids(&l), vec![StrokeId(0), StrokeId(1)]);
+        assert!(l.redo()); // re-erase S0
+        assert_eq!(ids(&l), vec![StrokeId(1)]);
+    }
+
+    #[test]
+    fn erase_restores_middle_stroke_in_order() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.10, 0.10), (0.20, 0.10)]); // S0 @ y=0.10
+        drawn(&mut l, &[(0.10, 0.50), (0.20, 0.50)]); // S1 @ y=0.50 (middle)
+        drawn(&mut l, &[(0.10, 0.90), (0.20, 0.90)]); // S2 @ y=0.90
+        assert_eq!(l.erase_at(0.15, 0.50, 0.02), vec![StrokeId(1)]);
+        assert_eq!(ids(&l), vec![StrokeId(0), StrokeId(2)]);
+        assert!(l.undo());
+        assert_eq!(
+            ids(&l),
+            vec![StrokeId(0), StrokeId(1), StrokeId(2)],
+            "middle stroke restored at its original index"
+        );
+    }
+
+    #[test]
+    fn single_gesture_erasing_two_strokes_undoes_one_at_a_time() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.10, 0.10), (0.20, 0.10)]); // S0 horizontal
+        drawn(&mut l, &[(0.14, 0.05), (0.14, 0.15)]); // S1 vertical, crosses near (0.15,0.10)
+        let removed = l.erase_at(0.15, 0.10, 0.03);
+        assert_eq!(removed.len(), 2, "both strokes hit by one erase point");
+        assert!(l.is_empty());
+        assert!(l.undo()); // restore one
+        assert_eq!(l.strokes().len(), 1);
+        assert!(l.undo()); // restore the other
+        assert_eq!(
+            ids(&l),
+            vec![StrokeId(0), StrokeId(1)],
+            "paint order preserved"
+        );
+    }
+
+    #[test]
+    fn interleaved_add_erase_undo_redo_reconstructs_exactly() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.10, 0.10), (0.20, 0.10)]); // add S0
+        l.erase_at(0.15, 0.10, 0.02); // erase S0
+        drawn(&mut l, &[(0.50, 0.50), (0.60, 0.50)]); // add S1
+        assert_eq!(ids(&l), vec![StrokeId(1)]);
+        // undo all three edits in reverse
+        assert!(l.undo()); // remove S1
+        assert!(l.undo()); // restore S0
+        assert_eq!(ids(&l), vec![StrokeId(0)]);
+        assert!(l.undo()); // remove S0
+        assert!(l.is_empty());
+        assert!(!l.undo());
+        // redo all three forward
+        assert!(l.redo()); // add S0
+        assert!(l.redo()); // erase S0
+        assert!(l.redo()); // add S1
+        assert_eq!(
+            ids(&l),
+            vec![StrokeId(1)],
+            "redo reconstructs original state"
+        );
     }
 }

--- a/inkread-ink/src/model.rs
+++ b/inkread-ink/src/model.rs
@@ -1,0 +1,620 @@
+//! Ink domain types and the per-page [`InkLayer`] (RR6).
+
+use std::fmt;
+
+/// The error surface of the ink domain. `reader-core` maps these onto its `CoreError` at the
+/// JNI boundary (RR21-FR3); the domain itself never panics on bad input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InkError {
+    /// A coordinate, pressure, or width was NaN or infinite.
+    NonFinite(&'static str),
+    /// `finish_stroke` was called but the in-progress stroke had no points.
+    EmptyStroke,
+    /// `push_point` was called with no stroke in progress.
+    NoActiveStroke,
+    /// A `.inkbin` blob was malformed or truncated (see [`crate::codec`]).
+    BadEncoding(String),
+}
+
+impl fmt::Display for InkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InkError::NonFinite(w) => write!(f, "non-finite {w}"),
+            InkError::EmptyStroke => write!(f, "stroke has no points"),
+            InkError::NoActiveStroke => write!(f, "no stroke in progress"),
+            InkError::BadEncoding(m) => write!(f, "malformed ink data: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for InkError {}
+
+/// The ink domain result alias.
+pub type InkResult<T> = Result<T, InkError>;
+
+/// A drawing tool. Color is preserved on grayscale panels for export + future color panels
+/// (RR6-FR6). The `Eraser` removes strokes it touches rather than depositing ink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tool {
+    /// Opaque pen ink.
+    Pen,
+    /// Translucent highlighter ink (drawn under text where the renderer supports it).
+    Highlighter,
+    /// Removes strokes it passes over (see [`InkLayer::erase_at`]).
+    Eraser,
+}
+
+impl Tool {
+    /// Decode the wire code (`0=Pen, 1=Highlighter, 2=Eraser`); unknown → `None`.
+    #[must_use]
+    pub fn from_code(code: u8) -> Option<Tool> {
+        match code {
+            0 => Some(Tool::Pen),
+            1 => Some(Tool::Highlighter),
+            2 => Some(Tool::Eraser),
+            _ => None,
+        }
+    }
+
+    /// The stable wire code for this tool (inverse of [`Self::from_code`]).
+    #[must_use]
+    pub fn code(self) -> u8 {
+        match self {
+            Tool::Pen => 0,
+            Tool::Highlighter => 1,
+            Tool::Eraser => 2,
+        }
+    }
+
+    /// Whether this tool deposits ink (Pen/Highlighter) vs. erases (Eraser).
+    #[must_use]
+    pub fn is_ink(self) -> bool {
+        matches!(self, Tool::Pen | Tool::Highlighter)
+    }
+}
+
+/// An RGBA ink color, preserved even when the panel renders grayscale (RR6-FR6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InkColor {
+    /// Red channel.
+    pub r: u8,
+    /// Green channel.
+    pub g: u8,
+    /// Blue channel.
+    pub b: u8,
+    /// Alpha channel (`255` = opaque).
+    pub a: u8,
+}
+
+impl InkColor {
+    /// Opaque black — the default pen color.
+    pub const BLACK: InkColor = InkColor {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 255,
+    };
+
+    /// Build an RGBA color.
+    #[must_use]
+    pub fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self { r, g, b, a }
+    }
+}
+
+impl Default for InkColor {
+    fn default() -> Self {
+        InkColor::BLACK
+    }
+}
+
+/// One captured sample along a stroke. Coordinates + pressure are normalized `[0,1]`; tilt is
+/// optional and in radians where the digitizer reports it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InkPoint {
+    /// X in normalized page space `[0,1]`, top-left origin.
+    pub x: f32,
+    /// Y in normalized page space `[0,1]`, top-left origin.
+    pub y: f32,
+    /// Normalized pen pressure `[0,1]` (`1.0` if the device has no pressure).
+    pub pressure: f32,
+    /// Pen tilt about the X axis, if reported.
+    pub tilt_x: Option<f32>,
+    /// Pen tilt about the Y axis, if reported.
+    pub tilt_y: Option<f32>,
+    /// Sample time in milliseconds relative to stroke start (caller-supplied; the core reads no
+    /// clock).
+    pub timestamp_ms: u32,
+}
+
+impl InkPoint {
+    /// Build a validated point. Rejects a non-finite x/y/pressure (`NonFinite`); clamps x, y, and
+    /// pressure into `[0,1]`; drops a non-finite tilt to `None`.
+    pub fn new(
+        x: f32,
+        y: f32,
+        pressure: f32,
+        tilt_x: Option<f32>,
+        tilt_y: Option<f32>,
+        timestamp_ms: u32,
+    ) -> InkResult<Self> {
+        if !x.is_finite() || !y.is_finite() || !pressure.is_finite() {
+            return Err(InkError::NonFinite("point coordinate"));
+        }
+        let finite = |t: Option<f32>| t.filter(|v| v.is_finite());
+        Ok(Self {
+            x: x.clamp(0.0, 1.0),
+            y: y.clamp(0.0, 1.0),
+            pressure: pressure.clamp(0.0, 1.0),
+            tilt_x: finite(tilt_x),
+            tilt_y: finite(tilt_y),
+            timestamp_ms,
+        })
+    }
+}
+
+/// Identifier for a stroke, unique and monotonic within a page [`InkLayer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StrokeId(pub u32);
+
+/// A vector ink stroke: an ordered, non-empty list of points with a tool, color, and nominal
+/// width.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Stroke {
+    /// Stable id within the page layer.
+    pub id: StrokeId,
+    /// The tool that drew it (always an ink tool — Pen/Highlighter).
+    pub tool: Tool,
+    /// The ink color (preserved on grayscale, RR6-FR6).
+    pub color: InkColor,
+    /// Nominal stroke width in normalized page units (modulated per-point by pressure).
+    pub width: f32,
+    /// The captured samples (always at least one).
+    pub points: Vec<InkPoint>,
+    /// Caller-supplied creation time (ms since epoch); the core reads no clock.
+    pub created_at_ms: u64,
+}
+
+impl Stroke {
+    /// The axis-aligned bounds of this stroke, expanded by half the nominal width, or `None` if
+    /// (impossibly) it has no points.
+    #[must_use]
+    pub fn bounds(&self) -> Option<BBox> {
+        let mut it = self.points.iter();
+        let first = it.next()?;
+        let mut b = BBox {
+            x0: first.x,
+            y0: first.y,
+            x1: first.x,
+            y1: first.y,
+        };
+        for p in it {
+            b.x0 = b.x0.min(p.x);
+            b.y0 = b.y0.min(p.y);
+            b.x1 = b.x1.max(p.x);
+            b.y1 = b.y1.max(p.y);
+        }
+        let m = self.width * 0.5;
+        Some(BBox {
+            x0: (b.x0 - m).max(0.0),
+            y0: (b.y0 - m).max(0.0),
+            x1: (b.x1 + m).min(1.0),
+            y1: (b.y1 + m).min(1.0),
+        })
+    }
+}
+
+/// Effective stroke width at a given pressure (RR6-FR3 pressure-to-width). A flat baseline of
+/// half the nominal width plus a pressure-scaled half keeps a zero-pressure sample visible.
+#[must_use]
+pub fn pressure_to_width(nominal: f32, pressure: f32) -> f32 {
+    let p = pressure.clamp(0.0, 1.0);
+    nominal * (0.5 + 0.5 * p)
+}
+
+/// An axis-aligned bounding box in normalized page space `[0,1]` — the dirty rect for a
+/// partial refresh (RR6-FR5). The caller maps it to device pixels.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BBox {
+    /// Left edge `[0,1]`.
+    pub x0: f32,
+    /// Top edge `[0,1]`.
+    pub y0: f32,
+    /// Right edge `[0,1]`.
+    pub x1: f32,
+    /// Bottom edge `[0,1]`.
+    pub y1: f32,
+}
+
+/// A reversible edit to an [`InkLayer`] — the unit of undo/redo.
+#[derive(Debug, Clone, PartialEq)]
+enum Edit {
+    /// A stroke was added (at the end of the list).
+    Add(Stroke),
+    /// A stroke was erased from position `index`.
+    Erase { index: usize, stroke: Stroke },
+}
+
+/// All ink on one page, with an undo/redo history (RR6-FR3).
+///
+/// Strokes are kept in paint order (later strokes draw on top). The undo/redo history is
+/// session-only and is **not** serialized — only [`Self::strokes`] persist (RR20: committed
+/// strokes survive; the in-progress stroke and history do not).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct InkLayer {
+    strokes: Vec<Stroke>,
+    next_id: u32,
+    pending: Option<Stroke>,
+    undo: Vec<Edit>,
+    redo: Vec<Edit>,
+}
+
+impl InkLayer {
+    /// An empty layer.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a layer from already-committed strokes (the codec/load path). `next_id` is set past
+    /// the largest existing id so new strokes never collide.
+    #[must_use]
+    pub fn from_strokes(strokes: Vec<Stroke>) -> Self {
+        let next_id = strokes.iter().map(|s| s.id.0).max().map_or(0, |m| m + 1);
+        Self {
+            strokes,
+            next_id,
+            pending: None,
+            undo: Vec::new(),
+            redo: Vec::new(),
+        }
+    }
+
+    /// The committed strokes in paint order (what the renderer draws and the codec persists).
+    #[must_use]
+    pub fn strokes(&self) -> &[Stroke] {
+        &self.strokes
+    }
+
+    /// Whether the layer has no committed strokes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.strokes.is_empty()
+    }
+
+    /// Begin an ink stroke (Pen/Highlighter). Any previous in-progress stroke is discarded.
+    /// Returns the id the stroke will have once finished. Rejects a non-finite width.
+    pub fn start_stroke(
+        &mut self,
+        tool: Tool,
+        color: InkColor,
+        width: f32,
+        created_at_ms: u64,
+    ) -> InkResult<StrokeId> {
+        if !width.is_finite() || width <= 0.0 {
+            return Err(InkError::NonFinite("stroke width"));
+        }
+        let id = StrokeId(self.next_id);
+        self.pending = Some(Stroke {
+            id,
+            tool,
+            color,
+            width,
+            points: Vec::new(),
+            created_at_ms,
+        });
+        Ok(id)
+    }
+
+    /// Append a sample to the in-progress stroke. Errors if no stroke is active or the point is
+    /// non-finite (it is otherwise clamped into `[0,1]`).
+    pub fn push_point(&mut self, point: InkPoint) -> InkResult<()> {
+        let stroke = self.pending.as_mut().ok_or(InkError::NoActiveStroke)?;
+        stroke.points.push(point);
+        Ok(())
+    }
+
+    /// Commit the in-progress stroke. Returns its id, or `None` (and discards it) if it had no
+    /// points. Committing clears the redo history (a new edit forks the timeline).
+    pub fn finish_stroke(&mut self) -> Option<StrokeId> {
+        let stroke = self.pending.take()?;
+        if stroke.points.is_empty() {
+            return None;
+        }
+        let id = stroke.id;
+        self.next_id = self.next_id.saturating_add(1);
+        self.strokes.push(stroke.clone());
+        self.undo.push(Edit::Add(stroke));
+        self.redo.clear();
+        Some(id)
+    }
+
+    /// Discard the in-progress stroke without committing (e.g. palm-rejected mid-stroke).
+    pub fn cancel_stroke(&mut self) {
+        self.pending = None;
+    }
+
+    /// The ids of committed strokes within `radius` of `(x, y)` (normalized), nearest segment
+    /// first by paint order — stroke hit-testing (RR6-FR3), non-destructive.
+    #[must_use]
+    pub fn strokes_hit(&self, x: f32, y: f32, radius: f32) -> Vec<StrokeId> {
+        self.strokes
+            .iter()
+            .filter(|s| stroke_hit(s, x, y, radius))
+            .map(|s| s.id)
+            .collect()
+    }
+
+    /// Erase every committed stroke touching `(x, y)` within `radius`. Returns the removed ids
+    /// (top-most first) and records one undoable edit per removed stroke. Clears redo.
+    pub fn erase_at(&mut self, x: f32, y: f32, radius: f32) -> Vec<StrokeId> {
+        let mut removed = Vec::new();
+        // Walk from the top (paint order end) so erasing the top-most stroke first feels right
+        // and the recorded indices stay valid for undo (LIFO restore).
+        let mut i = self.strokes.len();
+        while i > 0 {
+            i -= 1;
+            if stroke_hit(&self.strokes[i], x, y, radius) {
+                let stroke = self.strokes.remove(i);
+                removed.push(stroke.id);
+                self.undo.push(Edit::Erase { index: i, stroke });
+            }
+        }
+        if !removed.is_empty() {
+            self.redo.clear();
+        }
+        removed
+    }
+
+    /// Whether an undo is available.
+    #[must_use]
+    pub fn can_undo(&self) -> bool {
+        !self.undo.is_empty()
+    }
+
+    /// Whether a redo is available.
+    #[must_use]
+    pub fn can_redo(&self) -> bool {
+        !self.redo.is_empty()
+    }
+
+    /// Undo the most recent edit. Returns `true` if something was undone.
+    pub fn undo(&mut self) -> bool {
+        let Some(edit) = self.undo.pop() else {
+            return false;
+        };
+        match &edit {
+            Edit::Add(stroke) => {
+                self.strokes.retain(|s| s.id != stroke.id);
+            }
+            Edit::Erase { index, stroke } => {
+                let at = (*index).min(self.strokes.len());
+                self.strokes.insert(at, stroke.clone());
+            }
+        }
+        self.redo.push(edit);
+        true
+    }
+
+    /// Redo the most recently undone edit. Returns `true` if something was redone.
+    pub fn redo(&mut self) -> bool {
+        let Some(edit) = self.redo.pop() else {
+            return false;
+        };
+        match &edit {
+            Edit::Add(stroke) => {
+                self.strokes.push(stroke.clone());
+            }
+            Edit::Erase { index, stroke } => {
+                if let Some(pos) = self.strokes.iter().position(|s| s.id == stroke.id) {
+                    self.strokes.remove(pos);
+                } else {
+                    let _ = index;
+                }
+            }
+        }
+        self.undo.push(edit);
+        true
+    }
+
+    /// The union bounds of all committed strokes, or `None` if the layer is empty.
+    #[must_use]
+    pub fn bounds(&self) -> Option<BBox> {
+        let mut acc: Option<BBox> = None;
+        for s in &self.strokes {
+            if let Some(b) = s.bounds() {
+                acc = Some(match acc {
+                    None => b,
+                    Some(a) => BBox {
+                        x0: a.x0.min(b.x0),
+                        y0: a.y0.min(b.y0),
+                        x1: a.x1.max(b.x1),
+                        y1: a.y1.max(b.y1),
+                    },
+                });
+            }
+        }
+        acc
+    }
+}
+
+/// Whether any segment of `stroke` passes within `radius` of `(x, y)` (normalized).
+fn stroke_hit(stroke: &Stroke, x: f32, y: f32, radius: f32) -> bool {
+    let r2 = radius * radius;
+    let pts = &stroke.points;
+    if pts.len() == 1 {
+        return dist2_point(pts[0].x, pts[0].y, x, y) <= r2;
+    }
+    pts.windows(2)
+        .any(|w| dist2_to_segment(x, y, w[0].x, w[0].y, w[1].x, w[1].y) <= r2)
+}
+
+/// Squared distance between two points.
+fn dist2_point(ax: f32, ay: f32, bx: f32, by: f32) -> f32 {
+    let dx = ax - bx;
+    let dy = ay - by;
+    dx * dx + dy * dy
+}
+
+/// Squared distance from `(px,py)` to segment `(ax,ay)-(bx,by)`.
+fn dist2_to_segment(px: f32, py: f32, ax: f32, ay: f32, bx: f32, by: f32) -> f32 {
+    let abx = bx - ax;
+    let aby = by - ay;
+    let len2 = abx * abx + aby * aby;
+    if len2 <= f32::EPSILON {
+        return dist2_point(px, py, ax, ay);
+    }
+    let t = (((px - ax) * abx + (py - ay) * aby) / len2).clamp(0.0, 1.0);
+    let cx = ax + t * abx;
+    let cy = ay + t * aby;
+    dist2_point(px, py, cx, cy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pt(x: f32, y: f32) -> InkPoint {
+        InkPoint::new(x, y, 1.0, None, None, 0).unwrap()
+    }
+
+    fn drawn(layer: &mut InkLayer, pts: &[(f32, f32)]) -> StrokeId {
+        layer
+            .start_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0)
+            .unwrap();
+        for &(x, y) in pts {
+            layer.push_point(pt(x, y)).unwrap();
+        }
+        layer.finish_stroke().unwrap()
+    }
+
+    #[test]
+    fn point_rejects_non_finite_and_clamps_range() {
+        assert_eq!(
+            InkPoint::new(f32::NAN, 0.0, 1.0, None, None, 0),
+            Err(InkError::NonFinite("point coordinate"))
+        );
+        let p = InkPoint::new(1.5, -0.2, 2.0, Some(f32::INFINITY), None, 7).unwrap();
+        assert_eq!((p.x, p.y, p.pressure), (1.0, 0.0, 1.0));
+        assert_eq!(p.tilt_x, None); // infinite tilt dropped
+        assert_eq!(p.timestamp_ms, 7);
+    }
+
+    #[test]
+    fn tool_codes_round_trip() {
+        for t in [Tool::Pen, Tool::Highlighter, Tool::Eraser] {
+            assert_eq!(Tool::from_code(t.code()), Some(t));
+        }
+        assert_eq!(Tool::from_code(9), None);
+        assert!(Tool::Pen.is_ink() && !Tool::Eraser.is_ink());
+    }
+
+    #[test]
+    fn start_stroke_rejects_bad_width() {
+        let mut l = InkLayer::new();
+        assert!(l.start_stroke(Tool::Pen, InkColor::BLACK, 0.0, 0).is_err());
+        assert!(l
+            .start_stroke(Tool::Pen, InkColor::BLACK, f32::NAN, 0)
+            .is_err());
+    }
+
+    #[test]
+    fn empty_stroke_is_discarded() {
+        let mut l = InkLayer::new();
+        l.start_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0).unwrap();
+        assert_eq!(l.finish_stroke(), None);
+        assert!(l.is_empty());
+        assert!(!l.can_undo());
+    }
+
+    #[test]
+    fn push_point_without_start_errors() {
+        let mut l = InkLayer::new();
+        assert_eq!(l.push_point(pt(0.1, 0.1)), Err(InkError::NoActiveStroke));
+    }
+
+    #[test]
+    fn ids_are_monotonic() {
+        let mut l = InkLayer::new();
+        let a = drawn(&mut l, &[(0.1, 0.1), (0.2, 0.2)]);
+        let b = drawn(&mut l, &[(0.3, 0.3), (0.4, 0.4)]);
+        assert_eq!((a, b), (StrokeId(0), StrokeId(1)));
+        assert_eq!(l.strokes().len(), 2);
+    }
+
+    #[test]
+    fn undo_redo_add() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.1, 0.1), (0.2, 0.2)]);
+        assert_eq!(l.strokes().len(), 1);
+        assert!(l.undo());
+        assert!(l.is_empty());
+        assert!(l.redo());
+        assert_eq!(l.strokes().len(), 1);
+        assert!(!l.redo()); // nothing left
+    }
+
+    #[test]
+    fn new_edit_clears_redo() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.1, 0.1), (0.2, 0.2)]);
+        assert!(l.undo());
+        drawn(&mut l, &[(0.5, 0.5), (0.6, 0.6)]);
+        assert!(!l.can_redo(), "a new stroke forks the timeline");
+    }
+
+    #[test]
+    fn erase_hits_and_restores_via_undo() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.10, 0.10), (0.20, 0.10)]); // horizontal segment at y=0.1
+        drawn(&mut l, &[(0.80, 0.80), (0.90, 0.80)]); // far away
+        let removed = l.erase_at(0.15, 0.10, 0.02);
+        assert_eq!(removed, vec![StrokeId(0)]);
+        assert_eq!(l.strokes().len(), 1);
+        assert!(l.undo());
+        assert_eq!(l.strokes().len(), 2, "erased stroke restored");
+        // restored at original position (paint order preserved: id 0 then id 1)
+        assert_eq!(l.strokes()[0].id, StrokeId(0));
+    }
+
+    #[test]
+    fn erase_miss_changes_nothing() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.1, 0.1), (0.2, 0.1)]);
+        assert!(l.erase_at(0.9, 0.9, 0.02).is_empty());
+        assert_eq!(l.strokes().len(), 1);
+    }
+
+    #[test]
+    fn hit_test_is_non_destructive() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.1, 0.1), (0.2, 0.1)]);
+        assert_eq!(l.strokes_hit(0.15, 0.1, 0.02), vec![StrokeId(0)]);
+        assert_eq!(l.strokes().len(), 1, "hit-test does not remove");
+    }
+
+    #[test]
+    fn bounds_expand_by_half_width() {
+        let mut l = InkLayer::new();
+        drawn(&mut l, &[(0.40, 0.40), (0.60, 0.60)]);
+        let b = l.bounds().unwrap();
+        // width 0.01 → margin 0.005
+        assert!((b.x0 - 0.395).abs() < 1e-4 && (b.y1 - 0.605).abs() < 1e-4);
+    }
+
+    #[test]
+    fn from_strokes_sets_next_id_past_max() {
+        let mut seed = InkLayer::new();
+        drawn(&mut seed, &[(0.1, 0.1), (0.2, 0.2)]);
+        drawn(&mut seed, &[(0.3, 0.3), (0.4, 0.4)]);
+        let mut l = InkLayer::from_strokes(seed.strokes().to_vec());
+        let id = drawn(&mut l, &[(0.5, 0.5), (0.6, 0.6)]);
+        assert_eq!(id, StrokeId(2), "new id is past the largest loaded id");
+    }
+
+    #[test]
+    fn pressure_to_width_scales() {
+        assert!((pressure_to_width(0.02, 0.0) - 0.01).abs() < 1e-6);
+        assert!((pressure_to_width(0.02, 1.0) - 0.02).abs() < 1e-6);
+    }
+}

--- a/reader-core/Cargo.toml
+++ b/reader-core/Cargo.toml
@@ -19,9 +19,12 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 device-eink = { workspace = true }
+inkread-ink = { workspace = true }
 pdfium-render = { workspace = true }
 tiny-skia = { workspace = true }
 rusqlite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Amendment 1: `jni` is OPTIONAL and pulled in ONLY by the `jni-bridge` feature, so a
 # bare `cargo test -p reader-core` leaves `jni` out of the resolved graph (RR1-AC3 / IR-7).

--- a/reader-core/src/error.rs
+++ b/reader-core/src/error.rs
@@ -84,6 +84,19 @@ impl fmt::Display for CoreError {
 
 impl std::error::Error for CoreError {}
 
+/// Map an ink-domain error onto the core surface at the persistence boundary (RR21-FR3): a
+/// malformed `.inkbin` is a corrupt document; everything else is a bad argument.
+impl From<inkread_ink::InkError> for CoreError {
+    fn from(e: inkread_ink::InkError) -> Self {
+        match e {
+            inkread_ink::InkError::BadEncoding(m) => {
+                CoreError::CorruptDocument(format!("ink: {m}"))
+            }
+            other => CoreError::InvalidArgument(other.to_string()),
+        }
+    }
+}
+
 /// The core's result alias.
 pub type CoreResult<T> = Result<T, CoreError>;
 

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -436,12 +436,16 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkBeginStr
 ) {
     env.with_env(|env| -> jni::errors::Result<()> {
         let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
-        let tool = Tool::from_code(tool as u8).ok_or_else(|| {
-            throw(
-                env,
-                &CoreError::InvalidArgument(format!("unknown ink tool {tool}")),
-            )
-        })?;
+        // Validate, don't truncate: `tool as u8` would silently fold 256 → Pen, 258 → Eraser.
+        let tool = u8::try_from(tool)
+            .ok()
+            .and_then(Tool::from_code)
+            .ok_or_else(|| {
+                throw(
+                    env,
+                    &CoreError::InvalidArgument(format!("unknown ink tool {tool}")),
+                )
+            })?;
         let c = color_rgba as u32;
         let color = InkColor::rgba((c >> 24) as u8, (c >> 16) as u8, (c >> 8) as u8, c as u8);
         session

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -24,7 +24,7 @@
 
 use jni::objects::{JByteArray, JByteBuffer, JClass, JString};
 use jni::strings::JNIString;
-use jni::sys::{jint, jlong};
+use jni::sys::{jboolean, jfloat, jint, jlong};
 use jni::{Env, EnvUnowned};
 
 use device_eink::{decode_capabilities, encode_commands, DeviceCapabilities};
@@ -32,8 +32,12 @@ use device_eink::{decode_capabilities, encode_commands, DeviceCapabilities};
 use std::path::Path;
 use std::sync::Arc;
 
+use inkread_ink::{InkColor, Tool};
+
 use crate::document::{encode_links_wire, encode_toc_wire};
 use crate::error::{CoreError, CoreResult};
+use crate::persistence::ink_store::{FsInkStore, InkStore};
+use crate::persistence::sidecar::SidecarPaths;
 use crate::persistence::sqlite::SqliteStore;
 use crate::persistence::{BookId, ReaderStore};
 use crate::render::{PixelBuffer, Viewport};
@@ -379,6 +383,171 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeJumpToPage<
         let commands = session.jump_to_page(target);
         let bytes = encode_commands(&commands);
         env.byte_array_from_slice(&bytes)
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// =====================================================================================
+// Ink annotation seam (RR6/RR7/RR10/RR20). The Kotlin shell feeds stylus geometry through
+// these; the Rust core owns the model + sidecar persistence. The live firmware-ink *render*
+// (ADR-SUPERNOTE-INK) is a separate device path and does NOT cross this seam.
+//
+//   nativeAttachInkStore(handle, docPath)        — bind the document's book.inkread/ sidecar
+//   nativeInkBeginStroke(handle, tool, rgba, width, createdAtMs)
+//   nativeInkAddPoint(handle, x, y, pressure, tiltX, tiltY, timestampMs)  (NaN tilt = absent)
+//   nativeInkEndStroke(handle)                   — commit + autosave
+//   nativeInkStrokesForPage(handle, page): bytes — .inkbin wire (decode with the ink codec)
+//   nativeInkUndo / nativeInkRedo(handle): bool  — autosaves on change
+//   nativeInkSave(handle)                        — explicit flush (onPause/close)
+//
+// `tool`: 0=Pen, 1=Highlighter, 2=Eraser. `rgba`: 0xRRGGBBAA packed into an int.
+// =====================================================================================
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeAttachInkStore<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    doc_path: JString<'local>,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        // SAFETY: borrowed, not owned (Amendment 2).
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let doc_path: String = doc_path.try_to_string(env)?;
+        let paths = SidecarPaths::for_document(Path::new(&doc_path));
+        let store: Arc<dyn InkStore> = Arc::new(FsInkStore::new(paths));
+        session
+            .attach_ink_store(store)
+            .map_err(|e| throw(env, &e))?;
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkBeginStroke<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    tool: jint,
+    color_rgba: jint,
+    width: jfloat,
+    created_at_ms: jlong,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let tool = Tool::from_code(tool as u8).ok_or_else(|| {
+            throw(
+                env,
+                &CoreError::InvalidArgument(format!("unknown ink tool {tool}")),
+            )
+        })?;
+        let c = color_rgba as u32;
+        let color = InkColor::rgba((c >> 24) as u8, (c >> 16) as u8, (c >> 8) as u8, c as u8);
+        session
+            .ink_begin_stroke(tool, color, width, created_at_ms.max(0) as u64)
+            .map_err(|e| throw(env, &e))?;
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkAddPoint<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    x: jfloat,
+    y: jfloat,
+    pressure: jfloat,
+    tilt_x: jfloat,
+    tilt_y: jfloat,
+    timestamp_ms: jint,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        // NaN tilt means "not reported"; the model also drops any non-finite tilt to None.
+        let tx = if tilt_x.is_nan() { None } else { Some(tilt_x) };
+        let ty = if tilt_y.is_nan() { None } else { Some(tilt_y) };
+        session
+            .ink_add_point(x, y, pressure, tx, ty, timestamp_ms.max(0) as u32)
+            .map_err(|e| throw(env, &e))?;
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkEndStroke<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session.ink_end_stroke().map_err(|e| throw(env, &e))?;
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkStrokesForPage<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    page: jint,
+) -> JByteArray<'local> {
+    env.with_env(|env| -> jni::errors::Result<JByteArray<'local>> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let target = if page < 0 { 0usize } else { page as usize };
+        let bytes = session
+            .ink_strokes_wire(target)
+            .map_err(|e| throw(env, &e))?;
+        env.byte_array_from_slice(&bytes)
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkUndo<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) -> jboolean {
+    env.with_env(|env| -> jni::errors::Result<jboolean> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let changed = session.ink_undo().map_err(|e| throw(env, &e))?;
+        Ok(jboolean::from(changed))
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkRedo<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) -> jboolean {
+    env.with_env(|env| -> jni::errors::Result<jboolean> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let changed = session.ink_redo().map_err(|e| throw(env, &e))?;
+        Ok(jboolean::from(changed))
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkSave<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session.save_ink().map_err(|e| throw(env, &e))?;
+        Ok(())
     })
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }

--- a/reader-core/src/persistence/identity.rs
+++ b/reader-core/src/persistence/identity.rs
@@ -1,0 +1,121 @@
+//! Document identity for sidecar re-association (RR10-FR6).
+//!
+//! A document is identified by a **content fingerprint + size** (plus title/author for display
+//! and interop). The fingerprint lets a moved/renamed file re-associate with its `book.inkread/`
+//! sidecar (RR10-AC3): we recompute it from the file's bytes on open and match.
+//!
+//! The fingerprint is **FNV-1a-128**, deliberately vendored here rather than taken from a crate
+//! or `std::hash::DefaultHasher`: it must be **stable forever across builds and toolchains**
+//! (a persisted identity can't change when the compiler does — `DefaultHasher`'s algorithm is
+//! explicitly allowed to change). It is a content *fingerprint*, not a cryptographic hash.
+
+use crate::document::DocumentMetadata;
+use crate::error::CoreResult;
+use crate::persistence::BookId;
+
+/// FNV-1a-128 offset basis.
+const FNV_OFFSET_128: u128 = 0x6c62272e07bb0142_62b821756295c58d;
+/// FNV-1a-128 prime.
+const FNV_PRIME_128: u128 = 0x0000000001000000_000000000000013B;
+
+/// FNV-1a-128 content fingerprint over `bytes` — stable across builds (see module docs).
+#[must_use]
+pub fn fingerprint(bytes: &[u8]) -> u128 {
+    let mut h = FNV_OFFSET_128;
+    for &b in bytes {
+        h ^= u128::from(b);
+        h = h.wrapping_mul(FNV_PRIME_128);
+    }
+    h
+}
+
+/// The robust identity of an opened document (RR10-FR6).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocIdentity {
+    /// Content fingerprint (FNV-1a-128 over the file bytes).
+    pub fingerprint: u128,
+    /// File size in bytes.
+    pub size: u64,
+    /// Title metadata, if any (display/interop only).
+    pub title: Option<String>,
+    /// Author metadata, if any (display/interop only).
+    pub author: Option<String>,
+}
+
+impl DocIdentity {
+    /// Derive identity from a document's bytes + parsed metadata. The fingerprint is computed
+    /// over the in-memory bytes the backend already holds (no extra IO).
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8], meta: &DocumentMetadata) -> Self {
+        Self {
+            fingerprint: fingerprint(bytes),
+            size: bytes.len() as u64,
+            title: meta.title.clone(),
+            author: meta.author.clone(),
+        }
+    }
+
+    /// The fingerprint as a fixed-width 32-char lowercase hex string.
+    #[must_use]
+    pub fn fingerprint_hex(&self) -> String {
+        format!("{:032x}", self.fingerprint)
+    }
+
+    /// The stable [`BookId`] for this document — `"<fingerprint_hex>-<size>"`. Size is folded in
+    /// so two files that happen to collide on the fingerprint still differ if their sizes do.
+    pub fn to_book_id(&self) -> CoreResult<BookId> {
+        BookId::new(format!("{}-{}", self.fingerprint_hex(), self.size))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(title: Option<&str>, author: Option<&str>) -> DocumentMetadata {
+        DocumentMetadata {
+            title: title.map(str::to_string),
+            author: author.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn same_bytes_same_identity() {
+        let a = DocIdentity::from_bytes(b"hello world", &meta(Some("T"), None));
+        let b = DocIdentity::from_bytes(b"hello world", &meta(Some("T"), None));
+        assert_eq!(a, b);
+        assert_eq!(a.to_book_id().unwrap(), b.to_book_id().unwrap());
+    }
+
+    #[test]
+    fn different_bytes_different_fingerprint() {
+        let a = DocIdentity::from_bytes(b"hello world", &meta(None, None));
+        let b = DocIdentity::from_bytes(b"hello worlds", &meta(None, None));
+        assert_ne!(a.fingerprint, b.fingerprint);
+    }
+
+    #[test]
+    fn one_bit_flip_changes_fingerprint() {
+        let a = fingerprint(b"page-0001");
+        let b = fingerprint(b"page-0002");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_and_pinned() {
+        // Pin the algorithm against drift: empty input must equal the FNV offset basis (no bytes
+        // processed), and the function must be deterministic. If either breaks, persisted
+        // identities would silently fail to re-associate.
+        assert_eq!(fingerprint(b""), FNV_OFFSET_128);
+        assert_eq!(fingerprint(b"inkread"), fingerprint(b"inkread"));
+        assert_eq!(DocIdentity::from_bytes(b"", &meta(None, None)).size, 0);
+    }
+
+    #[test]
+    fn book_id_format_includes_size() {
+        let id = DocIdentity::from_bytes(b"abc", &meta(None, None));
+        let bid = id.to_book_id().unwrap();
+        assert!(bid.as_str().ends_with("-3"), "size 3 folded into the id");
+        assert_eq!(bid.as_str().len(), 32 + 1 + 1); // hex + '-' + "3"
+    }
+}

--- a/reader-core/src/persistence/identity.rs
+++ b/reader-core/src/persistence/identity.rs
@@ -107,7 +107,9 @@ mod tests {
         // processed), and the function must be deterministic. If either breaks, persisted
         // identities would silently fail to re-associate.
         assert_eq!(fingerprint(b""), FNV_OFFSET_128);
-        assert_eq!(fingerprint(b"inkread"), fingerprint(b"inkread"));
+        // A pinned non-empty vector: a change here means a FNV prime/algorithm regression that
+        // would silently break re-association of every already-persisted sidecar.
+        assert_eq!(fingerprint(b"inkread"), 0x1e803fe25c4ff78d88226ddd13e0b86b);
         assert_eq!(DocIdentity::from_bytes(b"", &meta(None, None)).size, 0);
     }
 

--- a/reader-core/src/persistence/ink_store.rs
+++ b/reader-core/src/persistence/ink_store.rs
@@ -1,0 +1,340 @@
+//! The annotation-persistence **port** + adapters (RR10, RR20).
+//!
+//! [`InkStore`] is to ink what [`super::ReaderStore`] is to reading position: a narrow port the
+//! session depends on, with a production filesystem adapter ([`FsInkStore`]) and an in-memory
+//! adapter ([`MemInkStore`]) for tests / a store-less session. A store is scoped to **one
+//! document's** `book.inkread/` sidecar, so the port is keyed only by page.
+//!
+//! Crash-safety (RR10-FR7, RR20-FR3/FR4/FR6): every write goes to a `*.tmp` sibling that is
+//! flushed (`sync_all`) and then **atomically renamed** over the target. A crash therefore leaves
+//! the committed `.inkbin` either fully old or fully new — never half-written — and only an
+//! orphan `.tmp` (ignored by load + scan) is ever lost.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Mutex;
+
+use inkread_ink::{decode_layer, encode_layer, InkLayer};
+
+use crate::error::{CoreError, CoreResult};
+use crate::persistence::sidecar::{parse_page_file_name, SidecarMetadata, SidecarPaths};
+
+/// The annotation-persistence port for a single document's sidecar. `Send + Sync` so the session
+/// can hold it behind an `Arc` across the engine worker thread (RR21), mirroring `ReaderStore`.
+pub trait InkStore: Send + Sync {
+    /// Load the ink layer for `page`, or an **empty** layer if the page has no sidecar file
+    /// (never an error for an un-annotated page).
+    fn load_page(&self, page: usize) -> CoreResult<InkLayer>;
+
+    /// Persist `layer` for `page` atomically. An empty layer **removes** the page's file (all
+    /// strokes erased), keeping the sidecar tidy.
+    fn save_page(&self, page: usize, layer: &InkLayer) -> CoreResult<()>;
+
+    /// The zero-based indices of pages that currently have stored ink, ascending.
+    fn pages_with_ink(&self) -> CoreResult<Vec<usize>>;
+
+    /// Load the sidecar metadata, or `None` if absent. A *corrupt* metadata file is an error the
+    /// caller may treat as non-fatal (the strokes still load).
+    fn load_metadata(&self) -> CoreResult<Option<SidecarMetadata>>;
+
+    /// Persist the sidecar metadata atomically.
+    fn save_metadata(&self, meta: &SidecarMetadata) -> CoreResult<()>;
+}
+
+/// Wrap an IO error as a persistence error (RR21-FR3).
+fn io_err(e: io::Error) -> CoreError {
+    CoreError::Persistence(e.to_string())
+}
+
+/// Atomically replace `path` with `bytes`: write a flushed `*.tmp` sibling, then rename. The
+/// parent directory must already exist.
+fn atomic_write(path: &Path, bytes: &[u8]) -> CoreResult<()> {
+    let mut tmp_name: OsString = path.as_os_str().to_owned();
+    tmp_name.push(".tmp");
+    let tmp = Path::new(&tmp_name);
+    {
+        let mut f = fs::File::create(tmp).map_err(io_err)?;
+        f.write_all(bytes).map_err(io_err)?;
+        f.sync_all().map_err(io_err)?;
+    }
+    // Rename is atomic on the same filesystem; on failure drop the temp so no orphan lingers.
+    if let Err(e) = fs::rename(tmp, path) {
+        let _ = fs::remove_file(tmp);
+        return Err(io_err(e));
+    }
+    Ok(())
+}
+
+/// Filesystem adapter — the production [`InkStore`] over a `book.inkread/` directory.
+#[derive(Debug, Clone)]
+pub struct FsInkStore {
+    paths: SidecarPaths,
+}
+
+impl FsInkStore {
+    /// A store over the given sidecar layout.
+    #[must_use]
+    pub fn new(paths: SidecarPaths) -> Self {
+        Self { paths }
+    }
+}
+
+impl InkStore for FsInkStore {
+    fn load_page(&self, page: usize) -> CoreResult<InkLayer> {
+        match fs::read(self.paths.page_file(page)) {
+            Ok(bytes) => Ok(decode_layer(&bytes)?),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(InkLayer::new()),
+            Err(e) => Err(io_err(e)),
+        }
+    }
+
+    fn save_page(&self, page: usize, layer: &InkLayer) -> CoreResult<()> {
+        let file = self.paths.page_file(page);
+        if layer.is_empty() {
+            // Erased to nothing → remove the file (absence == no ink). Missing is fine.
+            return match fs::remove_file(&file) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(e) => Err(io_err(e)),
+            };
+        }
+        fs::create_dir_all(self.paths.annotations_dir()).map_err(io_err)?;
+        atomic_write(&file, &encode_layer(layer))
+    }
+
+    fn pages_with_ink(&self) -> CoreResult<Vec<usize>> {
+        let dir = self.paths.annotations_dir();
+        let rd = match fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(io_err(e)),
+        };
+        let mut pages = Vec::new();
+        for entry in rd {
+            let entry = entry.map_err(io_err)?;
+            if let Some(page) = entry.file_name().to_str().and_then(parse_page_file_name) {
+                pages.push(page);
+            }
+        }
+        pages.sort_unstable();
+        Ok(pages)
+    }
+
+    fn load_metadata(&self) -> CoreResult<Option<SidecarMetadata>> {
+        match fs::read(self.paths.metadata_file()) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .map(Some)
+                .map_err(|e| CoreError::Persistence(format!("metadata.json: {e}"))),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(io_err(e)),
+        }
+    }
+
+    fn save_metadata(&self, meta: &SidecarMetadata) -> CoreResult<()> {
+        fs::create_dir_all(self.paths.root()).map_err(io_err)?;
+        let bytes = serde_json::to_vec_pretty(meta)
+            .map_err(|e| CoreError::Persistence(format!("metadata.json: {e}")))?;
+        atomic_write(&self.paths.metadata_file(), &bytes)
+    }
+}
+
+/// In-memory adapter — a store-less session's backing and the unit-test double. Holds encoded
+/// `.inkbin` bytes per page so it exercises the same codec path as [`FsInkStore`].
+#[derive(Debug, Default)]
+pub struct MemInkStore {
+    pages: Mutex<BTreeMap<usize, Vec<u8>>>,
+    meta: Mutex<Option<SidecarMetadata>>,
+}
+
+impl MemInkStore {
+    /// An empty in-memory store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl InkStore for MemInkStore {
+    fn load_page(&self, page: usize) -> CoreResult<InkLayer> {
+        let pages = self.pages.lock().expect("ink store mutex");
+        match pages.get(&page) {
+            Some(bytes) => Ok(decode_layer(bytes)?),
+            None => Ok(InkLayer::new()),
+        }
+    }
+
+    fn save_page(&self, page: usize, layer: &InkLayer) -> CoreResult<()> {
+        let mut pages = self.pages.lock().expect("ink store mutex");
+        if layer.is_empty() {
+            pages.remove(&page);
+        } else {
+            pages.insert(page, encode_layer(layer));
+        }
+        Ok(())
+    }
+
+    fn pages_with_ink(&self) -> CoreResult<Vec<usize>> {
+        let pages = self.pages.lock().expect("ink store mutex");
+        Ok(pages.keys().copied().collect())
+    }
+
+    fn load_metadata(&self) -> CoreResult<Option<SidecarMetadata>> {
+        Ok(self.meta.lock().expect("ink store mutex").clone())
+    }
+
+    fn save_metadata(&self, meta: &SidecarMetadata) -> CoreResult<()> {
+        *self.meta.lock().expect("ink store mutex") = Some(meta.clone());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::identity::DocIdentity;
+    use inkread_ink::{InkColor, InkPoint, Tool};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// A dependency-free RAII temp directory under the OS temp dir.
+    struct TempDir {
+        path: PathBuf,
+    }
+    impl TempDir {
+        fn new() -> Self {
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let mut path = std::env::temp_dir();
+            path.push(format!("inkread-test-{}-{n}", std::process::id()));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn one_stroke_layer() -> InkLayer {
+        let mut l = InkLayer::new();
+        l.start_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0).unwrap();
+        l.push_point(InkPoint::new(0.1, 0.1, 1.0, None, None, 0).unwrap())
+            .unwrap();
+        l.push_point(InkPoint::new(0.2, 0.2, 1.0, None, None, 8).unwrap())
+            .unwrap();
+        l.finish_stroke().unwrap();
+        l
+    }
+
+    fn fs_store(tmp: &TempDir) -> FsInkStore {
+        FsInkStore::new(SidecarPaths::from_root(tmp.path.join("book.inkread")))
+    }
+
+    #[test]
+    fn save_then_load_round_trips_strokes() {
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        let layer = one_stroke_layer();
+        store.save_page(3, &layer).unwrap();
+        let back = store.load_page(3).unwrap();
+        assert_eq!(back.strokes(), layer.strokes());
+    }
+
+    #[test]
+    fn load_absent_page_is_empty() {
+        let tmp = TempDir::new();
+        assert!(fs_store(&tmp).load_page(0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_layer_removes_the_file() {
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        store.save_page(0, &one_stroke_layer()).unwrap();
+        assert_eq!(store.pages_with_ink().unwrap(), vec![0]);
+        store.save_page(0, &InkLayer::new()).unwrap(); // erased to nothing
+        assert!(store.pages_with_ink().unwrap().is_empty());
+        assert!(store.load_page(0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn pages_with_ink_lists_sorted_indices() {
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        for p in [5usize, 0, 2] {
+            store.save_page(p, &one_stroke_layer()).unwrap();
+        }
+        assert_eq!(store.pages_with_ink().unwrap(), vec![0, 2, 5]);
+    }
+
+    #[test]
+    fn orphan_tmp_is_ignored_and_committed_file_survives() {
+        // Simulates a crash mid-write: a stray *.tmp must not be seen as ink, and the previously
+        // committed page must still load intact (RR20-AC3 / RR10-AC2).
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        store.save_page(1, &one_stroke_layer()).unwrap();
+        let stray = store.paths.page_file(1);
+        let mut orphan: OsString = stray.as_os_str().to_owned();
+        orphan.push(".tmp");
+        fs::write(&orphan, b"garbage-half-write").unwrap();
+        assert_eq!(store.pages_with_ink().unwrap(), vec![1], "tmp ignored");
+        assert_eq!(
+            store.load_page(1).unwrap().strokes().len(),
+            1,
+            "committed survives"
+        );
+    }
+
+    #[test]
+    fn corrupt_inkbin_is_a_typed_error_not_a_panic() {
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        store.save_page(0, &one_stroke_layer()).unwrap();
+        fs::write(store.paths.page_file(0), b"NOTINKBIN").unwrap();
+        assert!(matches!(
+            store.load_page(0),
+            Err(CoreError::CorruptDocument(_))
+        ));
+    }
+
+    #[test]
+    fn metadata_round_trips_on_disk() {
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        assert_eq!(store.load_metadata().unwrap(), None);
+        let id =
+            DocIdentity::from_bytes(b"doc-bytes", &crate::document::DocumentMetadata::default());
+        let meta = SidecarMetadata::from_identity(&id, 12);
+        store.save_metadata(&meta).unwrap();
+        assert_eq!(store.load_metadata().unwrap(), Some(meta));
+    }
+
+    #[test]
+    fn corrupt_metadata_is_an_error() {
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        fs::create_dir_all(store.paths.root()).unwrap();
+        fs::write(store.paths.metadata_file(), b"{not json").unwrap();
+        assert!(store.load_metadata().is_err());
+    }
+
+    #[test]
+    fn mem_store_matches_fs_semantics() {
+        let store = MemInkStore::new();
+        assert!(store.load_page(0).unwrap().is_empty());
+        store.save_page(2, &one_stroke_layer()).unwrap();
+        assert_eq!(store.pages_with_ink().unwrap(), vec![2]);
+        assert_eq!(
+            store.load_page(2).unwrap().strokes(),
+            one_stroke_layer().strokes()
+        );
+        store.save_page(2, &InkLayer::new()).unwrap();
+        assert!(store.pages_with_ink().unwrap().is_empty());
+    }
+}

--- a/reader-core/src/persistence/ink_store.rs
+++ b/reader-core/src/persistence/ink_store.rs
@@ -43,6 +43,20 @@ pub trait InkStore: Send + Sync {
 
     /// Persist the sidecar metadata atomically.
     fn save_metadata(&self, meta: &SidecarMetadata) -> CoreResult<()>;
+
+    /// Move a page's stored ink aside (rename to `*.corrupt`) when it fails to decode, so the
+    /// reader can continue with an empty page WITHOUT destroying the unreadable bytes — they stay
+    /// recoverable (RR20-FR1). Default: a no-op for stores without on-disk files.
+    fn quarantine_page(&self, _page: usize) -> CoreResult<()> {
+        Ok(())
+    }
+
+    /// Move the whole `annotations/` directory aside when the sidecar belongs to a *different*
+    /// document (identity mismatch, RR10-AC3), so the opened document starts with a clean sidecar
+    /// and the stale ink is preserved rather than adopted. Default: a no-op.
+    fn reset_stale_annotations(&self) -> CoreResult<()> {
+        Ok(())
+    }
 }
 
 /// Wrap an IO error as a persistence error (RR21-FR3).
@@ -50,8 +64,18 @@ fn io_err(e: io::Error) -> CoreError {
     CoreError::Persistence(e.to_string())
 }
 
-/// Atomically replace `path` with `bytes`: write a flushed `*.tmp` sibling, then rename. The
-/// parent directory must already exist.
+/// Best-effort directory fsync so a rename/unlink is itself durable across power loss (RR20-FR6):
+/// `sync_all` on a file flushes its *data*, but the **directory entry** created/removed by the
+/// rename/unlink is only guaranteed durable once the parent dir is fsync'd. A platform or
+/// filesystem that rejects opening/fsyncing a directory is tolerated — the rename still happened.
+fn sync_dir(dir: &Path) {
+    if let Ok(f) = fs::File::open(dir) {
+        let _ = f.sync_all();
+    }
+}
+
+/// Atomically replace `path` with `bytes`: write a flushed `*.tmp` sibling, rename over the target,
+/// then fsync the parent directory so the rename survives power loss. The parent must exist.
 fn atomic_write(path: &Path, bytes: &[u8]) -> CoreResult<()> {
     let mut tmp_name: OsString = path.as_os_str().to_owned();
     tmp_name.push(".tmp");
@@ -65,6 +89,9 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> CoreResult<()> {
     if let Err(e) = fs::rename(tmp, path) {
         let _ = fs::remove_file(tmp);
         return Err(io_err(e));
+    }
+    if let Some(parent) = path.parent() {
+        sync_dir(parent);
     }
     Ok(())
 }
@@ -95,9 +122,15 @@ impl InkStore for FsInkStore {
     fn save_page(&self, page: usize, layer: &InkLayer) -> CoreResult<()> {
         let file = self.paths.page_file(page);
         if layer.is_empty() {
-            // Erased to nothing → remove the file (absence == no ink). Missing is fine.
+            // Erased to nothing → remove the file (absence == no ink). Missing is fine; fsync the
+            // dir so the unlink is durable (RR20-FR6).
             return match fs::remove_file(&file) {
-                Ok(()) => Ok(()),
+                Ok(()) => {
+                    if let Some(parent) = file.parent() {
+                        sync_dir(parent);
+                    }
+                    Ok(())
+                }
                 Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
                 Err(e) => Err(io_err(e)),
             };
@@ -140,6 +173,40 @@ impl InkStore for FsInkStore {
             .map_err(|e| CoreError::Persistence(format!("metadata.json: {e}")))?;
         atomic_write(&self.paths.metadata_file(), &bytes)
     }
+
+    fn quarantine_page(&self, page: usize) -> CoreResult<()> {
+        let src = self.paths.page_file(page);
+        let mut dst: OsString = src.as_os_str().to_owned();
+        dst.push(".corrupt"); // ".inkbin.corrupt" no longer matches the page-scan suffix
+        match fs::rename(&src, Path::new(&dst)) {
+            Ok(()) => {
+                if let Some(parent) = src.parent() {
+                    sync_dir(parent);
+                }
+                Ok(())
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(io_err(e)),
+        }
+    }
+
+    fn reset_stale_annotations(&self) -> CoreResult<()> {
+        let src = self.paths.annotations_dir();
+        let mut dst: OsString = src.as_os_str().to_owned();
+        dst.push(".stale");
+        let dst = Path::new(&dst);
+        let _ = fs::remove_dir_all(dst); // drop any prior quarantine so the rename can land
+        match fs::rename(&src, dst) {
+            Ok(()) => {
+                if let Some(parent) = src.parent() {
+                    sync_dir(parent);
+                }
+                Ok(())
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(io_err(e)),
+        }
+    }
 }
 
 /// In-memory adapter — a store-less session's backing and the unit-test double. Holds encoded
@@ -160,7 +227,7 @@ impl MemInkStore {
 
 impl InkStore for MemInkStore {
     fn load_page(&self, page: usize) -> CoreResult<InkLayer> {
-        let pages = self.pages.lock().expect("ink store mutex");
+        let pages = self.pages.lock().unwrap_or_else(|e| e.into_inner());
         match pages.get(&page) {
             Some(bytes) => Ok(decode_layer(bytes)?),
             None => Ok(InkLayer::new()),
@@ -168,7 +235,7 @@ impl InkStore for MemInkStore {
     }
 
     fn save_page(&self, page: usize, layer: &InkLayer) -> CoreResult<()> {
-        let mut pages = self.pages.lock().expect("ink store mutex");
+        let mut pages = self.pages.lock().unwrap_or_else(|e| e.into_inner());
         if layer.is_empty() {
             pages.remove(&page);
         } else {
@@ -178,16 +245,16 @@ impl InkStore for MemInkStore {
     }
 
     fn pages_with_ink(&self) -> CoreResult<Vec<usize>> {
-        let pages = self.pages.lock().expect("ink store mutex");
+        let pages = self.pages.lock().unwrap_or_else(|e| e.into_inner());
         Ok(pages.keys().copied().collect())
     }
 
     fn load_metadata(&self) -> CoreResult<Option<SidecarMetadata>> {
-        Ok(self.meta.lock().expect("ink store mutex").clone())
+        Ok(self.meta.lock().unwrap_or_else(|e| e.into_inner()).clone())
     }
 
     fn save_metadata(&self, meta: &SidecarMetadata) -> CoreResult<()> {
-        *self.meta.lock().expect("ink store mutex") = Some(meta.clone());
+        *self.meta.lock().unwrap_or_else(|e| e.into_inner()) = Some(meta.clone());
         Ok(())
     }
 }
@@ -301,6 +368,44 @@ mod tests {
             store.load_page(0),
             Err(CoreError::CorruptDocument(_))
         ));
+    }
+
+    #[test]
+    fn quarantine_clears_the_page_but_preserves_the_bytes() {
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        store.save_page(0, &one_stroke_layer()).unwrap();
+        fs::write(store.paths.page_file(0), b"NOTINKBIN").unwrap(); // corrupt it
+        store.quarantine_page(0).unwrap();
+        assert!(
+            store.load_page(0).unwrap().is_empty(),
+            "page now reads empty"
+        );
+        assert!(store.pages_with_ink().unwrap().is_empty(), "no live ink");
+        let mut q: OsString = store.paths.page_file(0).into_os_string();
+        q.push(".corrupt");
+        assert_eq!(
+            fs::read(&q).unwrap(),
+            b"NOTINKBIN",
+            "corrupt bytes preserved for recovery"
+        );
+    }
+
+    #[test]
+    fn reset_stale_annotations_moves_the_dir_aside() {
+        let tmp = TempDir::new();
+        let store = fs_store(&tmp);
+        store.save_page(0, &one_stroke_layer()).unwrap();
+        store.reset_stale_annotations().unwrap();
+        assert!(store.pages_with_ink().unwrap().is_empty(), "starts clean");
+        let mut stale: OsString = store.paths.annotations_dir().into_os_string();
+        stale.push(".stale");
+        assert!(
+            std::path::Path::new(&stale)
+                .join("page-0001.inkbin")
+                .exists(),
+            "old ink preserved in the .stale dir"
+        );
     }
 
     #[test]

--- a/reader-core/src/persistence/mod.rs
+++ b/reader-core/src/persistence/mod.rs
@@ -7,6 +7,7 @@
 //! M1a persists only the **integer-page reading position** (RR12-FR3) — fixed-layout PDF has no
 //! `PinPosition`; the [`ReadingPosition::resume_blob`] slot is reserved for the M2 reflow locator.
 
+pub mod identity;
 pub mod sqlite;
 
 use crate::error::{CoreError, CoreResult};

--- a/reader-core/src/persistence/mod.rs
+++ b/reader-core/src/persistence/mod.rs
@@ -8,6 +8,7 @@
 //! `PinPosition`; the [`ReadingPosition::resume_blob`] slot is reserved for the M2 reflow locator.
 
 pub mod identity;
+pub mod sidecar;
 pub mod sqlite;
 
 use crate::error::{CoreError, CoreResult};

--- a/reader-core/src/persistence/mod.rs
+++ b/reader-core/src/persistence/mod.rs
@@ -8,6 +8,7 @@
 //! `PinPosition`; the [`ReadingPosition::resume_blob`] slot is reserved for the M2 reflow locator.
 
 pub mod identity;
+pub mod ink_store;
 pub mod sidecar;
 pub mod sqlite;
 

--- a/reader-core/src/persistence/sidecar.rs
+++ b/reader-core/src/persistence/sidecar.rs
@@ -1,0 +1,217 @@
+//! Sidecar layout + portable `metadata.json` (RR10-FR2/FR3/FR5).
+//!
+//! Annotations live next to the document in a `book.inkread/` directory, never inside the
+//! original file (RR10-FR1):
+//! ```text
+//! book.pdf
+//! book.inkread/
+//!   metadata.json          # identity + progress + page count (this module)
+//!   annotations/
+//!     page-0001.inkbin     # one .inkbin per annotated page (inkread-ink codec)
+//!   exports/
+//!   thumbnails/
+//! ```
+//! This module is **pure** — it computes paths and (de)serializes `metadata.json`. The
+//! filesystem IO lives in [`super::ink_store`].
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::persistence::identity::DocIdentity;
+
+/// Current `metadata.json` schema version.
+pub const METADATA_VERSION: u32 = 1;
+
+/// The set of paths that make up a document's `book.inkread/` sidecar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidecarPaths {
+    root: PathBuf,
+}
+
+impl SidecarPaths {
+    /// The sidecar for `doc_path`: `book.pdf` → sibling `book.inkread/` (RR10-FR2). Any existing
+    /// extension is replaced, so `book.pdf` and `book` both map to `book.inkread`.
+    #[must_use]
+    pub fn for_document(doc_path: &Path) -> Self {
+        Self {
+            root: doc_path.with_extension("inkread"),
+        }
+    }
+
+    /// Build directly from a known sidecar root (tests / a relocated sidecar).
+    #[must_use]
+    pub fn from_root(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// The `book.inkread/` root directory.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// The `annotations/` subdirectory holding the per-page `.inkbin` files.
+    #[must_use]
+    pub fn annotations_dir(&self) -> PathBuf {
+        self.root.join("annotations")
+    }
+
+    /// The `.inkbin` path for `page` (zero-based) — `annotations/page-NNNN.inkbin`.
+    #[must_use]
+    pub fn page_file(&self, page: usize) -> PathBuf {
+        self.annotations_dir().join(page_file_name(page))
+    }
+
+    /// The `metadata.json` path.
+    #[must_use]
+    pub fn metadata_file(&self) -> PathBuf {
+        self.root.join("metadata.json")
+    }
+
+    /// The `exports/` subdirectory (RR11 artifacts).
+    #[must_use]
+    pub fn exports_dir(&self) -> PathBuf {
+        self.root.join("exports")
+    }
+
+    /// The `thumbnails/` subdirectory (RR17-FR5).
+    #[must_use]
+    pub fn thumbnails_dir(&self) -> PathBuf {
+        self.root.join("thumbnails")
+    }
+}
+
+/// The `.inkbin` file name for a zero-based page index. The 1-based, zero-padded form
+/// (`page-0001.inkbin`) matches the spec's example layout and sorts correctly.
+#[must_use]
+pub fn page_file_name(page: usize) -> String {
+    format!("page-{:04}.inkbin", page + 1)
+}
+
+/// Parse a zero-based page index back out of a `page-NNNN.inkbin` file name, or `None` if the
+/// name doesn't match the pattern. Inverse of [`page_file_name`].
+#[must_use]
+pub fn parse_page_file_name(name: &str) -> Option<usize> {
+    let digits = name.strip_prefix("page-")?.strip_suffix(".inkbin")?;
+    let one_based: usize = digits.parse().ok()?;
+    one_based.checked_sub(1)
+}
+
+/// Portable sidecar metadata (RR10-FR3/FR5). Serialized as `metadata.json` for interop; on
+/// reopen it lets us verify the sidecar belongs to the opened document (RR10-AC3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SidecarMetadata {
+    /// Schema version (`METADATA_VERSION`).
+    pub version: u32,
+    /// Content fingerprint as 32-char hex (see [`DocIdentity`]).
+    pub fingerprint: String,
+    /// File size in bytes at the time the sidecar was written.
+    pub size: u64,
+    /// Document title, if known.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Document author, if known.
+    #[serde(default)]
+    pub author: Option<String>,
+    /// Page count at write time.
+    pub page_count: usize,
+}
+
+impl SidecarMetadata {
+    /// Build metadata from a document identity + page count.
+    #[must_use]
+    pub fn from_identity(id: &DocIdentity, page_count: usize) -> Self {
+        Self {
+            version: METADATA_VERSION,
+            fingerprint: id.fingerprint_hex(),
+            size: id.size,
+            title: id.title.clone(),
+            author: id.author.clone(),
+            page_count,
+        }
+    }
+
+    /// Whether this metadata identifies the same document as `id` (fingerprint + size match).
+    #[must_use]
+    pub fn matches(&self, id: &DocIdentity) -> bool {
+        self.fingerprint == id.fingerprint_hex() && self.size == id.size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::DocumentMetadata;
+
+    fn ident() -> DocIdentity {
+        DocIdentity::from_bytes(
+            b"the quick brown fox",
+            &DocumentMetadata {
+                title: Some("Fox".into()),
+                author: Some("A. Nonymous".into()),
+            },
+        )
+    }
+
+    #[test]
+    fn sidecar_root_replaces_extension() {
+        let p = SidecarPaths::for_document(Path::new("/books/war-and-peace.pdf"));
+        assert_eq!(p.root(), Path::new("/books/war-and-peace.inkread"));
+        // extensionless documents also map cleanly
+        let q = SidecarPaths::for_document(Path::new("/books/notes"));
+        assert_eq!(q.root(), Path::new("/books/notes.inkread"));
+    }
+
+    #[test]
+    fn page_file_path_and_name() {
+        let p = SidecarPaths::from_root("/x/book.inkread");
+        assert_eq!(
+            p.page_file(0),
+            Path::new("/x/book.inkread/annotations/page-0001.inkbin")
+        );
+        assert_eq!(p.page_file(41).file_name().unwrap(), "page-0042.inkbin");
+        assert_eq!(
+            p.metadata_file(),
+            Path::new("/x/book.inkread/metadata.json")
+        );
+    }
+
+    #[test]
+    fn page_name_round_trips() {
+        for page in [0usize, 1, 41, 9999, 12345] {
+            assert_eq!(parse_page_file_name(&page_file_name(page)), Some(page));
+        }
+        assert_eq!(parse_page_file_name("notes.txt"), None);
+        assert_eq!(parse_page_file_name("page-0000.inkbin"), None); // 1-based: 0 is invalid
+        assert_eq!(parse_page_file_name("page-abc.inkbin"), None);
+    }
+
+    #[test]
+    fn metadata_json_round_trips() {
+        let meta = SidecarMetadata::from_identity(&ident(), 200);
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: SidecarMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, back);
+        assert!(json.contains("\"fingerprint\""));
+        assert!(json.contains("\"page_count\":200"));
+    }
+
+    #[test]
+    fn metadata_matches_same_document_only() {
+        let id = ident();
+        let meta = SidecarMetadata::from_identity(&id, 10);
+        assert!(meta.matches(&id));
+        let other = DocIdentity::from_bytes(b"a different document", &DocumentMetadata::default());
+        assert!(!meta.matches(&other));
+    }
+
+    #[test]
+    fn metadata_tolerates_missing_optional_fields() {
+        // title/author absent → deserializes with None (forward/back compat).
+        let json = r#"{"version":1,"fingerprint":"00","size":5,"page_count":3}"#;
+        let meta: SidecarMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.title, None);
+        assert_eq!(meta.page_count, 3);
+    }
+}

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -17,10 +17,15 @@ use crate::budget::{Caches, ResourceBudget, TrimLevel};
 use crate::document::fixed::PdfBackend;
 use crate::document::{Document, DocumentMetadata, PageLink, TocEntry};
 use crate::error::{CoreError, CoreResult};
+use crate::persistence::identity::DocIdentity;
+use crate::persistence::ink_store::InkStore;
+use crate::persistence::sidecar::SidecarMetadata;
 use crate::persistence::{BookId, ReaderStore, ReadingPosition};
 use crate::policy::EinkRefreshPolicy;
 use crate::render::{PixelBuffer, Viewport};
 use crate::settings::SettingsSnapshot;
+
+use inkread_ink::{encode_layer, InkColor, InkLayer, InkPoint, Stroke, Tool};
 
 /// A navigation gesture (Amendment 6). The int↔enum mapping is defined **once** here and
 /// documented at the JNI boundary; `nativeOnGesture` decodes an int into this.
@@ -69,6 +74,14 @@ pub struct ReaderSession {
     /// Bounded render + cover caches under the resource budget (RR24); trimmed on memory
     /// pressure. The render hot path consumes these in M1a.6 (with the threading rework).
     caches: Caches,
+    /// The annotation store for this document's sidecar (RR10); `None` = ink not persisted.
+    ink: Option<Arc<dyn InkStore>>,
+    /// The current page's ink layer (RR6). Reloaded on page change; empty without ink.
+    layer: InkLayer,
+    /// The tool of the in-progress stroke — routes [`Self::ink_add_point`] (ink vs. erase).
+    active_tool: Tool,
+    /// Width of the in-progress ink stroke, or the erase radius for the eraser (normalized).
+    active_width: f32,
 }
 
 impl ReaderSession {
@@ -91,6 +104,10 @@ impl ReaderSession {
             store: None,
             book: None,
             caches: Caches::new(&ResourceBudget::default_supernote()),
+            ink: None,
+            layer: InkLayer::new(),
+            active_tool: Tool::Pen,
+            active_width: 0.0,
         })
     }
 
@@ -170,6 +187,10 @@ impl ReaderSession {
             store: None,
             book: None,
             caches: Caches::new(&ResourceBudget::default_supernote()),
+            ink: None,
+            layer: InkLayer::new(),
+            active_tool: Tool::Pen,
+            active_width: 0.0,
         }
     }
 
@@ -248,6 +269,7 @@ impl ReaderSession {
     /// command stream for the shell to execute.
     pub fn on_gesture(&mut self, gesture: Gesture) -> Vec<RefreshCommand> {
         let last = self.page_count().saturating_sub(1);
+        let prev = self.page;
         match gesture {
             Gesture::NextPage => {
                 if self.page < last {
@@ -258,6 +280,9 @@ impl ReaderSession {
                 self.page = self.page.saturating_sub(1);
             }
         }
+        if self.page != prev {
+            self.load_ink_for_current_page();
+        }
         let page_rect = Rect::full(self.viewport.width, self.viewport.height);
         self.policy.on_page_turn(page_rect)
     }
@@ -266,7 +291,11 @@ impl ReaderSession {
     /// policy's `on_page_turn` for the refresh stream (RR11-FR1). Used by TOC/scrubber jumps.
     pub fn jump_to_page(&mut self, page: usize) -> Vec<RefreshCommand> {
         let last = self.page_count().saturating_sub(1);
+        let prev = self.page;
         self.page = page.min(last);
+        if self.page != prev {
+            self.load_ink_for_current_page();
+        }
         let page_rect = Rect::full(self.viewport.width, self.viewport.height);
         self.policy.on_page_turn(page_rect)
     }
@@ -291,6 +320,124 @@ impl ReaderSession {
             Some(page) => self.jump_to_page(page),
             None => Vec::new(),
         }
+    }
+
+    // ===== Ink annotation lifecycle (RR6/RR7/RR10/RR20) =====
+
+    /// Attach an annotation [`InkStore`] and load the current page's ink (RR7-FR7).
+    pub fn attach_ink_store(&mut self, store: Arc<dyn InkStore>) -> CoreResult<()> {
+        self.layer = store.load_page(self.page)?;
+        self.ink = Some(store);
+        Ok(())
+    }
+
+    /// Record the document's identity in the sidecar `metadata.json` (RR10-FR6/AC3) — call once
+    /// after open with the identity derived from the file bytes. No-op without a store.
+    pub fn write_sidecar_identity(&self, id: &DocIdentity) -> CoreResult<()> {
+        if let Some(store) = &self.ink {
+            store.save_metadata(&SidecarMetadata::from_identity(id, self.page_count()))?;
+        }
+        Ok(())
+    }
+
+    /// The current page's committed strokes (RR6).
+    #[must_use]
+    pub fn ink_strokes(&self) -> &[Stroke] {
+        self.layer.strokes()
+    }
+
+    /// `.inkbin` bytes for `page` — the open page's live layer, else loaded from the store
+    /// (RR7-AC1). The shell decodes these with the same `inkread-ink` codec.
+    pub fn ink_strokes_wire(&self, page: usize) -> CoreResult<Vec<u8>> {
+        if page == self.page {
+            Ok(encode_layer(&self.layer))
+        } else if let Some(store) = &self.ink {
+            Ok(encode_layer(&store.load_page(page)?))
+        } else {
+            Ok(encode_layer(&InkLayer::new()))
+        }
+    }
+
+    /// Begin a stroke (RR6). Pen/Highlighter accumulate points; Eraser removes strokes under each
+    /// subsequent point. `width` is the stroke width (ink) or the erase radius (eraser).
+    pub fn ink_begin_stroke(
+        &mut self,
+        tool: Tool,
+        color: InkColor,
+        width: f32,
+        created_at_ms: u64,
+    ) -> CoreResult<()> {
+        self.active_tool = tool;
+        self.active_width = width;
+        if tool.is_ink() {
+            self.layer.start_stroke(tool, color, width, created_at_ms)?;
+        } else {
+            self.layer.cancel_stroke();
+        }
+        Ok(())
+    }
+
+    /// Add a sample to the in-progress stroke (ink) or erase at the point (eraser) — RR6-FR5.
+    pub fn ink_add_point(
+        &mut self,
+        x: f32,
+        y: f32,
+        pressure: f32,
+        tilt_x: Option<f32>,
+        tilt_y: Option<f32>,
+        timestamp_ms: u32,
+    ) -> CoreResult<()> {
+        if self.active_tool.is_ink() {
+            self.layer
+                .push_point(InkPoint::new(x, y, pressure, tilt_x, tilt_y, timestamp_ms)?)?;
+        } else {
+            self.layer.erase_at(x, y, self.active_width);
+        }
+        Ok(())
+    }
+
+    /// Finish the in-progress stroke and **autosave** the page (RR7-FR6 / RR20-FR2).
+    pub fn ink_end_stroke(&mut self) -> CoreResult<()> {
+        if self.active_tool.is_ink() {
+            self.layer.finish_stroke();
+        }
+        self.autosave_ink()
+    }
+
+    /// Undo the last ink edit on the current page, autosaving if anything changed (RR6-FR3).
+    pub fn ink_undo(&mut self) -> CoreResult<bool> {
+        let changed = self.layer.undo();
+        if changed {
+            self.autosave_ink()?;
+        }
+        Ok(changed)
+    }
+
+    /// Redo the last undone ink edit, autosaving if anything changed (RR6-FR3).
+    pub fn ink_redo(&mut self) -> CoreResult<bool> {
+        let changed = self.layer.redo();
+        if changed {
+            self.autosave_ink()?;
+        }
+        Ok(changed)
+    }
+
+    /// Persist the current page's layer to the store (RR20-FR2). No-op without a store.
+    fn autosave_ink(&self) -> CoreResult<()> {
+        if let Some(store) = &self.ink {
+            store.save_page(self.page, &self.layer)?;
+        }
+        Ok(())
+    }
+
+    /// Swap the in-memory layer to the current page's stored ink on a page change. Any pending
+    /// stroke is dropped; a load failure degrades to an empty layer so navigation never fails.
+    fn load_ink_for_current_page(&mut self) {
+        self.layer.cancel_stroke();
+        self.layer = match &self.ink {
+            Some(store) => store.load_page(self.page).unwrap_or_default(),
+            None => InkLayer::new(),
+        };
     }
 }
 

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -422,6 +422,12 @@ impl ReaderSession {
         Ok(changed)
     }
 
+    /// Flush the current page's ink to the store (RR20-FR2) — an explicit save for pause/close,
+    /// complementing the automatic autosave on stroke-end/undo/redo.
+    pub fn save_ink(&self) -> CoreResult<()> {
+        self.autosave_ink()
+    }
+
     /// Persist the current page's layer to the store (RR20-FR2). No-op without a store.
     fn autosave_ink(&self) -> CoreResult<()> {
         if let Some(store) = &self.ink {

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -82,6 +82,12 @@ pub struct ReaderSession {
     active_tool: Tool,
     /// Width of the in-progress ink stroke, or the erase radius for the eraser (normalized).
     active_width: f32,
+    /// Whether the in-progress eraser gesture has removed anything yet — gates the autosave so a
+    /// no-op erase doesn't rewrite an unchanged page (needless e-ink flash / IO).
+    erase_changed: bool,
+    /// The opened document's content identity (RR10-FR6), computed from its bytes at open. `None`
+    /// for a byte-less test session ([`Self::with_document`]). Used to stamp/verify the sidecar.
+    identity: Option<DocIdentity>,
 }
 
 impl ReaderSession {
@@ -94,7 +100,18 @@ impl ReaderSession {
         caps: DeviceCapabilities,
         viewport: Viewport,
     ) -> CoreResult<Self> {
+        // Fingerprint the bytes before they move into the backend (RR10-FR6); fill title/author
+        // from the parsed metadata so the sidecar can be stamped + re-associated.
+        let fingerprint = crate::persistence::identity::fingerprint(&bytes);
+        let size = bytes.len() as u64;
         let document = PdfBackend::open(bytes)?;
+        let meta = document.metadata();
+        let identity = Some(DocIdentity {
+            fingerprint,
+            size,
+            title: meta.title,
+            author: meta.author,
+        });
         let screen = Rect::full(viewport.width, viewport.height);
         Ok(Self {
             document: Box::new(document),
@@ -108,6 +125,8 @@ impl ReaderSession {
             layer: InkLayer::new(),
             active_tool: Tool::Pen,
             active_width: 0.0,
+            erase_changed: false,
+            identity,
         })
     }
 
@@ -191,6 +210,8 @@ impl ReaderSession {
             layer: InkLayer::new(),
             active_tool: Tool::Pen,
             active_width: 0.0,
+            erase_changed: false,
+            identity: None,
         }
     }
 
@@ -324,20 +345,36 @@ impl ReaderSession {
 
     // ===== Ink annotation lifecycle (RR6/RR7/RR10/RR20) =====
 
-    /// Attach an annotation [`InkStore`] and load the current page's ink (RR7-FR7).
+    /// Attach an annotation [`InkStore`], **verify/stamp** the sidecar against the document's
+    /// identity (RR10-FR6/AC3), then load the current page's ink (RR7-FR7). A corrupt landing page
+    /// degrades to empty rather than blocking open — consistent with a page turn.
     pub fn attach_ink_store(&mut self, store: Arc<dyn InkStore>) -> CoreResult<()> {
-        self.layer = store.load_page(self.page)?;
         self.ink = Some(store);
+        self.verify_or_stamp_identity();
+        self.layer = self.load_layer_for_page(self.page);
         Ok(())
     }
 
-    /// Record the document's identity in the sidecar `metadata.json` (RR10-FR6/AC3) — call once
-    /// after open with the identity derived from the file bytes. No-op without a store.
-    pub fn write_sidecar_identity(&self, id: &DocIdentity) -> CoreResult<()> {
-        if let Some(store) = &self.ink {
-            store.save_metadata(&SidecarMetadata::from_identity(id, self.page_count()))?;
+    /// Reconcile the attached sidecar with the open document's identity (RR10-AC3): stamp a fresh
+    /// `metadata.json` if absent; if it belongs to a *different* document (same path, different
+    /// content) move the stale ink aside and re-stamp, so the open document never adopts foreign
+    /// strokes. Best-effort — a write failure here resurfaces on the first real autosave.
+    fn verify_or_stamp_identity(&self) {
+        let (Some(store), Some(id)) = (&self.ink, &self.identity) else {
+            return;
+        };
+        match store.load_metadata() {
+            Ok(Some(meta)) if meta.matches(id) => {} // ours — adopt the existing ink
+            Ok(Some(_)) => {
+                // Same path, different document: preserve the stale ink and start clean.
+                let _ = store.reset_stale_annotations();
+                let _ = store.save_metadata(&SidecarMetadata::from_identity(id, self.page_count()));
+            }
+            _ => {
+                // Fresh or unreadable metadata → (re)stamp this document's identity.
+                let _ = store.save_metadata(&SidecarMetadata::from_identity(id, self.page_count()));
+            }
         }
-        Ok(())
     }
 
     /// The current page's committed strokes (RR6).
@@ -367,8 +404,14 @@ impl ReaderSession {
         width: f32,
         created_at_ms: u64,
     ) -> CoreResult<()> {
+        if tool == Tool::Eraser && (!width.is_finite() || width <= 0.0) {
+            return Err(CoreError::InvalidArgument(format!(
+                "eraser radius must be finite and positive, got {width}"
+            )));
+        }
         self.active_tool = tool;
         self.active_width = width;
+        self.erase_changed = false;
         if tool.is_ink() {
             self.layer.start_stroke(tool, color, width, created_at_ms)?;
         } else {
@@ -390,18 +433,25 @@ impl ReaderSession {
         if self.active_tool.is_ink() {
             self.layer
                 .push_point(InkPoint::new(x, y, pressure, tilt_x, tilt_y, timestamp_ms)?)?;
-        } else {
-            self.layer.erase_at(x, y, self.active_width);
+        } else if !self.layer.erase_at(x, y, self.active_width).is_empty() {
+            self.erase_changed = true;
         }
         Ok(())
     }
 
-    /// Finish the in-progress stroke and **autosave** the page (RR7-FR6 / RR20-FR2).
+    /// Finish the in-progress stroke and autosave the page **only if it changed** (RR7-FR6 /
+    /// RR20-FR2): an ink stroke that committed at least one point, or an eraser gesture that
+    /// removed something. A no-op stroke/erase does not rewrite the page (saves e-ink flash + IO).
     pub fn ink_end_stroke(&mut self) -> CoreResult<()> {
-        if self.active_tool.is_ink() {
-            self.layer.finish_stroke();
+        let changed = if self.active_tool.is_ink() {
+            self.layer.finish_stroke().is_some()
+        } else {
+            self.erase_changed
+        };
+        if changed {
+            self.autosave_ink()?;
         }
-        self.autosave_ink()
+        Ok(())
     }
 
     /// Undo the last ink edit on the current page, autosaving if anything changed (RR6-FR3).
@@ -437,13 +487,27 @@ impl ReaderSession {
     }
 
     /// Swap the in-memory layer to the current page's stored ink on a page change. Any pending
-    /// stroke is dropped; a load failure degrades to an empty layer so navigation never fails.
+    /// stroke is dropped; the load degrades safely (see [`Self::load_layer_for_page`]).
     fn load_ink_for_current_page(&mut self) {
         self.layer.cancel_stroke();
-        self.layer = match &self.ink {
-            Some(store) => store.load_page(self.page).unwrap_or_default(),
-            None => InkLayer::new(),
+        self.layer = self.load_layer_for_page(self.page);
+    }
+
+    /// Load `page`'s ink, degrading safely so open/navigation never fails: a **corrupt** page is
+    /// quarantined (its bytes preserved aside, RR20-FR1) and returns empty; a transient IO error
+    /// also returns empty. The reader thus always opens and always turns.
+    fn load_layer_for_page(&self, page: usize) -> InkLayer {
+        let Some(store) = &self.ink else {
+            return InkLayer::new();
         };
+        match store.load_page(page) {
+            Ok(layer) => layer,
+            Err(CoreError::CorruptDocument(_)) => {
+                let _ = store.quarantine_page(page);
+                InkLayer::new()
+            }
+            Err(_) => InkLayer::new(),
+        }
     }
 }
 

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -277,7 +277,55 @@ fn basic_panel_session_collapses_to_full() {
 
 // ===== Ink annotation lifecycle (RR6/RR7/RR10/RR20) =====
 
-use crate::persistence::ink_store::MemInkStore;
+use crate::persistence::ink_store::{FsInkStore, MemInkStore};
+use crate::persistence::sidecar::SidecarPaths;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A dependency-free RAII temp dir (mirrors the one in `ink_store`'s tests).
+struct TempDir {
+    path: PathBuf,
+}
+impl TempDir {
+    fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!("inkread-session-test-{}-{n}", std::process::id()));
+        std::fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+}
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// An `InkStore` whose saves always fail — for the no-data-loss-on-failure test.
+struct FailingStore;
+impl InkStore for FailingStore {
+    fn load_page(&self, _page: usize) -> CoreResult<InkLayer> {
+        Ok(InkLayer::new())
+    }
+    fn save_page(&self, _page: usize, _layer: &InkLayer) -> CoreResult<()> {
+        Err(CoreError::Persistence("disk full".into()))
+    }
+    fn pages_with_ink(&self) -> CoreResult<Vec<usize>> {
+        Ok(Vec::new())
+    }
+    fn load_metadata(&self) -> CoreResult<Option<SidecarMetadata>> {
+        Ok(None)
+    }
+    fn save_metadata(&self, _meta: &SidecarMetadata) -> CoreResult<()> {
+        Err(CoreError::Persistence("disk full".into()))
+    }
+}
+
+/// An `FsInkStore` over `<tmp>/book.pdf`'s sidecar.
+fn fs_ink(doc: &std::path::Path) -> Arc<dyn InkStore> {
+    Arc::new(FsInkStore::new(SidecarPaths::for_document(doc)))
+}
 
 /// Draw and commit one pen stroke through the public session API.
 fn draw(s: &mut ReaderSession, pts: &[(f32, f32)]) {
@@ -368,4 +416,103 @@ fn ink_works_in_memory_without_a_store() {
     assert_eq!(s.ink_strokes().len(), 1);
     assert!(s.ink_undo().unwrap());
     assert_eq!(s.ink_strokes().len(), 0);
+}
+
+// RR7-AC1, on the REAL on-disk path (not the in-memory double): a stroke drawn on a virgin
+// path — no sidecar dir yet — round-trips through FsInkStore + the .inkbin codec + atomic write.
+#[test]
+fn ink_round_trips_through_fsinkstore_on_a_virgin_path() {
+    let tmp = TempDir::new();
+    let doc = tmp.path.join("book.pdf"); // nothing exists beside it
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(fs_ink(&doc)).unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+
+    let mut reopened = session(2, DeviceCapabilities::supernote_full());
+    reopened.attach_ink_store(fs_ink(&doc)).unwrap();
+    assert_eq!(
+        reopened.ink_strokes().len(),
+        1,
+        "stroke persisted to disk and reloaded on reopen"
+    );
+}
+
+// Inconsistent-degradation fix: a corrupt landing-page .inkbin must NOT block open; the page
+// shows empty and the bad bytes are quarantined (not clobbered).
+#[test]
+fn corrupt_landing_page_still_opens_and_quarantines() {
+    let tmp = TempDir::new();
+    let doc = tmp.path.join("book.pdf");
+    let paths = SidecarPaths::for_document(&doc);
+    {
+        let mut s = session(2, DeviceCapabilities::supernote_full());
+        s.attach_ink_store(fs_ink(&doc)).unwrap();
+        draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    }
+    std::fs::write(paths.page_file(0), b"NOTINKBIN").unwrap(); // corrupt page 0
+
+    let mut reopened = session(2, DeviceCapabilities::supernote_full());
+    assert!(
+        reopened.attach_ink_store(fs_ink(&doc)).is_ok(),
+        "document still opens despite a corrupt page"
+    );
+    assert_eq!(reopened.ink_strokes().len(), 0, "corrupt page shows empty");
+}
+
+// RR20-FR1: a failed autosave surfaces an error but must NOT lose the in-memory stroke (retryable).
+#[test]
+fn autosave_failure_surfaces_but_keeps_strokes_in_memory() {
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::new(FailingStore)).unwrap();
+    s.ink_begin_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0)
+        .unwrap();
+    s.ink_add_point(0.1, 0.1, 1.0, None, None, 0).unwrap();
+    assert!(s.ink_end_stroke().is_err(), "save failure is surfaced");
+    assert_eq!(
+        s.ink_strokes().len(),
+        1,
+        "stroke retained in memory for retry — no data loss"
+    );
+}
+
+// RR10-FR6/AC3 wiring: attach stamps the sidecar with the document's identity.
+#[test]
+fn attach_stamps_and_matches_document_identity() {
+    let mut s = session(3, DeviceCapabilities::supernote_full());
+    let id = DocIdentity::from_bytes(b"the-doc-bytes", &DocumentMetadata::default());
+    s.identity = Some(id.clone()); // (test reaches into the private field; open_pdf sets it for real)
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    let meta = store
+        .load_metadata()
+        .unwrap()
+        .expect("identity stamped on attach");
+    assert!(meta.matches(&id));
+    assert_eq!(meta.page_count, 3);
+}
+
+#[test]
+fn empty_erase_does_not_rewrite_the_page() {
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.1)]);
+    // an eraser gesture that hits nothing must not rewrite/remove the page
+    s.ink_begin_stroke(Tool::Eraser, InkColor::BLACK, 0.02, 0)
+        .unwrap();
+    s.ink_add_point(0.9, 0.9, 1.0, None, None, 0).unwrap();
+    s.ink_end_stroke().unwrap();
+    assert_eq!(s.ink_strokes().len(), 1);
+    assert_eq!(store.pages_with_ink().unwrap(), vec![0]);
+}
+
+#[test]
+fn eraser_rejects_non_positive_radius() {
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    assert!(s
+        .ink_begin_stroke(Tool::Eraser, InkColor::BLACK, 0.0, 0)
+        .is_err());
+    assert!(s
+        .ink_begin_stroke(Tool::Eraser, InkColor::BLACK, f32::NAN, 0)
+        .is_err());
 }

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -274,3 +274,98 @@ fn basic_panel_session_collapses_to_full() {
         }]
     ));
 }
+
+// ===== Ink annotation lifecycle (RR6/RR7/RR10/RR20) =====
+
+use crate::persistence::ink_store::MemInkStore;
+
+/// Draw and commit one pen stroke through the public session API.
+fn draw(s: &mut ReaderSession, pts: &[(f32, f32)]) {
+    s.ink_begin_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0)
+        .unwrap();
+    for &(x, y) in pts {
+        s.ink_add_point(x, y, 1.0, None, None, 0).unwrap();
+    }
+    s.ink_end_stroke().unwrap();
+}
+
+#[test]
+fn ink_saves_and_reloads_across_sessions() {
+    // RR7-AC1: a stroke written on a page reappears after reopen.
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    assert_eq!(s.ink_strokes().len(), 1);
+
+    // A fresh session over the same sidecar reloads the stroke.
+    let mut reopened = session(2, DeviceCapabilities::supernote_full());
+    reopened.attach_ink_store(store).unwrap();
+    assert_eq!(reopened.ink_strokes().len(), 1, "stroke reloaded on reopen");
+}
+
+#[test]
+fn ink_undo_redo_autosaves_to_store() {
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    assert_eq!(store.pages_with_ink().unwrap(), vec![0]);
+
+    assert!(s.ink_undo().unwrap());
+    assert!(
+        store.pages_with_ink().unwrap().is_empty(),
+        "undo autosaved the now-empty page (file removed)"
+    );
+    assert!(s.ink_redo().unwrap());
+    assert_eq!(
+        store.pages_with_ink().unwrap(),
+        vec![0],
+        "redo re-persisted"
+    );
+}
+
+#[test]
+fn page_turn_loads_each_pages_own_ink() {
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(3, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(store).unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]); // page 0
+
+    s.on_gesture(Gesture::NextPage); // → page 1
+    assert_eq!(s.ink_strokes().len(), 0, "page 1 starts empty");
+    draw(&mut s, &[(0.5, 0.5), (0.6, 0.6)]); // page 1
+
+    s.on_gesture(Gesture::PrevPage); // back to page 0
+    assert_eq!(s.ink_strokes().len(), 1, "page 0 ink reloaded on return");
+    s.on_gesture(Gesture::NextPage); // page 1 again
+    assert_eq!(s.ink_strokes().len(), 1, "page 1 ink intact");
+}
+
+#[test]
+fn eraser_removes_strokes_and_autosaves() {
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    draw(&mut s, &[(0.10, 0.10), (0.20, 0.10)]);
+
+    s.ink_begin_stroke(Tool::Eraser, InkColor::BLACK, 0.03, 0)
+        .unwrap();
+    s.ink_add_point(0.15, 0.10, 1.0, None, None, 0).unwrap();
+    s.ink_end_stroke().unwrap();
+    assert_eq!(s.ink_strokes().len(), 0);
+    assert!(
+        store.pages_with_ink().unwrap().is_empty(),
+        "erase autosaved the empty page"
+    );
+}
+
+#[test]
+fn ink_works_in_memory_without_a_store() {
+    // A store-less session still captures and edits ink (just no persistence) — no panic.
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    assert_eq!(s.ink_strokes().len(), 1);
+    assert!(s.ink_undo().unwrap());
+    assert_eq!(s.ink_strokes().len(), 0);
+}


### PR DESCRIPTION
Two cohesive pieces on this branch (12 commits).

## Annotation persistence — Rust core, host-tested
- `inkread-ink` crate: vector ink model (Stroke/InkLayer, undo/redo, eraser hit-test) + hardened `.inkbin` codec.
- Sidecar storage (`book.inkread/` + `.inkbin` + `metadata.json`), stable **FNV-1a-128 document identity**, **atomic crash-safe writes** (parent-dir fsync, corrupt/stale quarantine).
- Session ink lifecycle (begin/add/end, autosave, reload-on-page-turn) + a **feature-gated JNI ink seam**.
- Passed a **3-agent adversarial review** (conformance / quality / security); all findings applied.

## Shell UI overhaul — Android (DEVICE-UNVERIFIED)
- **Home launcher**: brand + version + a "Recently opened" shelf with first-page thumbnails.
- **KOReader-style bottom bar**: page slider + page-number entry + control row (replaces the floating menu).
- **Bookmarks** (per-book, dog-ear marker, list-and-jump).
- **Palm-rejection fix**: defer the finger tap and cancel it on any stylus event (fixes resting-palm-opens-menu).

## Tests
~165 host tests green (`cargo fmt` + `clippy -D warnings` + `cargo test --workspace`). Host build stays jni-free; `jni-bridge` compiles clean. The Android shell installs + boots on the Supernote, but the new UI gestures are **not yet hand-verified on-device**.

## Merge order
Targets `feat/mvp`. **Merge this first** — the dictionary PR is stacked on top of this branch.