### PR TITLE
Land the dictionary into feat/mvp (stacked-PR fixup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ supernote/
 .gradle/
 build/
 app/build/
+# The dictionary corpus is a generated build artifact (scripts/stage-dict.sh / buildApk stage_dict).
+app/src/main/assets/dict.db
 local.properties
 *.iml
 .idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,7 @@ name = "reader-core"
 version = "0.1.0"
 dependencies = [
  "device-eink",
+ "inkread-dict",
  "inkread-ink",
  "jni",
  "pdfium-render",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkread-dict"
+version = "0.1.0"
+dependencies = [
+ "rusqlite",
+]
+
+[[package]]
 name = "inkread-ink"
 version = "0.1.0"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "build-dict"
+version = "0.1.0"
+dependencies = [
+ "flate2",
+ "inkread-dict",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 # RR1-AC3: bare `cargo test -p reader-core` builds with `jni` absent from the resolved graph.
 [workspace]
 resolver = "2"
-members = ["device-eink", "inkread-dict", "inkread-ink", "reader-core", "reader-desktop"]
+members = ["build-dict", "device-eink", "inkread-dict", "inkread-ink", "reader-core", "reader-desktop"]
 
 [workspace.package]
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 # RR1-AC3: bare `cargo test -p reader-core` builds with `jni` absent from the resolved graph.
 [workspace]
 resolver = "2"
-members = ["device-eink", "inkread-ink", "reader-core", "reader-desktop"]
+members = ["device-eink", "inkread-dict", "inkread-ink", "reader-core", "reader-desktop"]
 
 [workspace.package]
 version = "0.1.0"
@@ -20,6 +20,7 @@ repository = "https://github.com/jraghavan/inkread"
 [workspace.dependencies]
 # Internal crates.
 device-eink = { path = "device-eink" }
+inkread-dict = { path = "inkread-dict" }
 inkread-ink = { path = "inkread-ink" }
 reader-core = { path = "reader-core" }
 

--- a/LICENSES-3RDPARTY.md
+++ b/LICENSES-3RDPARTY.md
@@ -9,6 +9,10 @@ the dependency set changes.
 
 - **pdfium** (`libpdfium.so`/`.dylib`, bblanchon prebuilt, pinned `chromium/7881` = PDFium 151.0.7881.0) — **BSD-3-Clause** (PDFium) — clean; bundled under `app/src/main/jniLibs/` on device and bound via `PDFIUM_DYNAMIC_LIB_PATH` on the host (RR5-FR1/FR5). Attribution: see the PDFium and bblanchon/pdfium-binaries notices.
 
+## Bundled data (generated build artifacts, not committed to git)
+
+- **WordNet 3.0** (Princeton University) — the English dictionary corpus (definitions + synsets) imported into `app/src/main/assets/dict.db` by `scripts/stage-dict.sh`, sourced from the Hu Zheng StarDict packaging (`download.huzheng.org`). **WordNet License** — permissive: free use/redistribution provided the Princeton copyright + license notice is retained (ADR-INKREAD-0009 / RR22-FR5). The `dict.db` artifact is gitignored and regenerated at build time. Other languages are looked up online (opt-in) and cached, not bundled.
+
 ## Rust dependencies (106 crates, all features)
 
 | Crate | Version | License (SPDX) |

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
      not requested yet for the M0 bring-up; M0 opens a path the user places on-device. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Opt-in online dictionary fallback (Wiktionary) for non-bundled languages (RR12 / D4). -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -87,6 +87,30 @@ object NativeBridge {
      * [WireCodec.decodeLinks]. The shell hit-tests a tap and jumps (internal) or opens the URI.
      */
     external fun nativePageLinks(handle: Long, page: Int): ByteArray
+
+    // ---- text selection + dictionary (RR11/RR12 / ADR-INKREAD-0009 D3) ----
+
+    /** The word under normalized `(x, y)` on `page`; decode with [WireCodec.decodeSelection]. */
+    external fun nativeWordAt(handle: Long, page: Int, x: Float, y: Float): ByteArray
+
+    /** The text within the normalized rect on `page`; decode with [WireCodec.decodeSelection]. */
+    external fun nativeTextInRect(handle: Long, page: Int, x0: Float, y0: Float, x1: Float, y1: Float): ByteArray
+
+    /** Open the dictionary corpus at [path]; returns an opaque handle (0 on failure → throws). */
+    external fun nativeDictOpen(path: String): Long
+
+    /** Free a dictionary handle. Callers zero their field on close (double-close safe). */
+    external fun nativeDictClose(dictHandle: Long)
+
+    /**
+     * Look [word] up on-device, preferring the comma-separated [langsCsv] languages; decode with
+     * [WireCodec.decodeDefinition]. A miss (found == false) is the shell's cue to try its online
+     * source and cache the result with [nativeDictPut].
+     */
+    external fun nativeDefine(dictHandle: Long, word: String, langsCsv: String): ByteArray
+
+    /** Cache a definition (e.g. an online result) into the corpus so the next lookup is instant. */
+    external fun nativeDictPut(dictHandle: Long, lang: String, headword: String, defn: String)
 }
 
 /** One flattened table-of-contents entry (RR11-FR2). [targetPage] is null for a label-only entry. */
@@ -107,6 +131,23 @@ data class LinkRect(
     /** Whether the normalized tap point `(nx, ny)` falls inside this link. */
     fun contains(nx: Float, ny: Float): Boolean = nx in x0..x1 && ny in y0..y1
 }
+
+/** A normalized highlight box `[0,1]` of a [Selection] (RR11 / D3). */
+data class SelBox(val x0: Float, val y0: Float, val x1: Float, val y1: Float)
+
+/** A text selection: the selected string + the boxes to highlight (RR11 / D3). */
+data class Selection(val text: String, val boxes: List<SelBox>) {
+    val isEmpty: Boolean get() = text.isEmpty()
+}
+
+/** A dictionary lookup result (RR12 / D3); [found] is false on a miss (try online next). */
+data class WordDefinition(
+    val found: Boolean,
+    val headword: String,
+    val lang: String,
+    val senses: List<String>,
+    val synonyms: List<String>,
+)
 
 /** Navigation gestures — the int code mapping mirrors `Gesture::from_code` in the core. */
 enum class Gesture(val code: Int) {
@@ -262,4 +303,68 @@ object WireCodec {
 
     private const val LINKS_HEADER_LEN = 3
     private const val LINKS_RECORD_FIXED = 17 // x0,y0,x1,y1 (4×4) + kind(1)
+
+    /**
+     * Decode the selection wire from [NativeBridge.nativeWordAt]/[NativeBridge.nativeTextInRect]
+     * (RR11 / D3): `[ver][textLen u16][text][boxCount u16]` then per box `[x0,y0,x1,y1 f32]`.
+     * Mirrors `encode_selection_wire` in `reader-core/document`.
+     */
+    fun decodeSelection(bytes: ByteArray): Selection {
+        require(bytes.size >= 3) { "selection stream truncated" }
+        require(bytes[0] == WIRE_VERSION) { "bad selection wire version ${bytes[0]}" }
+        val buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        val tlen = buf.getShort(1).toInt() and 0xFFFF
+        var off = 3
+        require(bytes.size >= off + tlen) { "selection text overruns" }
+        val text = String(bytes, off, tlen, Charsets.UTF_8)
+        off += tlen
+        require(bytes.size >= off + 2) { "selection box count truncated" }
+        val count = buf.getShort(off).toInt() and 0xFFFF
+        off += 2
+        val boxes = ArrayList<SelBox>(count)
+        repeat(count) {
+            require(bytes.size >= off + 16) { "selection box truncated" }
+            boxes.add(SelBox(buf.getFloat(off), buf.getFloat(off + 4), buf.getFloat(off + 8), buf.getFloat(off + 12)))
+            off += 16
+        }
+        return Selection(text, boxes)
+    }
+
+    /**
+     * Decode the definition wire from [NativeBridge.nativeDefine] (RR12 / D3): `[ver][found u8]`;
+     * when found, `[hwLen u16][hw][langLen u8][lang][senseCount u16][senses…][synCount u16][syns…]`.
+     * Mirrors `encode_definition_wire` in `reader-core/dict`.
+     */
+    fun decodeDefinition(bytes: ByteArray): WordDefinition {
+        require(bytes.size >= 2) { "definition stream truncated" }
+        require(bytes[0] == WIRE_VERSION) { "bad definition wire version ${bytes[0]}" }
+        if (bytes[1].toInt() == 0) return WordDefinition(false, "", "", emptyList(), emptyList())
+        val buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        var off = 2
+        fun str16(): String {
+            require(bytes.size >= off + 2) { "string length truncated" }
+            val n = buf.getShort(off).toInt() and 0xFFFF
+            off += 2
+            require(bytes.size >= off + n) { "string overruns" }
+            val s = String(bytes, off, n, Charsets.UTF_8)
+            off += n
+            return s
+        }
+        fun list(): List<String> {
+            require(bytes.size >= off + 2) { "list count truncated" }
+            val c = buf.getShort(off).toInt() and 0xFFFF
+            off += 2
+            return ArrayList<String>(c).apply { repeat(c) { add(str16()) } }
+        }
+        val headword = str16()
+        require(bytes.size >= off + 1) { "lang length truncated" }
+        val llen = bytes[off].toInt() and 0xFF
+        off += 1
+        require(bytes.size >= off + llen) { "lang overruns" }
+        val lang = String(bytes, off, llen, Charsets.UTF_8)
+        off += llen
+        val senses = list()
+        val synonyms = list()
+        return WordDefinition(true, headword, lang, senses, synonyms)
+    }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -8,6 +8,8 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
+import android.graphics.Typeface
+import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
@@ -26,9 +28,15 @@ import android.view.ViewGroup
 import android.view.Window
 import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.SeekBar
 import android.widget.TextView
 import dev.jraghavan.inkread.eink.EinkAdapter
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.math.max
+import kotlin.math.min
+import org.json.JSONObject
 import dev.jraghavan.inkread.eink.SupernoteEinkAdapter
 import dev.jraghavan.inkread.eink.SupernoteInk
 import java.io.File
@@ -90,6 +98,16 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     @Volatile private var pageCount = 0
     /** Stable id of the open book (its file name); keys thumbnails + the bookmarks file. */
     @Volatile private var currentBookId = ""
+
+    // ---- dictionary (RR12 / D4) ----
+    /** Open `Dict` handle (0 = not opened). Engine-thread only. */
+    private var dictHandle = 0L
+    /** When true, the stylus SELECTS text (for a lookup) instead of inking. */
+    @Volatile private var selectMode = false
+    /** In-progress selection stroke as interleaved view-px x,y; UI-thread only. */
+    private val selBuf = ArrayList<Float>()
+    /** Net for a swallowed stylus UP during selection (mirrors [strokeFinalize]). */
+    private val selectionFinalize = Runnable { finalizeSelection() }
     /** The in-progress stroke as interleaved view-px x,y; UI-thread only. */
     private val strokeBuf = ArrayList<Float>()
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -162,7 +180,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 // cancels any pending finger tap (that finger was a resting palm).
                 lastStylusMs = SystemClock.uptimeMillis()
                 mainHandler.removeCallbacks(pendingTap)
-                captureStylus(event)
+                if (selectMode) captureSelection(event) else captureStylus(event)
             } else if (event.actionMasked == MotionEvent.ACTION_DOWN &&
                 tool == MotionEvent.TOOL_TYPE_FINGER
             ) {
@@ -253,7 +271,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     }
 
     override fun onDestroy() {
-        engine.execute { closeDocument() }
+        engine.execute {
+            closeDocument()
+            closeDict()
+        }
         engine.shutdown() // lets the queued close run, then stops the worker
         super.onDestroy()
     }
@@ -720,6 +741,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         control("📚\nLibrary") { showLibraryDialog() }
         control(if (marked) "🔖\nRemove" else "🔖\nBookmark") { toggleBookmark() }
         control("📑\nMarks") { showBookmarks() }
+        control("🔍\nDefine") { enterSelectMode() }
         control("📄\nContents") { showContentsLazy() }
         control("📂\nOpen") { openPicker() }
         container.addView(controls)
@@ -842,6 +864,266 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
         )
         finish()
+    }
+
+    // ===== Dictionary (RR12 / ADR-INKREAD-0009 D4) =====
+
+    /**
+     * Enter "Define" mode: the firmware ink is released so the **stylus selects text** instead of
+     * drawing — a stylus tap looks up the word, a drag highlights a phrase (RR11/RR12). Reliable
+     * because stylus up/down is delivered (unlike the swallowed finger up that drives navigation).
+     */
+    private fun enterSelectMode() {
+        selectMode = true
+        ink.teardown() // stop firmware ink so the next stylus stroke is a selection, not ink
+        Toast.makeText(this, "Tap a word (or drag over text) to look it up", Toast.LENGTH_SHORT).show()
+    }
+
+    /** Accumulate the selection stroke; finalize on UP (or a debounced pause if UP is swallowed). */
+    private fun captureSelection(e: MotionEvent) {
+        when (e.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                selBuf.clear()
+                selBuf.add(e.x); selBuf.add(e.y)
+                armSelectionTimeout()
+            }
+            MotionEvent.ACTION_MOVE -> {
+                for (i in 0 until e.historySize) {
+                    selBuf.add(e.getHistoricalX(i)); selBuf.add(e.getHistoricalY(i))
+                }
+                selBuf.add(e.x); selBuf.add(e.y)
+                armSelectionTimeout()
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                selBuf.add(e.x); selBuf.add(e.y)
+                mainHandler.removeCallbacks(selectionFinalize)
+                finalizeSelection()
+            }
+        }
+    }
+
+    private fun armSelectionTimeout() {
+        mainHandler.removeCallbacks(selectionFinalize)
+        mainHandler.postDelayed(selectionFinalize, STROKE_PAUSE_MS)
+    }
+
+    /** Decide tap vs. drag, leave select mode, re-claim ink, and dispatch the lookup (UI thread). */
+    private fun finalizeSelection() {
+        if (selBuf.size < 2) { selBuf.clear(); return }
+        val pts = selBuf.toFloatArray()
+        selBuf.clear()
+        val w = surfaceView.width.toFloat()
+        val h = surfaceView.height.toFloat()
+        selectMode = false
+        ink.setup() // re-claim firmware ink for normal writing
+        if (w <= 0f || h <= 0f) return
+
+        var minX = pts[0]; var maxX = pts[0]; var minY = pts[1]; var maxY = pts[1]
+        var i = 0
+        while (i + 1 < pts.size) {
+            minX = min(minX, pts[i]); maxX = max(maxX, pts[i])
+            minY = min(minY, pts[i + 1]); maxY = max(maxY, pts[i + 1])
+            i += 2
+        }
+        val dragged = (maxX - minX) > w * 0.03f || (maxY - minY) > h * 0.02f
+        val page = currentPage
+        if (dragged) {
+            val r = floatArrayOf(minX / w, minY / h, maxX / w, maxY / h)
+            engine.execute { defineRect(page, r) }
+        } else {
+            val nx = pts[0] / w
+            val ny = pts[1] / h
+            engine.execute { defineWord(page, nx, ny) }
+        }
+    }
+
+    /** Resolve the word under a normalized point and look it up (engine thread). */
+    private fun defineWord(page: Int, nx: Float, ny: Float) {
+        if (docHandle == 0L) return
+        val sel = try {
+            WireCodec.decodeSelection(NativeBridge.nativeWordAt(docHandle, page, nx, ny))
+        } catch (e: RuntimeException) {
+            Log.e(TAG, "wordAt failed: ${e.message}"); return
+        }
+        if (sel.isEmpty) {
+            runOnUiThread { Toast.makeText(this, "No word there", Toast.LENGTH_SHORT).show() }
+            return
+        }
+        lookupAndShow(sel.text)
+    }
+
+    /** Resolve the text within a highlighted rect and look up its first word (engine thread). */
+    private fun defineRect(page: Int, r: FloatArray) {
+        if (docHandle == 0L) return
+        val sel = try {
+            WireCodec.decodeSelection(NativeBridge.nativeTextInRect(docHandle, page, r[0], r[1], r[2], r[3]))
+        } catch (e: RuntimeException) {
+            Log.e(TAG, "textInRect failed: ${e.message}"); return
+        }
+        val word = sel.text.split(Regex("\\s+")).firstOrNull().orEmpty()
+        if (word.isBlank()) {
+            runOnUiThread { Toast.makeText(this, "No text selected", Toast.LENGTH_SHORT).show() }
+            return
+        }
+        lookupAndShow(word)
+    }
+
+    /** On-device lookup → online fallback (cached) → show the popup (engine thread). */
+    private fun lookupAndShow(rawWord: String) {
+        val word = rawWord.trim().trim { !it.isLetter() && it != '\'' && it != '-' }
+        if (word.isEmpty()) return
+        if (!ensureDictOpen()) {
+            runOnUiThread { Toast.makeText(this, "Dictionary not available", Toast.LENGTH_SHORT).show() }
+            return
+        }
+        var def = try {
+            WireCodec.decodeDefinition(NativeBridge.nativeDefine(dictHandle, word, "en"))
+        } catch (e: RuntimeException) {
+            WordDefinition(false, "", "", emptyList(), emptyList())
+        }
+        if (!def.found) {
+            onlineLookup(word)?.let { online ->
+                try {
+                    NativeBridge.nativeDictPut(dictHandle, online.lang, online.headword, online.senses.joinToString("\n"))
+                } catch (e: RuntimeException) {
+                    Log.w(TAG, "dict cache failed: ${e.message}")
+                }
+                def = online
+            }
+        }
+        val result = def
+        runOnUiThread {
+            if (result.found) showDictPopup(word, result)
+            else Toast.makeText(this, "\"$word\" not found", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    /** Best-effort online lookup via Wiktionary's REST API (RR12; opt-in network). Engine thread. */
+    private fun onlineLookup(word: String): WordDefinition? {
+        return try {
+            val url = URL("https://en.wiktionary.org/api/rest_v1/page/definition/${Uri.encode(word)}")
+            val conn = (url.openConnection() as HttpURLConnection).apply {
+                connectTimeout = 4000
+                readTimeout = 6000
+                setRequestProperty("User-Agent", "InkRead/0.1 (offline e-ink reader)")
+            }
+            if (conn.responseCode != 200) return null
+            val body = conn.inputStream.bufferedReader().use { it.readText() }
+            val root = JSONObject(body)
+            val lang = if (root.has("en")) "en" else root.keys().asSequence().firstOrNull() ?: return null
+            val arr = root.getJSONArray(lang)
+            val senses = ArrayList<String>()
+            outer@ for (i in 0 until arr.length()) {
+                val group = arr.getJSONObject(i)
+                val pos = group.optString("partOfSpeech", "")
+                val defs = group.optJSONArray("definitions") ?: continue
+                for (j in 0 until defs.length()) {
+                    val d = stripHtmlTags(defs.getJSONObject(j).optString("definition", ""))
+                    if (d.isNotBlank()) senses.add(if (pos.isNotEmpty()) "($pos) $d" else d)
+                    if (senses.size >= 6) break@outer
+                }
+            }
+            if (senses.isEmpty()) null else WordDefinition(true, word, lang, senses, emptyList())
+        } catch (e: Exception) {
+            Log.w(TAG, "online lookup failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun stripHtmlTags(s: String): String =
+        s.replace(Regex("<[^>]*>"), "").replace("&amp;", "&").replace("&#39;", "'").trim()
+
+    /** Copy the bundled corpus out of assets (once) and open it; returns true if usable. */
+    private fun ensureDictOpen(): Boolean {
+        if (dictHandle != 0L) return true
+        val dest = File(filesDir, "dict.db")
+        if (!dest.exists() || dest.length() == 0L) {
+            runOnUiThread { Toast.makeText(this, "Preparing dictionary…", Toast.LENGTH_SHORT).show() }
+            try {
+                assets.open("dict.db").use { input -> dest.outputStream().use { input.copyTo(it) } }
+            } catch (e: Exception) {
+                Log.e(TAG, "dict copy failed: ${e.message}")
+                return false
+            }
+        }
+        dictHandle = try {
+            NativeBridge.nativeDictOpen(dest.absolutePath)
+        } catch (e: RuntimeException) {
+            Log.e(TAG, "dict open failed: ${e.message}"); 0L
+        }
+        return dictHandle != 0L
+    }
+
+    private fun closeDict() {
+        val h = dictHandle
+        dictHandle = 0L
+        if (h != 0L) {
+            try { NativeBridge.nativeDictClose(h) } catch (e: RuntimeException) { /* ignore */ }
+        }
+    }
+
+    /** The Kindle-style definition card: headword + senses + thesaurus, anchored to the bottom. */
+    private fun showDictPopup(word: String, def: WordDefinition) {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+        val col = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.WHITE)
+            setPadding(dp(22), dp(16), dp(22), dp(18))
+        }
+        col.addView(
+            TextView(this).apply {
+                text = def.headword.ifEmpty { word }
+                setTextColor(Color.BLACK)
+                textSize = 24f
+                typeface = Typeface.DEFAULT_BOLD
+            },
+        )
+        if (def.lang.isNotEmpty() && def.lang != "en") {
+            col.addView(
+                TextView(this).apply {
+                    text = def.lang
+                    setTextColor(Color.DKGRAY)
+                    textSize = 12f
+                },
+            )
+        }
+        for ((i, s) in def.senses.take(6).withIndex()) {
+            col.addView(
+                TextView(this).apply {
+                    text = "${i + 1}.  $s"
+                    setTextColor(Color.BLACK)
+                    textSize = 15f
+                    setPadding(0, dp(6), 0, 0)
+                },
+            )
+        }
+        if (def.synonyms.isNotEmpty()) {
+            col.addView(
+                TextView(this).apply {
+                    text = "SYNONYMS"
+                    setTextColor(Color.DKGRAY)
+                    textSize = 11f
+                    typeface = Typeface.DEFAULT_BOLD
+                    setPadding(0, dp(14), 0, dp(2))
+                },
+            )
+            col.addView(
+                TextView(this).apply {
+                    text = def.synonyms.take(12).joinToString(", ")
+                    setTextColor(Color.BLACK)
+                    textSize = 15f
+                },
+            )
+        }
+        dialog.setContentView(ScrollView(this).apply { addView(col) })
+        dialog.window?.apply {
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            setGravity(Gravity.BOTTOM)
+            setBackgroundDrawable(ColorDrawable(Color.WHITE))
+        }
+        dialog.show()
     }
 
     /** Persist the current reading position (RR12-FR3 / RR27); store-less / closed = no-op. */

--- a/build-dict/Cargo.toml
+++ b/build-dict/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "build-dict"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Offline tool (host-only, NOT shipped to device): import StarDict dictionaries into the indexed dict.db corpus inkread-dict reads at runtime (ADR-INKREAD-0009 D2). Keeps the gzip dep out of the device cdylib."
+
+[[bin]]
+name = "build-dict"
+path = "src/main.rs"
+
+[dependencies]
+inkread-dict = { workspace = true }
+# .dict.dz is dictzip — gzip-compatible, so flate2's GzDecoder decompresses it. MIT/Apache.
+flate2 = "1"

--- a/build-dict/src/main.rs
+++ b/build-dict/src/main.rs
@@ -1,0 +1,126 @@
+//! `build-dict` — import StarDict dictionaries into the `dict.db` corpus (ADR-INKREAD-0009 D2).
+//!
+//! Offline, host-only tool (never shipped to the device). Run once per language to populate the
+//! pre-built SQLite the app opens read-only at runtime:
+//!
+//! ```text
+//! build-dict <stardict-dir> <out-dict.db> <lang>
+//! ```
+//!
+//! `<stardict-dir>` holds a StarDict set (`*.ifo`, `*.idx`, `*.dict` or `*.dict.dz`, optional
+//! `*.syn`); `<lang>` is the code stored with every entry (`en`, `it`, `fr`, `da`, …). Re-running
+//! with another language adds to the same `out-dict.db`.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use flate2::read::GzDecoder;
+use inkread_dict::stardict::{definition_text, parse_idx, parse_ifo, parse_syn};
+use inkread_dict::Dict;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 4 {
+        eprintln!("usage: build-dict <stardict-dir> <out-dict.db> <lang>");
+        return ExitCode::FAILURE;
+    }
+    match run(Path::new(&args[1]), Path::new(&args[2]), &args[3]) {
+        Ok(n) => {
+            println!("imported {n} entries ({}) → {}", args[3], args[2]);
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("build-dict: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(dir: &Path, out_db: &Path, lang: &str) -> Result<usize, String> {
+    let ifo_path = find(dir, "ifo")?;
+    let idx_path = find(dir, "idx")?;
+    let ifo = parse_ifo(&read_text(&ifo_path)?);
+    let idx = parse_idx(
+        &fs::read(&idx_path).map_err(io(&idx_path))?,
+        ifo.offset_bits,
+    );
+    let dict_bytes = read_dict(dir)?;
+
+    let db = Dict::open(out_db).map_err(|e| e.to_string())?;
+    let mut imported = 0usize;
+    for entry in &idx {
+        let (start, end) = (
+            entry.offset as usize,
+            entry.offset as usize + entry.size as usize,
+        );
+        let Some(block) = dict_bytes.get(start..end) else {
+            continue; // a bad offset/size just skips that entry
+        };
+        let defn = definition_text(block, ifo.same_type_sequence);
+        if defn.is_empty() {
+            continue;
+        }
+        if db.put_entry(lang, &entry.word, &defn).is_ok() {
+            imported += 1;
+        }
+    }
+
+    // Alternate spellings (.syn) become alias entries pointing at the same definition, so a lookup
+    // of either spelling resolves. (Thesaurus synonyms come from a separate source — D5.)
+    if let Ok(syn_path) = find(dir, "syn") {
+        for s in parse_syn(&fs::read(&syn_path).map_err(io(&syn_path))?) {
+            if let Some(target) = idx.get(s.index as usize) {
+                let (start, end) = (
+                    target.offset as usize,
+                    target.offset as usize + target.size as usize,
+                );
+                if let Some(block) = dict_bytes.get(start..end) {
+                    let defn = definition_text(block, ifo.same_type_sequence);
+                    if !defn.is_empty() && db.put_entry(lang, &s.word, &defn).is_ok() {
+                        imported += 1;
+                    }
+                }
+            }
+        }
+    }
+    Ok(imported)
+}
+
+/// The `.dict` data, decompressing `.dict.dz` (gzip-compatible) when that's the only form present.
+fn read_dict(dir: &Path) -> Result<Vec<u8>, String> {
+    if let Ok(plain) = find(dir, "dict") {
+        return fs::read(&plain).map_err(io(&plain));
+    }
+    let dz = find(dir, "dict.dz")?;
+    let raw = fs::read(&dz).map_err(io(&dz))?;
+    let mut out = Vec::new();
+    GzDecoder::new(raw.as_slice())
+        .read_to_end(&mut out)
+        .map_err(|e| format!("decompress {}: {e}", dz.display()))?;
+    Ok(out)
+}
+
+/// Find the single file in `dir` ending with `.<ext>` (case-sensitive on the extension).
+fn find(dir: &Path, ext: &str) -> Result<PathBuf, String> {
+    let suffix = format!(".{ext}");
+    fs::read_dir(dir)
+        .map_err(io(dir))?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(&suffix))
+        })
+        .ok_or_else(|| format!("no *{suffix} file in {}", dir.display()))
+}
+
+fn read_text(path: &Path) -> Result<String, String> {
+    fs::read_to_string(path).map_err(io(path))
+}
+
+fn io(path: &Path) -> impl Fn(std::io::Error) -> String + '_ {
+    move |e| format!("{}: {e}", path.display())
+}

--- a/build-dict/src/main.rs
+++ b/build-dict/src/main.rs
@@ -17,18 +17,28 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use flate2::read::GzDecoder;
-use inkread_dict::stardict::{definition_text, parse_idx, parse_ifo, parse_syn};
+use inkread_dict::stardict::{
+    definition_text, extract_inline_synonyms, parse_idx, parse_ifo, parse_syn, parse_synonym_list,
+    IdxEntry,
+};
 use inkread_dict::Dict;
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
-    if args.len() != 4 {
-        eprintln!("usage: build-dict <stardict-dir> <out-dict.db> <lang>");
+    let syn = args.iter().any(|a| a == "--syn");
+    let pos: Vec<&String> = args
+        .iter()
+        .skip(1)
+        .filter(|a| !a.starts_with("--"))
+        .collect();
+    if pos.len() != 3 {
+        eprintln!("usage: build-dict <stardict-dir> <out-dict.db> <lang> [--syn]");
         return ExitCode::FAILURE;
     }
-    match run(Path::new(&args[1]), Path::new(&args[2]), &args[3]) {
+    match run(Path::new(pos[0]), Path::new(pos[1]), pos[2], syn) {
         Ok(n) => {
-            println!("imported {n} entries ({}) → {}", args[3], args[2]);
+            let kind = if syn { "synonyms" } else { "entries" };
+            println!("imported {n} {kind} ({}) → {}", pos[2], pos[1]);
             ExitCode::SUCCESS
         }
         Err(e) => {
@@ -38,54 +48,68 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(dir: &Path, out_db: &Path, lang: &str) -> Result<usize, String> {
-    let ifo_path = find(dir, "ifo")?;
+fn run(dir: &Path, out_db: &Path, lang: &str, syn: bool) -> Result<usize, String> {
     let idx_path = find(dir, "idx")?;
-    let ifo = parse_ifo(&read_text(&ifo_path)?);
+    let ifo = parse_ifo(&read_text(&find(dir, "ifo")?)?);
     let idx = parse_idx(
         &fs::read(&idx_path).map_err(io(&idx_path))?,
         ifo.offset_bits,
     );
     let dict_bytes = read_dict(dir)?;
-
     let db = Dict::open(out_db).map_err(|e| e.to_string())?;
-    let mut imported = 0usize;
-    for entry in &idx {
-        let (start, end) = (
-            entry.offset as usize,
-            entry.offset as usize + entry.size as usize,
-        );
-        let Some(block) = dict_bytes.get(start..end) else {
-            continue; // a bad offset/size just skips that entry
-        };
-        let defn = definition_text(block, ifo.same_type_sequence);
-        if defn.is_empty() {
-            continue;
+
+    // The plain-text definition block for an idx entry, or None on a bad offset/size.
+    let block_of = |e: &IdxEntry| -> Option<String> {
+        let (start, end) = (e.offset as usize, e.offset as usize + e.size as usize);
+        dict_bytes
+            .get(start..end)
+            .map(|b| definition_text(b, ifo.same_type_sequence))
+    };
+
+    if syn {
+        // Thesaurus: each entry's body is a synonym list (Moby) → synonyms table.
+        let mut items: Vec<(String, Vec<String>)> = Vec::new();
+        for e in &idx {
+            if let Some(defn) = block_of(e) {
+                let syns = parse_synonym_list(&defn);
+                if !syns.is_empty() {
+                    items.push((e.word.clone(), syns));
+                }
+            }
         }
-        if db.put_entry(lang, &entry.word, &defn).is_ok() {
-            imported += 1;
-        }
+        return db.import_synonyms(lang, &items).map_err(|e| e.to_string());
     }
 
-    // Alternate spellings (.syn) become alias entries pointing at the same definition, so a lookup
-    // of either spelling resolves. (Thesaurus synonyms come from a separate source — D5.)
+    // Definitions, plus tight synonyms harvested from any inline `[syn: {…}]` markup (WordNet).
+    let mut items: Vec<(String, String)> = Vec::new();
+    let mut syns: Vec<(String, Vec<String>)> = Vec::new();
+    for e in &idx {
+        if let Some(defn) = block_of(e) {
+            if !defn.is_empty() {
+                let mut s = extract_inline_synonyms(&defn);
+                s.retain(|x| !x.eq_ignore_ascii_case(&e.word)); // drop the headword itself
+                if !s.is_empty() {
+                    syns.push((e.word.clone(), s));
+                }
+                items.push((e.word.clone(), defn));
+            }
+        }
+    }
+    // Alternate spellings (.syn) → alias entries pointing at the same definition.
     if let Ok(syn_path) = find(dir, "syn") {
         for s in parse_syn(&fs::read(&syn_path).map_err(io(&syn_path))?) {
             if let Some(target) = idx.get(s.index as usize) {
-                let (start, end) = (
-                    target.offset as usize,
-                    target.offset as usize + target.size as usize,
-                );
-                if let Some(block) = dict_bytes.get(start..end) {
-                    let defn = definition_text(block, ifo.same_type_sequence);
-                    if !defn.is_empty() && db.put_entry(lang, &s.word, &defn).is_ok() {
-                        imported += 1;
+                if let Some(defn) = block_of(target) {
+                    if !defn.is_empty() {
+                        items.push((s.word, defn));
                     }
                 }
             }
         }
     }
-    Ok(imported)
+    let n = db.import_entries(lang, &items).map_err(|e| e.to_string())?;
+    db.import_synonyms(lang, &syns).map_err(|e| e.to_string())?;
+    Ok(n)
 }
 
 /// The `.dict` data, decompressing `.dict.dz` (gzip-compatible) when that's the only form present.

--- a/buildApk.sh
+++ b/buildApk.sh
@@ -217,6 +217,21 @@ stage_pdfium() {
 }
 
 # =========================================================
+# stage_dict — ensure the on-device dictionary corpus (assets/dict.db) exists (ADR-INKREAD-0009).
+# A generated build artifact (gitignored, ~60 MB): delegates to scripts/stage-dict.sh, which
+# downloads free WordNet + imports it via build-dict. No-op if dict.db is already present.
+# =========================================================
+stage_dict() {
+    local root="$1"
+    if [[ -f "$root/$APP_MODULE/src/main/assets/dict.db" ]]; then
+        write_color_output "dict.db present: $APP_MODULE/src/main/assets/dict.db" "Green"
+        return 0
+    fi
+    write_color_output "staging dictionary corpus (scripts/stage-dict.sh)…" "Blue"
+    bash "$root/scripts/stage-dict.sh" || die "dictionary staging failed (scripts/stage-dict.sh)"
+}
+
+# =========================================================
 # build_apk — assemble + sign the APK via gradle (RR29-FR1/FR2)
 # =========================================================
 build_apk() {
@@ -272,6 +287,7 @@ main() {
 
     build_rust "$root" "$profile_flag"
     stage_pdfium "$root"
+    stage_dict "$root"
     # Capitalize the first letter portably (macOS ships bash 3.2, which lacks ${var^}).
     local task                              # assembleRelease / assembleDebug
     case "$variant" in

--- a/inkread-dict/Cargo.toml
+++ b/inkread-dict/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "inkread-dict"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Offline-first dictionary + thesaurus lookup engine (RR12 / ADR-INKREAD-0009): layered resolution (exact → stem) over an indexed SQLite corpus, language routing, and a permission-gated online-fallback port. Host-testable; names no vendor (IR-7)."
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+# Bundled SQLite (compiled from source) — hermetic host build, same engine cross-compiles for the
+# device (mirrors reader-core's ADR Decision 4). The pre-built dict.db is opened read-only on device.
+rusqlite = { workspace = true }

--- a/inkread-dict/src/engine.rs
+++ b/inkread-dict/src/engine.rs
@@ -1,0 +1,341 @@
+//! The [`Dict`] lookup engine over the SQLite corpus (ADR-INKREAD-0009 D2).
+
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::{Definition, DictError, DictResult, OnlineSource};
+
+/// The corpus schema (idempotent — a pre-built `dict.db` already has it). `key` is the normalized
+/// lowercase headword used for lookup; `headword` is the display form.
+const SCHEMA: &str = "
+CREATE TABLE IF NOT EXISTS entries (
+  lang     TEXT NOT NULL,
+  key      TEXT NOT NULL,
+  headword TEXT NOT NULL,
+  defn     TEXT NOT NULL,
+  PRIMARY KEY (lang, key)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS idx_entries_key ON entries(key);
+CREATE TABLE IF NOT EXISTS synonyms (
+  lang TEXT NOT NULL,
+  key  TEXT NOT NULL,
+  syn  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_syn_key ON synonyms(lang, key);
+";
+
+/// The dictionary corpus + lookup engine. `Send + Sync` via an interior `Mutex` so the engine can
+/// be shared (`Arc`) across threads, mirroring `reader-core`'s `SqliteStore`.
+pub struct Dict {
+    conn: Mutex<Connection>,
+}
+
+impl Dict {
+    /// Open (or create) a corpus at `path`, ensuring the schema.
+    pub fn open(path: impl AsRef<Path>) -> DictResult<Self> {
+        let conn = Connection::open(path).map_err(be)?;
+        conn.execute_batch(SCHEMA).map_err(be)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// An in-memory corpus (tests, and the transient online cache).
+    pub fn open_in_memory() -> DictResult<Self> {
+        let conn = Connection::open_in_memory().map_err(be)?;
+        conn.execute_batch(SCHEMA).map_err(be)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Insert/replace a dictionary entry (the StarDict importer + the online cache use this).
+    pub fn put_entry(&self, lang: &str, headword: &str, defn: &str) -> DictResult<()> {
+        let key = normalize(headword);
+        self.lock()
+            .execute(
+                "INSERT OR REPLACE INTO entries (lang, key, headword, defn) VALUES (?1, ?2, ?3, ?4)",
+                params![lang, key, headword, defn],
+            )
+            .map_err(be)?;
+        Ok(())
+    }
+
+    /// Add a thesaurus synonym for a headword.
+    pub fn put_synonym(&self, lang: &str, headword: &str, syn: &str) -> DictResult<()> {
+        let key = normalize(headword);
+        self.lock()
+            .execute(
+                "INSERT INTO synonyms (lang, key, syn) VALUES (?1, ?2, ?3)",
+                params![lang, key, syn],
+            )
+            .map_err(be)?;
+        Ok(())
+    }
+
+    /// Resolve `query` to a [`Definition`] (RR12): try `lang_hints` first then any language, then a
+    /// stem fallback for inflected forms (`running`→`run`). On a full on-device miss, fall through
+    /// to `online` (if supplied) and cache the result. `None` if nothing matches.
+    pub fn lookup(
+        &self,
+        query: &str,
+        lang_hints: &[&str],
+        online: Option<&dyn OnlineSource>,
+    ) -> Option<Definition> {
+        let key = normalize(query);
+        if key.is_empty() {
+            return None;
+        }
+        let mut candidates = vec![key.clone()];
+        candidates.extend(stem_candidates(&key));
+        candidates.dedup();
+
+        for cand in &candidates {
+            for lang in lang_hints {
+                if let Some(d) = self.exact(lang, cand) {
+                    return Some(d);
+                }
+            }
+            if let Some(d) = self.exact_any(cand) {
+                return Some(d);
+            }
+        }
+
+        if let Some(src) = online {
+            if let Some(e) = src.lookup(query) {
+                let _ = self.put_entry(&e.lang, &e.headword, &e.senses.join("\n"));
+                return Some(Definition {
+                    headword: e.headword,
+                    lang: e.lang,
+                    senses: e.senses,
+                    synonyms: Vec::new(),
+                });
+            }
+        }
+        None
+    }
+
+    fn exact(&self, lang: &str, key: &str) -> Option<Definition> {
+        let (headword, defn) = self
+            .lock()
+            .query_row(
+                "SELECT headword, defn FROM entries WHERE lang = ?1 AND key = ?2",
+                params![lang, key],
+                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+            )
+            .optional()
+            .ok()??;
+        Some(self.build(lang, key, headword, defn))
+    }
+
+    fn exact_any(&self, key: &str) -> Option<Definition> {
+        let (lang, headword, defn) = self
+            .lock()
+            .query_row(
+                "SELECT lang, headword, defn FROM entries WHERE key = ?1 LIMIT 1",
+                params![key],
+                |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, String>(2)?,
+                    ))
+                },
+            )
+            .optional()
+            .ok()??;
+        Some(self.build(&lang, key, headword, defn))
+    }
+
+    fn build(&self, lang: &str, key: &str, headword: String, defn: String) -> Definition {
+        let senses = defn
+            .split('\n')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
+        Definition {
+            headword,
+            lang: lang.to_string(),
+            senses,
+            synonyms: self.synonyms(lang, key),
+        }
+    }
+
+    fn synonyms(&self, lang: &str, key: &str) -> Vec<String> {
+        let conn = self.lock();
+        let mut stmt = match conn.prepare("SELECT syn FROM synonyms WHERE lang = ?1 AND key = ?2") {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        // Bind `out` first and confine the borrowing iterator to this block so it ends before the
+        // guard (`conn`) drops at return.
+        let mut out = Vec::new();
+        if let Ok(rows) = stmt.query_map(params![lang, key], |r| r.get::<_, String>(0)) {
+            for s in rows.flatten() {
+                out.push(s);
+            }
+        }
+        out
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Connection> {
+        self.conn.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+fn be(e: rusqlite::Error) -> DictError {
+    DictError::Backend(e.to_string())
+}
+
+/// Normalize a word for the lookup key: trimmed + lowercased.
+fn normalize(word: &str) -> String {
+    word.trim().to_lowercase()
+}
+
+/// Candidate base forms for an inflected word (heuristic; a real lemmatizer/forms-table is D5).
+/// Ordered most-to-least likely; the caller tries each. Suffixes are ASCII, so the byte slices
+/// always land on a char boundary even for accented (it/fr/da) words.
+fn stem_candidates(key: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let len = key.chars().count();
+    let mut push = |s: String| {
+        if s.chars().count() >= 2 {
+            out.push(s);
+        }
+    };
+
+    if key.ends_with("ies") && len > 4 {
+        push(format!("{}y", &key[..key.len() - 3])); // berries -> berry
+    }
+    if key.ends_with("ing") && len > 5 {
+        let base = &key[..key.len() - 3];
+        push(base.to_string()); // singing -> sing
+        push(undouble(base)); // running -> runn -> run
+        push(format!("{base}e")); // making -> mak -> make
+    }
+    if key.ends_with("ed") && len > 4 {
+        let base = &key[..key.len() - 2];
+        push(base.to_string()); // walked -> walk
+        push(undouble(base)); // stopped -> stopp -> stop
+        push(format!("{base}e")); // baked -> bak -> bake
+    }
+    if key.ends_with("es") && len > 4 {
+        push(key[..key.len() - 2].to_string()); // boxes -> box
+    }
+    for suf in ["s", "ly", "er", "est"] {
+        if key.ends_with(suf) && len > suf.len() + 2 {
+            push(key[..key.len() - suf.len()].to_string());
+        }
+    }
+    out.dedup();
+    out
+}
+
+/// Drop a trailing doubled consonant (`runn` -> `run`).
+fn undouble(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() >= 2 && chars[chars.len() - 1] == chars[chars.len() - 2] {
+        chars[..chars.len() - 1].iter().collect()
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OnlineEntry;
+
+    fn fixture() -> Dict {
+        let d = Dict::open_in_memory().unwrap();
+        d.put_entry("en", "run", "to move quickly on foot\nto operate or manage")
+            .unwrap();
+        d.put_synonym("en", "run", "sprint").unwrap();
+        d.put_synonym("en", "run", "dash").unwrap();
+        d.put_entry("en", "make", "to create or produce").unwrap();
+        d.put_entry("en", "stop", "to cease moving").unwrap();
+        d.put_entry("en", "berry", "a small juicy fruit").unwrap();
+        d.put_entry("it", "casa", "house; home").unwrap();
+        d
+    }
+
+    #[test]
+    fn exact_lookup_returns_senses_and_synonyms() {
+        let d = fixture();
+        let def = d.lookup("run", &["en"], None).unwrap();
+        assert_eq!(def.headword, "run");
+        assert_eq!(def.lang, "en");
+        assert_eq!(def.senses.len(), 2);
+        assert_eq!(def.synonyms, vec!["sprint", "dash"]);
+    }
+
+    #[test]
+    fn lookup_is_trimmed_and_case_insensitive() {
+        let d = fixture();
+        assert_eq!(d.lookup("  RUN  ", &["en"], None).unwrap().headword, "run");
+    }
+
+    #[test]
+    fn stemming_finds_the_base_word() {
+        let d = fixture();
+        for inflected in ["running", "runs"] {
+            assert_eq!(
+                d.lookup(inflected, &["en"], None).map(|x| x.headword),
+                Some("run".to_string()),
+                "{inflected}",
+            );
+        }
+        assert_eq!(d.lookup("making", &["en"], None).unwrap().headword, "make");
+        assert_eq!(d.lookup("stopped", &["en"], None).unwrap().headword, "stop");
+        assert_eq!(
+            d.lookup("berries", &["en"], None).unwrap().headword,
+            "berry"
+        );
+    }
+
+    #[test]
+    fn language_routing_prefers_hints_then_any() {
+        let d = fixture();
+        // 'casa' isn't English; with an en-only hint it still resolves via exact_any (it).
+        assert_eq!(d.lookup("casa", &["en"], None).unwrap().lang, "it");
+        assert_eq!(d.lookup("casa", &["it", "en"], None).unwrap().lang, "it");
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        let d = fixture();
+        assert!(d.lookup("zxqwv", &["en"], None).is_none());
+        assert!(d.lookup("   ", &["en"], None).is_none());
+    }
+
+    struct FakeOnline;
+    impl OnlineSource for FakeOnline {
+        fn lookup(&self, word: &str) -> Option<OnlineEntry> {
+            if word == "neologism" {
+                Some(OnlineEntry {
+                    lang: "en".into(),
+                    headword: "neologism".into(),
+                    senses: vec!["a newly coined word".into()],
+                })
+            } else {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn online_fallback_returns_and_caches() {
+        let d = fixture();
+        // miss on device → online resolves it
+        let def = d.lookup("neologism", &["en"], Some(&FakeOnline)).unwrap();
+        assert_eq!(def.senses, vec!["a newly coined word"]);
+        // cached: a second lookup with NO online source still hits
+        assert_eq!(
+            d.lookup("neologism", &["en"], None).unwrap().headword,
+            "neologism"
+        );
+    }
+}

--- a/inkread-dict/src/engine.rs
+++ b/inkread-dict/src/engine.rs
@@ -75,6 +75,53 @@ impl Dict {
         Ok(())
     }
 
+    /// Bulk-import dictionary entries in one transaction — the offline importer's fast path
+    /// (150k autocommit inserts would be far too slow). Returns the count written.
+    pub fn import_entries(&self, lang: &str, items: &[(String, String)]) -> DictResult<usize> {
+        let conn = self.lock();
+        let tx = conn.unchecked_transaction().map_err(be)?;
+        let mut n = 0;
+        {
+            let mut stmt = tx
+                .prepare(
+                    "INSERT OR REPLACE INTO entries (lang, key, headword, defn) VALUES (?1, ?2, ?3, ?4)",
+                )
+                .map_err(be)?;
+            for (headword, defn) in items {
+                stmt.execute(params![lang, normalize(headword), headword, defn])
+                    .map_err(be)?;
+                n += 1;
+            }
+        }
+        tx.commit().map_err(be)?;
+        Ok(n)
+    }
+
+    /// Bulk-import thesaurus synonyms in one transaction. Returns the count written.
+    pub fn import_synonyms(
+        &self,
+        lang: &str,
+        items: &[(String, Vec<String>)],
+    ) -> DictResult<usize> {
+        let conn = self.lock();
+        let tx = conn.unchecked_transaction().map_err(be)?;
+        let mut n = 0;
+        {
+            let mut stmt = tx
+                .prepare("INSERT INTO synonyms (lang, key, syn) VALUES (?1, ?2, ?3)")
+                .map_err(be)?;
+            for (headword, syns) in items {
+                let key = normalize(headword);
+                for syn in syns {
+                    stmt.execute(params![lang, key, syn]).map_err(be)?;
+                    n += 1;
+                }
+            }
+        }
+        tx.commit().map_err(be)?;
+        Ok(n)
+    }
+
     /// Resolve `query` to a [`Definition`] (RR12): try `lang_hints` first then any language, then a
     /// stem fallback for inflected forms (`running`→`run`). On a full on-device miss, fall through
     /// to `online` (if supplied) and cache the result. `None` if nothing matches.

--- a/inkread-dict/src/lib.rs
+++ b/inkread-dict/src/lib.rs
@@ -1,0 +1,67 @@
+//! `inkread-dict` — the offline-first dictionary + thesaurus engine (RR12 / ADR-INKREAD-0009 D2).
+//!
+//! A [`Dict`] resolves a tapped/highlighted word to a [`Definition`] (senses + synonyms) over an
+//! **indexed SQLite corpus** (`dict.db`, pre-built offline from StarDict + WordNet — D2 build step).
+//! Lookup is layered for the Kindle-like "finds the base word" feel: exact → normalized →
+//! stem-stripped, across the document's likely languages. A miss may fall through to an
+//! **online source** (the shell supplies the network impl via [`OnlineSource`], so the core stays
+//! offline-testable, IR-4); online hits are **cached** back into the DB so a repeat is instant.
+//!
+//! This crate is pure logic + SQLite; it names no vendor and is fully host-tested against an
+//! in-memory fixture.
+
+mod engine;
+
+pub use engine::Dict;
+
+/// A resolved dictionary entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Definition {
+    /// The display headword that matched (may differ from the query after stemming).
+    pub headword: String,
+    /// BCP-47-ish language code of the matched entry (`en`, `it`, `fr`, `da`, …).
+    pub lang: String,
+    /// One or more sense lines.
+    pub senses: Vec<String>,
+    /// Thesaurus synonyms for the headword (may be empty).
+    pub synonyms: Vec<String>,
+}
+
+/// A network dictionary source the shell wires up (Wiktionary, etc.). Kept as a port so the engine
+/// — and its tests — never touch the network (RR19-FR9: online is user-configured + opt-in).
+pub trait OnlineSource: Send + Sync {
+    /// Look `word` up online, or `None` on a miss/error. Implementations must be non-blocking-safe
+    /// for the caller's thread model (the shell calls this off the UI thread).
+    fn lookup(&self, word: &str) -> Option<OnlineEntry>;
+}
+
+/// A definition fetched from an [`OnlineSource`], ready to cache + return.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnlineEntry {
+    /// Language code of the result.
+    pub lang: String,
+    /// The headword as the source spells it.
+    pub headword: String,
+    /// Sense lines.
+    pub senses: Vec<String>,
+}
+
+/// The dictionary result alias.
+pub type DictResult<T> = Result<T, DictError>;
+
+/// The dictionary error surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DictError {
+    /// Opening or preparing the corpus failed.
+    Backend(String),
+}
+
+impl std::fmt::Display for DictError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DictError::Backend(m) => write!(f, "dictionary backend error: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for DictError {}

--- a/inkread-dict/src/lib.rs
+++ b/inkread-dict/src/lib.rs
@@ -11,6 +11,7 @@
 //! in-memory fixture.
 
 mod engine;
+pub mod stardict;
 
 pub use engine::Dict;
 

--- a/inkread-dict/src/stardict.rs
+++ b/inkread-dict/src/stardict.rs
@@ -143,6 +143,54 @@ pub fn definition_text(block: &[u8], same_type: Option<char>) -> String {
     }
 }
 
+/// Parse a thesaurus entry's body into synonyms. Moby entries are a header line
+/// (`"N Moby Thesaurus words for "x":"`) followed by a comma-separated list; we take everything
+/// after the first colon and split on commas. Over-long tokens (junk) are dropped.
+#[must_use]
+pub fn parse_synonym_list(defn: &str) -> Vec<String> {
+    let body = defn.split_once(':').map_or(defn, |(_, tail)| tail);
+    let mut out: Vec<String> = body
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && s.chars().count() <= 60)
+        .map(str::to_string)
+        .collect();
+    out.dedup();
+    out
+}
+
+/// Extract tight synonyms from WordNet-style `[syn: {a}, {b}]` markup inside a definition: each
+/// `{token}` within a `[syn: …]` span is a synonym (true synset members, far sharper + smaller than
+/// a broad thesaurus). De-duplicated; the caller drops the headword itself. A no-op for dictionaries
+/// without that markup.
+#[must_use]
+pub fn extract_inline_synonyms(defn: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut search = defn;
+    while let Some(start) = search.find("[syn:") {
+        let after = &search[start + 5..];
+        let end = after.find(']').unwrap_or(after.len());
+        let mut rest = &after[..end];
+        while let Some(b) = rest.find('{') {
+            let tail = &rest[b + 1..];
+            match tail.find('}') {
+                Some(e) => {
+                    let tok = tail[..e].trim();
+                    if !tok.is_empty() {
+                        out.push(tok.to_string());
+                    }
+                    rest = &tail[e + 1..];
+                }
+                None => break,
+            }
+        }
+        search = &after[end..];
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
 fn read_be(b: &[u8]) -> u64 {
     b.iter().fold(0u64, |acc, &x| (acc << 8) | u64::from(x))
 }
@@ -237,6 +285,30 @@ mod tests {
         );
         // type-prefixed (no sametypesequence): first byte is the type
         assert_eq!(definition_text(b"mhello", None), "hello");
+    }
+
+    #[test]
+    fn parse_synonym_list_extracts_moby_synonyms() {
+        let body =
+            "12 Moby Thesaurus words for \"happy\":\n  cheerful, glad, joyful,\n  joyous, pleased";
+        let syns = parse_synonym_list(body);
+        assert_eq!(
+            syns,
+            vec!["cheerful", "glad", "joyful", "joyous", "pleased"]
+        );
+        // no header colon → split the whole thing
+        assert_eq!(parse_synonym_list("a, b, c"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn extract_inline_synonyms_from_wordnet_markup() {
+        let defn = "n 1: a score in baseball [syn: {run}, {tally}]\nn 2: foot race [syn: {run}, {running}]";
+        assert_eq!(
+            extract_inline_synonyms(defn),
+            vec!["run", "running", "tally"]
+        );
+        // no markup → empty
+        assert!(extract_inline_synonyms("plain definition").is_empty());
     }
 
     #[test]

--- a/inkread-dict/src/stardict.rs
+++ b/inkread-dict/src/stardict.rs
@@ -1,0 +1,256 @@
+//! Pure StarDict-format parsing for the offline corpus importer (ADR-INKREAD-0009 D2).
+//!
+//! StarDict ships three core files: `.ifo` (text metadata), `.idx` (a sorted index of
+//! `word\0 offset size`), and `.dict[.dz]` (concatenated definition blocks). An optional `.syn`
+//! maps alternate spellings to index entries. This module parses **already-decompressed bytes** so
+//! it stays dependency-free and fully host-tested; the `build-dict` tool does the file IO and the
+//! `.dz` (gzip) decompression and calls [`crate::Dict::put_entry`].
+
+/// The `.ifo` fields the importer needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ifo {
+    /// Single type char applied to every entry (`m` = plain text, `h` = HTML, …), or `None` when
+    /// each definition block is type-prefixed.
+    pub same_type_sequence: Option<char>,
+    /// Index offset width — `32` (default) or `64`.
+    pub offset_bits: u32,
+    /// Declared headword count (advisory).
+    pub word_count: u64,
+}
+
+/// One `.idx` record: a headword and where its definition sits in `.dict`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdxEntry {
+    /// The headword.
+    pub word: String,
+    /// Byte offset of the definition block in `.dict`.
+    pub offset: u64,
+    /// Byte length of the definition block.
+    pub size: u32,
+}
+
+/// One `.syn` record: an alternate spelling and the `.idx` entry index it resolves to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SynEntry {
+    /// The alternate spelling.
+    pub word: String,
+    /// Zero-based index into the `.idx` entries.
+    pub index: u32,
+}
+
+/// Parse `.ifo` text (lenient: unknown keys ignored, missing keys defaulted).
+#[must_use]
+pub fn parse_ifo(text: &str) -> Ifo {
+    let mut same = None;
+    let mut bits = 32u32;
+    let mut word_count = 0u64;
+    for line in text.lines() {
+        if let Some((k, v)) = line.split_once('=') {
+            let v = v.trim();
+            match k.trim() {
+                "sametypesequence" => same = v.chars().next(),
+                "idxoffsetbits" => bits = if v == "64" { 64 } else { 32 },
+                "wordcount" => word_count = v.parse().unwrap_or(0),
+                _ => {}
+            }
+        }
+    }
+    Ifo {
+        same_type_sequence: same,
+        offset_bits: bits,
+        word_count,
+    }
+}
+
+/// Parse `.idx` bytes into entries. Records are `word\0` + big-endian offset (`offset_bits/8`
+/// bytes) + big-endian `u32` size. Truncated trailing bytes are ignored (never panics).
+#[must_use]
+pub fn parse_idx(bytes: &[u8], offset_bits: u32) -> Vec<IdxEntry> {
+    let off_len = if offset_bits == 64 { 8 } else { 4 };
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let start = i;
+        while i < bytes.len() && bytes[i] != 0 {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break; // no terminator → truncated
+        }
+        let word = String::from_utf8_lossy(&bytes[start..i]).into_owned();
+        i += 1; // skip the NUL
+        if i + off_len + 4 > bytes.len() {
+            break;
+        }
+        let offset = read_be(&bytes[i..i + off_len]);
+        i += off_len;
+        let size = read_be(&bytes[i..i + 4]) as u32;
+        i += 4;
+        if !word.is_empty() {
+            out.push(IdxEntry { word, offset, size });
+        }
+    }
+    out
+}
+
+/// Parse `.syn` bytes: `word\0` + big-endian `u32` index.
+#[must_use]
+pub fn parse_syn(bytes: &[u8]) -> Vec<SynEntry> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let start = i;
+        while i < bytes.len() && bytes[i] != 0 {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+        let word = String::from_utf8_lossy(&bytes[start..i]).into_owned();
+        i += 1;
+        if i + 4 > bytes.len() {
+            break;
+        }
+        let index = read_be(&bytes[i..i + 4]) as u32;
+        i += 4;
+        if !word.is_empty() {
+            out.push(SynEntry { word, index });
+        }
+    }
+    out
+}
+
+/// Extract the plain-text definition for an entry's `.dict` block. With `same_type` set, the whole
+/// block is that type's content; without it, the block is type-prefixed (first byte = type char).
+/// HTML (`h`) is crudely stripped to text; other text types pass through (lossy UTF-8).
+#[must_use]
+pub fn definition_text(block: &[u8], same_type: Option<char>) -> String {
+    match same_type {
+        Some('h') => strip_html(&String::from_utf8_lossy(block)),
+        Some(_) => String::from_utf8_lossy(block).trim().to_string(),
+        None => {
+            if block.is_empty() {
+                return String::new();
+            }
+            let t = block[0] as char;
+            let content = &block[1..];
+            if t == 'h' {
+                strip_html(&String::from_utf8_lossy(content))
+            } else {
+                String::from_utf8_lossy(content).trim().to_string()
+            }
+        }
+    }
+}
+
+fn read_be(b: &[u8]) -> u64 {
+    b.iter().fold(0u64, |acc, &x| (acc << 8) | u64::from(x))
+}
+
+/// Strip HTML tags + unescape the common entities — enough to turn a dictionary HTML body into
+/// readable definition text.
+fn strip_html(s: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for c in s.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ifo_reads_the_fields() {
+        let ifo = parse_ifo(
+            "StarDict's dict ifo file\nversion=2.4.2\nwordcount=42\nsametypesequence=m\nidxoffsetbits=32\n",
+        );
+        assert_eq!(ifo.same_type_sequence, Some('m'));
+        assert_eq!(ifo.offset_bits, 32);
+        assert_eq!(ifo.word_count, 42);
+        // 64-bit + missing sametypesequence
+        let ifo2 = parse_ifo("idxoffsetbits=64\n");
+        assert_eq!(ifo2.offset_bits, 64);
+        assert_eq!(ifo2.same_type_sequence, None);
+    }
+
+    /// Build a 32-bit `.idx` record.
+    fn idx_rec(word: &str, offset: u32, size: u32) -> Vec<u8> {
+        let mut v = word.as_bytes().to_vec();
+        v.push(0);
+        v.extend_from_slice(&offset.to_be_bytes());
+        v.extend_from_slice(&size.to_be_bytes());
+        v
+    }
+
+    #[test]
+    fn parse_idx_reads_records_in_order() {
+        let mut bytes = idx_rec("run", 0, 7);
+        bytes.extend(idx_rec("café", 7, 5)); // accented headword survives
+        let idx = parse_idx(&bytes, 32);
+        assert_eq!(idx.len(), 2);
+        assert_eq!(
+            idx[0],
+            IdxEntry {
+                word: "run".into(),
+                offset: 0,
+                size: 7
+            }
+        );
+        assert_eq!(idx[1].word, "café");
+        assert_eq!(idx[1].offset, 7);
+    }
+
+    #[test]
+    fn parse_idx_tolerates_truncation() {
+        let mut bytes = idx_rec("run", 0, 7);
+        bytes.extend_from_slice(b"trunc\0\x00\x00"); // a word with a chopped offset/size
+        let idx = parse_idx(&bytes, 32);
+        assert_eq!(
+            idx.len(),
+            1,
+            "the complete record parses; the truncated tail is dropped"
+        );
+    }
+
+    #[test]
+    fn definition_text_plain_and_html() {
+        assert_eq!(
+            definition_text(b"to move quickly", Some('m')),
+            "to move quickly"
+        );
+        assert_eq!(
+            definition_text(b"<b>a</b> small <i>fruit</i>", Some('h')),
+            "a small fruit"
+        );
+        // type-prefixed (no sametypesequence): first byte is the type
+        assert_eq!(definition_text(b"mhello", None), "hello");
+    }
+
+    #[test]
+    fn parse_syn_maps_spelling_to_index() {
+        let mut bytes = b"colour".to_vec();
+        bytes.push(0);
+        bytes.extend_from_slice(&5u32.to_be_bytes());
+        let syn = parse_syn(&bytes);
+        assert_eq!(
+            syn,
+            vec![SynEntry {
+                word: "colour".into(),
+                index: 5
+            }]
+        );
+    }
+}

--- a/reader-core/Cargo.toml
+++ b/reader-core/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 device-eink = { workspace = true }
+inkread-dict = { workspace = true }
 inkread-ink = { workspace = true }
 pdfium-render = { workspace = true }
 tiny-skia = { workspace = true }

--- a/reader-core/src/dict.rs
+++ b/reader-core/src/dict.rs
@@ -1,0 +1,95 @@
+//! Dictionary integration (RR12 / ADR-INKREAD-0009 D3): re-exports the `inkread-dict` engine and
+//! the wire codec the JNI bridge uses to ship a [`Definition`] to the shell. The engine itself is
+//! the separate `inkread-dict` crate (offline-testable); this module is just the reader-core-side
+//! glue + marshaling, kept pure so it is host-tested.
+
+pub use inkread_dict::{Definition, Dict, DictError, DictResult, OnlineEntry, OnlineSource};
+
+/// Wire-format version for a [`Definition`] (RR12 / D3).
+const DEFINITION_WIRE_VERSION: u8 = 0x01;
+
+/// Encode a (possibly absent) definition for the shell. Layout (little-endian):
+/// `[ver=1][found: u8]`; when `found == 1`:
+/// `[headword_len: u16][headword][lang_len: u8][lang][sense_count: u16]` then per sense
+/// `[len: u16][utf-8]`, then `[syn_count: u16]` then per synonym `[len: u16][utf-8]`.
+/// Pure marshaling; lengths saturate rather than panic (RR21-FR3).
+#[must_use]
+pub fn encode_definition_wire(def: Option<&Definition>) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(DEFINITION_WIRE_VERSION);
+    let Some(d) = def else {
+        out.push(0); // not found
+        return out;
+    };
+    out.push(1);
+    put_str16(&mut out, &d.headword);
+    let lang = d.lang.as_bytes();
+    let llen = u8::try_from(lang.len()).unwrap_or(u8::MAX);
+    out.push(llen);
+    out.extend_from_slice(&lang[..llen as usize]);
+    put_list(&mut out, &d.senses);
+    put_list(&mut out, &d.synonyms);
+    out
+}
+
+/// Append a `u16`-length-prefixed UTF-8 string.
+fn put_str16(out: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    let len = u16::try_from(bytes.len()).unwrap_or(u16::MAX);
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(&bytes[..len as usize]);
+}
+
+/// Append a `u16` count followed by that many `u16`-length-prefixed strings.
+fn put_list(out: &mut Vec<u8>, items: &[String]) {
+    let count = u16::try_from(items.len()).unwrap_or(u16::MAX);
+    out.extend_from_slice(&count.to_le_bytes());
+    for s in items.iter().take(count as usize) {
+        put_str16(out, s);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_a_found_definition() {
+        let def = Definition {
+            headword: "run".into(),
+            lang: "en".into(),
+            senses: vec!["to move quickly".into(), "to operate".into()],
+            synonyms: vec!["sprint".into()],
+        };
+        let w = encode_definition_wire(Some(&def));
+        assert_eq!(w[0], DEFINITION_WIRE_VERSION);
+        assert_eq!(w[1], 1, "found");
+        // headword len = 3 (LE u16) at [2..4]
+        assert_eq!(u16::from_le_bytes([w[2], w[3]]), 3);
+        assert_eq!(&w[4..7], b"run");
+        // the lang, sense text, and synonym are all present in the payload
+        let s = String::from_utf8_lossy(&w);
+        assert!(s.contains("en"));
+        assert!(s.contains("to move quickly") && s.contains("to operate"));
+        assert!(s.contains("sprint"));
+    }
+
+    #[test]
+    fn encodes_a_miss() {
+        let w = encode_definition_wire(None);
+        assert_eq!(w, vec![DEFINITION_WIRE_VERSION, 0]);
+    }
+
+    #[test]
+    fn empty_senses_and_synonyms_round_to_zero_counts() {
+        let def = Definition {
+            headword: "x".into(),
+            lang: "en".into(),
+            senses: vec![],
+            synonyms: vec![],
+        };
+        let w = encode_definition_wire(Some(&def));
+        // ver + found + hw_len(2)+ "x" + lang_len(1)+"en" + sense_count(2)=0 + syn_count(2)=0
+        assert_eq!(w.len(), 1 + 1 + 2 + 1 + 1 + 2 + 2 + 2);
+    }
+}

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -18,6 +18,7 @@ use std::sync::{Mutex, OnceLock};
 
 use pdfium_render::prelude::*;
 
+use crate::document::text_select::{self, CharBox, NormRect, TextSelection};
 use crate::document::{Document, DocumentMetadata, LinkTarget, PageLink, TocEntry};
 use crate::error::{CoreError, CoreResult};
 use crate::render::PixelBuffer;
@@ -191,6 +192,52 @@ impl PdfBackend {
                 .set_reverse_byte_order(true)
         })
     }
+
+    /// The page's glyphs as normalized [`CharBox`]es (RR11 / D1b) — the input to the pure
+    /// selection logic. pdfium gives chars in reading order with point-space, bottom-left-origin
+    /// bounds; we normalize + flip Y exactly like [`Self::page_links`]. An out-of-range page, a
+    /// text-less page, or a glyph with no resolvable bounds simply contributes nothing (never
+    /// panics, RR21-FR3).
+    fn page_chars(&self, index: usize) -> Vec<CharBox> {
+        let page = match i32::try_from(index)
+            .ok()
+            .and_then(|i| self.document.pages().get(i).ok())
+        {
+            Some(p) => p,
+            None => return Vec::new(),
+        };
+        let pw = page.width().value;
+        let ph = page.height().value;
+        if pw <= 0.0 || ph <= 0.0 {
+            return Vec::new();
+        }
+        let text = match page.text() {
+            Ok(t) => t,
+            Err(_) => return Vec::new(),
+        };
+        let mut out = Vec::new();
+        for ch in text.chars().iter() {
+            let Some(c) = ch.unicode_char() else { continue };
+            let bounds = match ch.loose_bounds() {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            let nx0 = (bounds.left().value / pw).clamp(0.0, 1.0);
+            let nx1 = (bounds.right().value / pw).clamp(0.0, 1.0);
+            let ny_top = ((ph - bounds.top().value) / ph).clamp(0.0, 1.0);
+            let ny_bottom = ((ph - bounds.bottom().value) / ph).clamp(0.0, 1.0);
+            out.push(CharBox {
+                ch: c,
+                rect: NormRect {
+                    x0: nx0.min(nx1),
+                    y0: ny_top.min(ny_bottom),
+                    x1: nx0.max(nx1),
+                    y1: ny_top.max(ny_bottom),
+                },
+            });
+        }
+        out
+    }
 }
 
 impl Document for PdfBackend {
@@ -271,6 +318,14 @@ impl Document for PdfBackend {
             });
         }
         out
+    }
+
+    fn word_at(&self, page: usize, x: f32, y: f32) -> Option<TextSelection> {
+        text_select::word_at(&self.page_chars(page), x, y)
+    }
+
+    fn text_in_rect(&self, page: usize, rect: NormRect) -> TextSelection {
+        text_select::text_in_rect(&self.page_chars(page), rect)
     }
 }
 

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -173,6 +173,18 @@ pub trait Document {
     fn page_links(&self, _page: usize) -> Vec<PageLink> {
         Vec::new()
     }
+
+    /// The word under the normalized point `(x, y)` on `page` (RR11 / dictionary tap, D1).
+    /// Default: `None` — a format without a text layer has no selection (never panics).
+    fn word_at(&self, _page: usize, _x: f32, _y: f32) -> Option<TextSelection> {
+        None
+    }
+
+    /// The text whose glyphs fall within the normalized `rect` on `page` (RR11 / drag-highlight,
+    /// D1). Default: an empty selection.
+    fn text_in_rect(&self, _page: usize, _rect: NormRect) -> TextSelection {
+        TextSelection::default()
+    }
 }
 
 #[cfg(test)]

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -137,6 +137,32 @@ pub fn encode_toc_wire(entries: &[TocEntry]) -> Vec<u8> {
     out
 }
 
+/// Wire-format version for a [`TextSelection`] the JNI bridge ships to the shell (RR11 / D1).
+const SELECTION_WIRE_VERSION: u8 = 0x01;
+
+/// Encode a text selection (the selected string + its highlight boxes) for the shell — pure
+/// marshaling (no device/JNI types), so it is host-tested. Layout (little-endian):
+/// `[ver=1][text_len: u16][text: utf-8 × text_len][box_count: u16]` then per box
+/// `[x0 f32][y0 f32][x1 f32][y1 f32]`. Lengths saturate rather than panic (RR21-FR3).
+#[must_use]
+pub fn encode_selection_wire(sel: &TextSelection) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(SELECTION_WIRE_VERSION);
+    let bytes = sel.text.as_bytes();
+    let tlen = u16::try_from(bytes.len()).unwrap_or(u16::MAX);
+    out.extend_from_slice(&tlen.to_le_bytes());
+    out.extend_from_slice(&bytes[..tlen as usize]);
+    let bcount = u16::try_from(sel.boxes.len()).unwrap_or(u16::MAX);
+    out.extend_from_slice(&bcount.to_le_bytes());
+    for b in sel.boxes.iter().take(bcount as usize) {
+        out.extend_from_slice(&b.x0.to_le_bytes());
+        out.extend_from_slice(&b.y0.to_le_bytes());
+        out.extend_from_slice(&b.x1.to_le_bytes());
+        out.extend_from_slice(&b.y1.to_le_bytes());
+    }
+    out
+}
+
 /// The core trait every format implements (M0 subset).
 ///
 /// Render targets a borrowed [`PixelBuffer`] (Fork 4); the backend white-fills before
@@ -366,5 +392,31 @@ mod tests {
         };
         h.hint_page(2);
         assert_eq!(h.last.get(), Some(2));
+    }
+
+    #[test]
+    fn encode_selection_wire_carries_text_and_boxes() {
+        let sel = TextSelection {
+            text: "hello".into(),
+            boxes: vec![NormRect {
+                x0: 0.1,
+                y0: 0.2,
+                x1: 0.3,
+                y1: 0.25,
+            }],
+        };
+        let w = encode_selection_wire(&sel);
+        assert_eq!(w[0], SELECTION_WIRE_VERSION);
+        assert_eq!(u16::from_le_bytes([w[1], w[2]]), 5); // text len
+        assert_eq!(&w[3..8], b"hello");
+        assert_eq!(u16::from_le_bytes([w[8], w[9]]), 1); // box count
+        assert_eq!(f32::from_le_bytes([w[10], w[11], w[12], w[13]]), 0.1);
+    }
+
+    #[test]
+    fn encode_selection_wire_empty_is_header_only() {
+        let w = encode_selection_wire(&TextSelection::default());
+        // ver + text_len(0) + box_count(0)
+        assert_eq!(w, vec![SELECTION_WIRE_VERSION, 0, 0, 0, 0]);
     }
 }

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -5,6 +5,9 @@
 //! ([`fixed::PdfBackend`]) is the one implementation in M0.
 
 pub mod fixed;
+pub mod text_select;
+
+pub use text_select::{CharBox, NormRect, TextSelection};
 
 use crate::error::CoreResult;
 use crate::render::PixelBuffer;

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -1,0 +1,354 @@
+//! Pure text-selection logic (RR11 / ADR-INKREAD-0009 D1).
+//!
+//! The document backend supplies the page's characters as [`CharBox`]es — each a glyph plus its
+//! **normalized** box (`[0,1]`, top-left origin, exactly like `PageLink`/ink). This module turns a
+//! tap point or a dragged rectangle into a [`TextSelection`] (the text + the boxes to highlight).
+//! It is **pure and dependency-free** so it is fully host-tested without pdfium; the backend only
+//! has to produce `CharBox`es (see `fixed::pdf`).
+
+/// A normalized rectangle `[0,1]` with a top-left origin. Mirrors `PageLink`'s convention.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NormRect {
+    /// Left edge `[0,1]`.
+    pub x0: f32,
+    /// Top edge `[0,1]`.
+    pub y0: f32,
+    /// Right edge `[0,1]`.
+    pub x1: f32,
+    /// Bottom edge `[0,1]`.
+    pub y1: f32,
+}
+
+impl NormRect {
+    /// Whether the point `(x, y)` lies within this rect (inclusive).
+    #[must_use]
+    pub fn contains(&self, x: f32, y: f32) -> bool {
+        x >= self.x0 && x <= self.x1 && y >= self.y0 && y <= self.y1
+    }
+
+    /// Whether this rect overlaps `other` (any shared area, edges touching counts).
+    #[must_use]
+    pub fn intersects(&self, other: &NormRect) -> bool {
+        self.x0 <= other.x1 && other.x0 <= self.x1 && self.y0 <= other.y1 && other.y0 <= self.y1
+    }
+
+    /// The smallest rect covering both.
+    #[must_use]
+    pub fn union(&self, other: &NormRect) -> NormRect {
+        NormRect {
+            x0: self.x0.min(other.x0),
+            y0: self.y0.min(other.y0),
+            x1: self.x1.max(other.x1),
+            y1: self.y1.max(other.y1),
+        }
+    }
+
+    fn height(&self) -> f32 {
+        (self.y1 - self.y0).max(0.0)
+    }
+}
+
+/// A single glyph with its normalized box — the unit selection works over. Backends emit these in
+/// reading order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CharBox {
+    /// The character.
+    pub ch: char,
+    /// Its normalized box.
+    pub rect: NormRect,
+}
+
+/// A resolved selection: the selected text plus the boxes a shell highlights (one per text line).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TextSelection {
+    /// The selected text (trimmed; line runs joined by a single space).
+    pub text: String,
+    /// One box per line run of the selection (for highlight rendering / dirty-rect refresh).
+    pub boxes: Vec<NormRect>,
+}
+
+impl TextSelection {
+    /// Whether the selection produced no text.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+}
+
+/// Vertical tolerance (page-height fraction) for "same line" / nearest-on-line tap matching.
+const LINE_MARGIN: f32 = 0.012;
+/// Horizontal tolerance (page-width fraction) for snapping a near-miss tap to a glyph.
+const HIT_TOLERANCE: f32 = 0.03;
+
+/// The word under `(x, y)` (tap / long-press), or `None` if the point isn't on a word glyph
+/// (whitespace, punctuation, or empty space). Expands across letters/digits and *internal*
+/// apostrophes/hyphens (`don't`, `well-known`).
+#[must_use]
+pub fn word_at(chars: &[CharBox], x: f32, y: f32) -> Option<TextSelection> {
+    let hit = hit_char(chars, x, y)?;
+    if !is_word_char(chars[hit].ch) {
+        return None;
+    }
+    let mut start = hit;
+    while start > 0 && joins(&chars[start - 1], &chars[start]) {
+        start -= 1;
+    }
+    let mut end = hit;
+    while end + 1 < chars.len() && joins(&chars[end], &chars[end + 1]) {
+        end += 1;
+    }
+    let run = &chars[start..=end];
+    let text = run
+        .iter()
+        .map(|c| c.ch)
+        .collect::<String>()
+        .trim_matches(is_connector)
+        .to_string();
+    if text.is_empty() {
+        return None;
+    }
+    Some(TextSelection {
+        text,
+        boxes: line_boxes(run),
+    })
+}
+
+/// The text whose glyphs fall within `rect` (drag-highlight), in reading order, with one highlight
+/// box per line run.
+#[must_use]
+pub fn text_in_rect(chars: &[CharBox], rect: NormRect) -> TextSelection {
+    let selected: Vec<&CharBox> = chars.iter().filter(|c| rect.intersects(&c.rect)).collect();
+    if selected.is_empty() {
+        return TextSelection::default();
+    }
+    // Group consecutive glyphs into line runs (a new line breaks the run).
+    let mut lines: Vec<Vec<&CharBox>> = Vec::new();
+    for c in selected {
+        match lines.last_mut() {
+            Some(line) if same_line(&line[0].rect, &c.rect) => line.push(c),
+            _ => lines.push(vec![c]),
+        }
+    }
+    let mut parts = Vec::with_capacity(lines.len());
+    let mut boxes = Vec::with_capacity(lines.len());
+    for line in &lines {
+        parts.push(
+            line.iter()
+                .map(|c| c.ch)
+                .collect::<String>()
+                .trim()
+                .to_string(),
+        );
+        let mut b = line[0].rect;
+        for c in &line[1..] {
+            b = b.union(&c.rect);
+        }
+        boxes.push(b);
+    }
+    TextSelection {
+        text: parts.join(" ").trim().to_string(),
+        boxes,
+    }
+}
+
+/// The glyph at `(x, y)`: the one whose box contains it, else the nearest on the same line within
+/// [`HIT_TOLERANCE`] (so a tap landing just off a glyph still selects it).
+fn hit_char(chars: &[CharBox], x: f32, y: f32) -> Option<usize> {
+    if let Some(i) = chars.iter().position(|c| c.rect.contains(x, y)) {
+        return Some(i);
+    }
+    let mut best: Option<usize> = None;
+    let mut best_d = f32::MAX;
+    for (i, c) in chars.iter().enumerate() {
+        if y < c.rect.y0 - LINE_MARGIN || y > c.rect.y1 + LINE_MARGIN {
+            continue; // not on this glyph's line
+        }
+        let cx = (c.rect.x0 + c.rect.x1) * 0.5;
+        let d = (cx - x).abs();
+        if d < best_d {
+            best_d = d;
+            best = Some(i);
+        }
+    }
+    best.filter(|_| best_d <= HIT_TOLERANCE)
+}
+
+/// Union the boxes of a single-line glyph run into per-line highlight rects (a word is one line,
+/// but guard for a run that wraps).
+fn line_boxes(run: &[CharBox]) -> Vec<NormRect> {
+    let mut boxes = Vec::new();
+    for c in run {
+        match boxes.last_mut() {
+            Some(b) if same_line(b, &c.rect) => *b = b.union(&c.rect),
+            _ => boxes.push(c.rect),
+        }
+    }
+    boxes
+}
+
+/// Whether two boxes share enough vertical overlap to be on the same text line.
+fn same_line(a: &NormRect, b: &NormRect) -> bool {
+    let overlap = a.y1.min(b.y1) - a.y0.max(b.y0);
+    let min_h = a.height().min(b.height()).max(1e-4);
+    overlap > 0.4 * min_h
+}
+
+/// Whether `a` and `b` are part of the same word: same line, both word-ish, not two connectors.
+fn joins(a: &CharBox, b: &CharBox) -> bool {
+    same_line(&a.rect, &b.rect)
+        && is_word_or_connector(a.ch)
+        && is_word_or_connector(b.ch)
+        && (is_word_char(a.ch) || is_word_char(b.ch))
+}
+
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric()
+}
+
+fn is_connector(c: char) -> bool {
+    matches!(c, '\'' | '\u{2019}' | '-')
+}
+
+fn is_word_or_connector(c: char) -> bool {
+    is_word_char(c) || is_connector(c)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a single line of glyphs from a string, evenly spaced across `[x0, x1]` at row `y`.
+    fn line(s: &str, x0: f32, x1: f32, y: f32, h: f32) -> Vec<CharBox> {
+        let n = s.chars().count().max(1);
+        let w = (x1 - x0) / n as f32;
+        s.chars()
+            .enumerate()
+            .map(|(i, ch)| CharBox {
+                ch,
+                rect: NormRect {
+                    x0: x0 + i as f32 * w,
+                    y0: y,
+                    x1: x0 + (i as f32 + 1.0) * w,
+                    y1: y + h,
+                },
+            })
+            .collect()
+    }
+
+    #[test]
+    fn word_at_tap_selects_whole_word() {
+        let chars = line("the quick fox", 0.0, 0.6, 0.10, 0.03);
+        // tap inside "quick"
+        let sel = word_at(&chars, 0.25, 0.115).unwrap();
+        assert_eq!(sel.text, "quick");
+        assert_eq!(sel.boxes.len(), 1);
+        assert!(sel.boxes[0].x0 < 0.25 && sel.boxes[0].x1 > 0.25);
+    }
+
+    #[test]
+    fn word_at_handles_internal_apostrophe_and_hyphen() {
+        let a = line("don't", 0.0, 0.2, 0.1, 0.03);
+        assert_eq!(word_at(&a, 0.1, 0.115).unwrap().text, "don't");
+        let b = line("well-known", 0.0, 0.4, 0.1, 0.03);
+        assert_eq!(word_at(&b, 0.2, 0.115).unwrap().text, "well-known");
+    }
+
+    #[test]
+    fn word_at_on_space_or_empty_returns_none() {
+        let chars = line("a b", 0.0, 0.3, 0.1, 0.03);
+        // the middle glyph is the space
+        assert!(word_at(&chars, 0.15, 0.115).is_none());
+        // far away from any glyph
+        assert!(word_at(&chars, 0.9, 0.9).is_none());
+    }
+
+    #[test]
+    fn word_at_snaps_a_near_miss_tap() {
+        let chars = line("hi", 0.4, 0.5, 0.10, 0.03);
+        // tap slightly below the line but within LINE_MARGIN and near in x
+        let sel = word_at(&chars, 0.45, 0.14);
+        assert_eq!(sel.unwrap().text, "hi");
+    }
+
+    #[test]
+    fn text_in_rect_collects_a_span_in_order() {
+        let chars = line("hello world", 0.0, 0.55, 0.10, 0.03);
+        // rect over "hello"
+        let sel = text_in_rect(
+            &chars,
+            NormRect {
+                x0: 0.0,
+                y0: 0.09,
+                x1: 0.26,
+                y1: 0.14,
+            },
+        );
+        assert!(sel.text.starts_with("hello"));
+        assert_eq!(sel.boxes.len(), 1, "single line → one highlight box");
+    }
+
+    #[test]
+    fn text_in_rect_spans_two_lines_into_two_boxes() {
+        let mut chars = line("first line", 0.0, 0.5, 0.10, 0.03);
+        chars.extend(line("second line", 0.0, 0.5, 0.16, 0.03));
+        let sel = text_in_rect(
+            &chars,
+            NormRect {
+                x0: 0.0,
+                y0: 0.08,
+                x1: 0.5,
+                y1: 0.20,
+            },
+        );
+        assert_eq!(sel.boxes.len(), 2, "two lines → two highlight boxes");
+        assert!(sel.text.contains("first") && sel.text.contains("second"));
+    }
+
+    #[test]
+    fn text_in_rect_empty_when_nothing_inside() {
+        let chars = line("abc", 0.0, 0.3, 0.1, 0.03);
+        let sel = text_in_rect(
+            &chars,
+            NormRect {
+                x0: 0.8,
+                y0: 0.8,
+                x1: 0.9,
+                y1: 0.9,
+            },
+        );
+        assert!(sel.is_empty());
+    }
+
+    #[test]
+    fn rect_helpers() {
+        let r = NormRect {
+            x0: 0.1,
+            y0: 0.1,
+            x1: 0.3,
+            y1: 0.3,
+        };
+        assert!(r.contains(0.2, 0.2));
+        assert!(!r.contains(0.5, 0.2));
+        assert!(r.intersects(&NormRect {
+            x0: 0.25,
+            y0: 0.25,
+            x1: 0.4,
+            y1: 0.4
+        }));
+        let u = r.union(&NormRect {
+            x0: 0.0,
+            y0: 0.0,
+            x1: 0.2,
+            y1: 0.2,
+        });
+        assert_eq!(
+            u,
+            NormRect {
+                x0: 0.0,
+                y0: 0.0,
+                x1: 0.3,
+                y1: 0.3
+            }
+        );
+    }
+}

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -34,7 +34,8 @@ use std::sync::Arc;
 
 use inkread_ink::{InkColor, Tool};
 
-use crate::document::{encode_links_wire, encode_toc_wire};
+use crate::dict::{encode_definition_wire, Dict};
+use crate::document::{encode_links_wire, encode_selection_wire, encode_toc_wire, NormRect};
 use crate::error::{CoreError, CoreResult};
 use crate::persistence::ink_store::{FsInkStore, InkStore};
 use crate::persistence::sidecar::SidecarPaths;
@@ -64,6 +65,18 @@ unsafe fn session_mut<'a>(handle: jlong) -> CoreResult<&'a mut ReaderSession> {
         return Err(CoreError::InvalidArgument("null document handle".into()));
     }
     Ok(&mut *(handle as *mut ReaderSession))
+}
+
+/// Reconstruct a borrowed `&Dict` from a non-null dictionary handle (RR12 / D3). Lookup is `&self`,
+/// so a shared reference suffices; the handle is a `Box<Dict>` from `nativeDictOpen`.
+///
+/// # Safety
+/// `handle` must be a value previously returned by `nativeDictOpen` and not yet closed.
+unsafe fn dict_ref<'a>(handle: jlong) -> CoreResult<&'a Dict> {
+    if handle == 0 {
+        return Err(CoreError::InvalidArgument("null dictionary handle".into()));
+    }
+    Ok(&*(handle as *const Dict))
 }
 
 // =====================================================================================
@@ -551,6 +564,143 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkSave<'lo
     env.with_env(|env| -> jni::errors::Result<()> {
         let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
         session.save_ink().map_err(|e| throw(env, &e))?;
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// =====================================================================================
+// Text selection + dictionary seam (RR11/RR12 / ADR-INKREAD-0009 D3). The shell turns a
+// tap/drag into a selection, then looks the word up in the on-device corpus; an on-device miss
+// is the shell's cue to try its (opt-in) online source and cache via nativeDictPut.
+//
+//   nativeWordAt(handle, page, x, y) : bytes        — selection wire (decode: WireCodec.decodeSelection)
+//   nativeTextInRect(handle, page, x0,y0,x1,y1) : bytes
+//   nativeDictOpen(path) : long                     — open the dict.db corpus; long handle
+//   nativeDictClose(handle)                         — free it
+//   nativeDefine(dictHandle, word, langsCsv) : bytes — definition wire (on-device only)
+//   nativeDictPut(dictHandle, lang, headword, defn) — cache an online result for next time
+//
+// Coordinates are normalized [0,1], top-left origin (matching the render + links).
+// =====================================================================================
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeWordAt<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    page: jint,
+    x: jfloat,
+    y: jfloat,
+) -> JByteArray<'local> {
+    env.with_env(|env| -> jni::errors::Result<JByteArray<'local>> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let target = if page < 0 { 0usize } else { page as usize };
+        let sel = session.word_at(target, x, y).unwrap_or_default();
+        env.byte_array_from_slice(&encode_selection_wire(&sel))
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeTextInRect<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    page: jint,
+    x0: jfloat,
+    y0: jfloat,
+    x1: jfloat,
+    y1: jfloat,
+) -> JByteArray<'local> {
+    env.with_env(|env| -> jni::errors::Result<JByteArray<'local>> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let target = if page < 0 { 0usize } else { page as usize };
+        let sel = session.text_in_rect(target, NormRect { x0, y0, x1, y1 });
+        env.byte_array_from_slice(&encode_selection_wire(&sel))
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeDictOpen<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    path: JString<'local>,
+) -> jlong {
+    env.with_env(|env| -> jni::errors::Result<jlong> {
+        let path: String = path.try_to_string(env)?;
+        match Dict::open(&path) {
+            Ok(d) => Ok(Box::into_raw(Box::new(d)) as jlong),
+            Err(e) => Err(throw(
+                env,
+                &CoreError::Persistence(format!("dict open {path}: {e}")),
+            )),
+        }
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeDictClose<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) {
+    env.with_env(|_env| -> jni::errors::Result<()> {
+        if handle != 0 {
+            // SAFETY: a non-zero handle is a Box<Dict> from nativeDictOpen; reclaim + drop it. The
+            // shell zeroes its field on close, so a double-close never reaches here with the same value.
+            unsafe {
+                drop(Box::from_raw(handle as *mut Dict));
+            }
+        }
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeDefine<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    dict_handle: jlong,
+    word: JString<'local>,
+    langs_csv: JString<'local>,
+) -> JByteArray<'local> {
+    env.with_env(|env| -> jni::errors::Result<JByteArray<'local>> {
+        let dict = unsafe { dict_ref(dict_handle) }.map_err(|e| throw(env, &e))?;
+        let word: String = word.try_to_string(env)?;
+        let langs_csv: String = langs_csv.try_to_string(env)?;
+        let langs: Vec<&str> = langs_csv
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        // On-device only (online = None); a miss is the shell's cue to try its online source.
+        let def = dict.lookup(&word, &langs, None);
+        env.byte_array_from_slice(&encode_definition_wire(def.as_ref()))
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeDictPut<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    dict_handle: jlong,
+    lang: JString<'local>,
+    headword: JString<'local>,
+    defn: JString<'local>,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let dict = unsafe { dict_ref(dict_handle) }.map_err(|e| throw(env, &e))?;
+        let lang: String = lang.try_to_string(env)?;
+        let headword: String = headword.try_to_string(env)?;
+        let defn: String = defn.try_to_string(env)?;
+        dict.put_entry(&lang, &headword, &defn)
+            .map_err(|e| throw(env, &CoreError::Persistence(format!("dict put: {e}"))))?;
         Ok(())
     })
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()

--- a/reader-core/src/lib.rs
+++ b/reader-core/src/lib.rs
@@ -8,6 +8,7 @@
 //! IR-7: no vendor name appears here; all device specifics live in the Kotlin adapters.
 
 pub mod budget;
+pub mod dict;
 pub mod document;
 pub mod error;
 pub mod persistence;

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use crate::budget::{Caches, ResourceBudget, TrimLevel};
 use crate::document::fixed::PdfBackend;
-use crate::document::{Document, DocumentMetadata, PageLink, TocEntry};
+use crate::document::{Document, DocumentMetadata, NormRect, PageLink, TextSelection, TocEntry};
 use crate::error::{CoreError, CoreResult};
 use crate::persistence::identity::DocIdentity;
 use crate::persistence::ink_store::InkStore;
@@ -332,6 +332,20 @@ impl ReaderSession {
     #[must_use]
     pub fn page_links(&self, page: usize) -> Vec<PageLink> {
         self.document.page_links(page)
+    }
+
+    /// The word under the normalized point `(x, y)` on `page` (RR11 / dictionary tap) — a
+    /// pass-through to [`Document::word_at`].
+    #[must_use]
+    pub fn word_at(&self, page: usize, x: f32, y: f32) -> Option<TextSelection> {
+        self.document.word_at(page, x, y)
+    }
+
+    /// The text within the normalized `rect` on `page` (RR11 / drag-highlight) — a pass-through to
+    /// [`Document::text_in_rect`].
+    #[must_use]
+    pub fn text_in_rect(&self, page: usize, rect: NormRect) -> TextSelection {
+        self.document.text_in_rect(page, rect)
     }
 
     /// Navigate to a TOC entry's target page (RR11-AC1). An unresolved entry (no

--- a/scripts/stage-dict.sh
+++ b/scripts/stage-dict.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+# =========================================================
+# stage-dict.sh — build the on-device English dictionary corpus (ADR-INKREAD-0009 D2).
+#
+# Imports free, public-domain WordNet (definitions + tight inline `[syn:]` synonyms) into
+# app/src/main/assets/dict.db via the build-dict tool. The app opens this SQLite read-only at
+# runtime; other languages fall back to (cached) online lookup. dict.db is a gitignored build
+# artifact — regenerate it here; it is staged into the APK by buildApk.sh.
+#
+#   ./scripts/stage-dict.sh          # build the corpus if app/src/main/assets/dict.db is absent
+#   ./scripts/stage-dict.sh --force  # rebuild it
+# =========================================================
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+ASSETS="app/src/main/assets"
+OUT="$ASSETS/dict.db"
+CACHE="build/dict-vendor"
+# WordNet 3.0 (Princeton), StarDict packaging by Hu Zheng — definitions + synsets, free to use.
+WN_URL="http://download.huzheng.org/dict.org/stardict-dictd_www.dict.org_wn-2.4.2.tar.bz2"
+
+[[ "${1:-}" == "--force" ]] && rm -f "$OUT"
+if [[ -f "$OUT" ]]; then
+    echo "dict.db present ($(du -h "$OUT" | cut -f1)) — pass --force to rebuild."
+    exit 0
+fi
+
+mkdir -p "$CACHE" "$ASSETS"
+tgz="$CACHE/$(basename "$WN_URL")"
+if [[ ! -f "$tgz" ]]; then
+    command -v curl >/dev/null 2>&1 || { echo "curl not found (needed to fetch WordNet)"; exit 1; }
+    echo "fetching WordNet → $tgz"
+    curl -sSL --max-time 300 -o "$tgz" "$WN_URL"
+fi
+dir="$CACHE/wn"
+if [[ ! -d "$dir" ]]; then
+    mkdir -p "$dir"
+    tar -xjf "$tgz" -C "$dir" --strip-components=1
+fi
+
+# Use the rust-toolchain.toml-pinned cargo if rustup is available (a Homebrew rust would fail MSRV).
+CARGO="cargo"
+if command -v rustup >/dev/null 2>&1; then
+    CARGO="$(dirname "$(rustup which cargo)")/cargo"
+fi
+"$CARGO" build -p build-dict --release
+rm -f "$OUT"
+./target/release/build-dict "$dir" "$OUT" en
+command -v sqlite3 >/dev/null 2>&1 && sqlite3 "$OUT" "VACUUM;" || true
+echo "staged $OUT ($(du -h "$OUT" | cut -f1))"


### PR DESCRIPTION
**Fixup.** PR #2 was stacked on `feat/annotation-persistence`, so merging it landed the dictionary into *that* branch, not the trunk — `feat/mvp` currently has the annotation + UI (PR #1) but **none of the dictionary work**. This PR lands the 9 missing commits onto `feat/mvp`.

## Contents (D1–D4, ADR-INKREAD-0009)
- D1 core text selection (`word_at` / `text_in_rect`)
- D2 `inkread-dict` engine + `build-dict` StarDict importer + WordNet corpus pipeline
- D3 JNI seam (6 exports + Kotlin decoders)
- D4 device UI (Define mode, tap/highlight → Kindle popup, Wiktionary online fallback)

Additive: new crates (`inkread-dict`, `build-dict`) + new files; the few shared files (`session.rs`, `jni.rs`, `ReaderActivity.kt`, manifest) are forward diffs on top of what's already in `feat/mvp`. Host-green; CI fix already present so the aarch64 cross-check passes.

After this merges, `feat/annotation-persistence` and `feat/dict-text-selection` can be deleted.