### PR TITLE
feat(search): in-document text search across PDF + EPUB (RR2)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -96,6 +96,13 @@ object NativeBridge {
     /** The text within the normalized rect on `page`; decode with [WireCodec.decodeSelection]. */
     external fun nativeTextInRect(handle: Long, page: Int, x0: Float, y0: Float, x1: Float, y1: Float): ByteArray
 
+    /**
+     * Find [query] on `page` (RR2 in-document search), case-insensitive. Returns the search wire
+     * (decode with [WireCodec.decodeSearch]): one match per occurrence with a snippet + highlight
+     * boxes. Call page-by-page so the scan stays memory-bounded.
+     */
+    external fun nativeSearchPage(handle: Long, page: Int, query: String): ByteArray
+
     /** Open the dictionary corpus at [path]; returns an opaque handle (0 on failure → throws). */
     external fun nativeDictOpen(path: String): Long
 
@@ -236,6 +243,12 @@ data class SelBox(val x0: Float, val y0: Float, val x1: Float, val y1: Float)
 data class Selection(val text: String, val boxes: List<SelBox>) {
     val isEmpty: Boolean get() = text.isEmpty()
 }
+
+/** One in-document search match on a page (RR2): highlight [boxes] + a context [snippet]. */
+data class SearchMatch(val boxes: List<SelBox>, val snippet: String)
+
+/** A search match resolved to its [page] (the shell pairs a page index with each [SearchMatch]). */
+data class SearchHit(val page: Int, val match: SearchMatch)
 
 /** A dictionary lookup result (RR12 / D3); [found] is false on a miss (try online next). */
 data class WordDefinition(
@@ -425,6 +438,39 @@ object WireCodec {
             off += 16
         }
         return Selection(text, boxes)
+    }
+
+    /**
+     * Decode the search wire from [NativeBridge.nativeSearchPage] (RR2): `[ver][matchCount u16]`
+     * then per match `[snippetLen u16][snippet][boxCount u16]` then per box `[x0,y0,x1,y1 f32]`.
+     * Mirrors `encode_search_wire` in `reader-core/document`.
+     */
+    fun decodeSearch(bytes: ByteArray): List<SearchMatch> {
+        require(bytes.size >= 3) { "search stream truncated" }
+        require(bytes[0] == WIRE_VERSION) { "bad search wire version ${bytes[0]}" }
+        val buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        val matchCount = buf.getShort(1).toInt() and 0xFFFF
+        var off = 3
+        val out = ArrayList<SearchMatch>(matchCount)
+        repeat(matchCount) {
+            require(bytes.size >= off + 2) { "snippet length truncated" }
+            val slen = buf.getShort(off).toInt() and 0xFFFF
+            off += 2
+            require(bytes.size >= off + slen) { "snippet overruns" }
+            val snippet = String(bytes, off, slen, Charsets.UTF_8)
+            off += slen
+            require(bytes.size >= off + 2) { "box count truncated" }
+            val count = buf.getShort(off).toInt() and 0xFFFF
+            off += 2
+            val boxes = ArrayList<SelBox>(count)
+            repeat(count) {
+                require(bytes.size >= off + 16) { "search box truncated" }
+                boxes.add(SelBox(buf.getFloat(off), buf.getFloat(off + 4), buf.getFloat(off + 8), buf.getFloat(off + 12)))
+                off += 16
+            }
+            out.add(SearchMatch(boxes, snippet))
+        }
+        return out
     }
 
     /**

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -144,6 +144,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private var moveStartX = 0f
     private var moveStartY = 0f
     private var movingSelection = false
+    /** In-document search (RR2): the current query's hits across the doc, and the index of the
+     *  one we're parked on. `searchBoxes` are the active hit's highlight boxes, drawn while the
+     *  reader is on `searchBoxesPage`. Read on both threads. */
+    @Volatile private var searchHits: List<SearchHit> = emptyList()
+    @Volatile private var searchIndex = -1
+    @Volatile private var searchQuery = ""
+    @Volatile private var searchBoxes: List<SelBox> = emptyList()
+    @Volatile private var searchBoxesPage = -1
+
     /** The in-progress stroke as interleaved view-px x,y; UI-thread only. */
     private val strokeBuf = ArrayList<Float>()
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -224,6 +233,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     }
     /** Filled square handles at the selection box corners (NeoReader frame 132). */
     private val selectionHandlePaint = Paint().apply { color = Color.BLACK; style = Paint.Style.FILL; isAntiAlias = true }
+    /** Search-hit highlight: a light translucent fill so the matched text stays readable on e-ink. */
+    private val searchFillPaint = Paint().apply { color = Color.parseColor("#33000000"); style = Paint.Style.FILL; isAntiAlias = true }
+    /** A crisp outline around the active search hit (the one the reader is parked on). */
+    private val searchBoxPaint = Paint().apply { color = Color.BLACK; style = Paint.Style.STROKE; strokeWidth = 2f; isAntiAlias = true }
     /** Small full-page thumbnail (from the fit render) for the zoom minimap; null until first render. */
     private var fitThumb: Bitmap? = null
     private var minimapActive = false
@@ -632,6 +645,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         for (s in pageStrokes) drawStroke(cv, s)
         // The active lasso selection's bounding box (ADR-INKREAD-0010).
         if (selectedIds.isNotEmpty() && selectionBounds.size == 4) drawSelectionBox(cv)
+        // The active in-document search hit's highlight boxes (RR2), if it lives on this page.
+        if (searchBoxesPage == currentPage) drawSearchHighlight(cv)
         // Keep a small full-page thumbnail from the fit render to drive the zoom minimap.
         if (zoom <= 1f) updateFitThumb(bmp)
         // Zoom minimap (top-right): full page + the current viewport window (RR5-FR3).
@@ -1075,6 +1090,184 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
     }
 
+    // ---- in-document search (RR2) ----
+
+    /** Draw the active search hit's highlight boxes on the page (a light fill + crisp outline). */
+    private fun drawSearchHighlight(canvas: Canvas) {
+        for (b in searchBoxes) {
+            val l = nToVx(b.x0); val t = nToVy(b.y0); val r = nToVx(b.x1); val btm = nToVy(b.y1)
+            canvas.drawRect(l, t, r, btm, searchFillPaint)
+            canvas.drawRect(l, t, r, btm, searchBoxPaint)
+        }
+    }
+
+    /**
+     * Prompt for a query, then scan the whole document on the engine thread (case-insensitive,
+     * PDF + EPUB). On hits, jump to the first and offer the results list; on none, a toast. The
+     * "Results" button reopens the last query's results without rescanning.
+     */
+    private fun showSearchDialog() {
+        if (docHandle == 0L) { openPicker(); return }
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val input = EditText(this).apply {
+            inputType = InputType.TYPE_CLASS_TEXT
+            imeOptions = android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH
+            setSingleLine(true)
+            hint = "Find in document"
+            setText(searchQuery)
+            setSelection(text?.length ?: 0)
+        }
+        val pad = dp(20)
+        val wrap = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(pad, dp(8), pad, 0)
+            addView(input, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+        }
+        val builder = AlertDialog.Builder(this)
+            .setTitle("Search")
+            .setView(wrap)
+            .setPositiveButton("Search") { _, _ -> runSearch(input.text.toString()) }
+            .setNegativeButton("Cancel", null)
+        if (searchHits.isNotEmpty()) builder.setNeutralButton("Results") { _, _ -> showSearchResults() }
+        val dialog = builder.create()
+        input.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH) {
+                dialog.dismiss(); runSearch(input.text.toString()); true
+            } else false
+        }
+        dialog.show()
+    }
+
+    /** Scan every page for [raw] on the engine thread, collecting hits (capped). Bails if the open
+     *  document changes mid-scan. Jumps to the first hit and reports the count on the UI thread. */
+    private fun runSearch(raw: String) {
+        val query = raw.trim()
+        if (query.isEmpty()) { clearSearch(); return }
+        val handle = docHandle
+        if (handle == 0L) return
+        Toast.makeText(this, "Searching…", Toast.LENGTH_SHORT).show()
+        engine.execute {
+            if (docHandle != handle) return@execute
+            val total = pageCount.coerceAtLeast(1)
+            val hits = ArrayList<SearchHit>()
+            var page = 0
+            while (page < total && hits.size < MAX_SEARCH_HITS) {
+                if (docHandle != handle) return@execute
+                val matches = try {
+                    WireCodec.decodeSearch(NativeBridge.nativeSearchPage(handle, page, query))
+                } catch (e: RuntimeException) {
+                    Log.e(TAG, "search p$page failed: ${e.message}"); emptyList()
+                }
+                for (m in matches) {
+                    hits.add(SearchHit(page, m))
+                    if (hits.size >= MAX_SEARCH_HITS) break
+                }
+                page++
+            }
+            searchQuery = query
+            searchHits = hits
+            searchIndex = -1
+            runOnUiThread {
+                if (hits.isEmpty()) {
+                    Toast.makeText(this, "No matches for \"$query\"", Toast.LENGTH_SHORT).show()
+                } else {
+                    val capped = if (hits.size >= MAX_SEARCH_HITS) " (first $MAX_SEARCH_HITS)" else ""
+                    val plural = if (hits.size == 1) "" else "es"
+                    Toast.makeText(this, "${hits.size} match$plural$capped", Toast.LENGTH_SHORT).show()
+                    gotoSearchHit(0)
+                }
+            }
+        }
+    }
+
+    /** Park on search hit [i]: set its highlight boxes and jump to its page (the highlight draws
+     *  in [renderAndBlit] once the reader is on that page). */
+    private fun gotoSearchHit(i: Int) {
+        val hits = searchHits
+        if (i < 0 || i >= hits.size) return
+        val hit = hits[i]
+        searchIndex = i
+        searchBoxes = hit.match.boxes
+        searchBoxesPage = hit.page
+        postJump(hit.page)
+    }
+
+    /** Step to the next/previous hit (wrapping). With no active search, reopens the search dialog. */
+    private fun searchStep(delta: Int) {
+        val hits = searchHits
+        if (hits.isEmpty()) { showSearchDialog(); return }
+        val n = hits.size
+        val next = (((searchIndex + delta) % n) + n) % n
+        gotoSearchHit(next)
+        Toast.makeText(this, "${next + 1} / $n", Toast.LENGTH_SHORT).show()
+    }
+
+    /** A bottom sheet listing the current query's hits (page + snippet); tap a row to jump. */
+    private fun showSearchResults() {
+        val hits = searchHits
+        if (hits.isEmpty()) { showSearchDialog(); return }
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+        val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        hits.forEachIndexed { i, hit ->
+            list.addView(LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(dp(18), dp(12), dp(18), dp(12))
+                isClickable = true
+                setOnClickListener { dialog.dismiss(); gotoSearchHit(i) }
+                addView(TextView(this@ReaderActivity).apply {
+                    text = "p. ${hit.page + 1}"; setTextColor(Color.parseColor("#666666")); textSize = 11f
+                })
+                addView(TextView(this@ReaderActivity).apply {
+                    text = hit.match.snippet; setTextColor(Color.BLACK); textSize = 14f; setPadding(0, dp(2), 0, 0)
+                })
+            })
+            list.addView(View(this).apply { setBackgroundColor(Color.parseColor("#22000000")) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 1))
+        }
+        // Header: a count label flanked by Prev/Next steppers (step renders behind the sheet).
+        fun stepper(label: String, delta: Int) = TextView(this).apply {
+            text = label; setTextColor(Color.BLACK); textSize = 18f; gravity = Gravity.CENTER
+            setPadding(dp(16), dp(8), dp(16), dp(8)); isClickable = true
+            setOnClickListener { searchStep(delta) }
+        }
+        val header = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            addView(stepper("◀", -1))
+            addView(TextView(this@ReaderActivity).apply {
+                text = "${hits.size} results for \"$searchQuery\""
+                setTextColor(Color.BLACK); textSize = 13f; gravity = Gravity.CENTER
+                setPadding(dp(8), dp(12), dp(8), dp(8))
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            addView(stepper("▶", +1))
+        }
+        val container = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.WHITE)
+            addView(header)
+            addView(ScrollView(this@ReaderActivity).apply { addView(list) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
+        }
+        dialog.setContentView(container)
+        dialog.window?.apply {
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, (resources.displayMetrics.heightPixels * 0.7f).toInt())
+            setGravity(Gravity.BOTTOM)
+            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.WHITE))
+        }
+        dialog.show()
+    }
+
+    /** Clear the active search and wipe its on-page highlight. */
+    private fun clearSearch() {
+        searchHits = emptyList(); searchIndex = -1; searchQuery = ""; searchBoxes = emptyList()
+        val hadBoxes = searchBoxesPage >= 0
+        searchBoxesPage = -1
+        if (hadBoxes) engine.execute { renderAndBlit(); adapter.refreshFull() }
+    }
+
     /**
      * The reader's bottom control bar (RR16/RR25), KOReader-style: a thin panel **hugging the
      * bottom edge** — a page slider with a tappable page indicator, above a flat row of controls
@@ -1181,6 +1374,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // (Bookmark toggle moved to the top-right corner dog-ear; "Marks" lists them.)
         control(R.drawable.ic_menu_marks, "Marks") { showBookmarks() }
         control(R.drawable.ic_menu_contents, "Contents") { showContentsLazy() }
+        control(R.drawable.ic_menu_search, "Search") { showSearchDialog() }
         control(R.drawable.ic_menu_zoom_out, "Zoom −") { zoomBy(1f / ZOOM_STEP) }
         control(R.drawable.ic_menu_zoom_in, "Zoom +") { zoomBy(ZOOM_STEP) }
         control(R.drawable.ic_menu_export, "Export") { showExportDialog() }
@@ -2626,6 +2820,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // Supernote folders the Partner app syncs — searched to place the export beside the original.
         val SYNCED_DIRS = arrayOf("Document", "EXPORT", "Note", "INBOX", "MyStyle", "Download")
         const val SELECTION_HANDLE_PX = 8f // half-size of the square corner handles on the selection box.
+        const val MAX_SEARCH_HITS = 1000 // cap a query's collected hits to bound memory + scan time (RR2/RR19).
+        const val HIGHLIGHT_WIDTH_PX = 30f // wide marker band (vs INK_STROKE_WIDTH for the pen).
         const val STROKE_PAUSE_MS = 600L // commit a stroke after this pen-pause (swallowed-UP net).
         const val LONG_PRESS_MS = 500L // hold the pen this long (≈still) on a word → look it up.
         const val LONG_PRESS_SLOP_PX = 16f // movement beyond this cancels the long-press (it's a stroke).
@@ -2639,7 +2835,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val CORE_TOOL_HIGHLIGHTER = 1
         const val CORE_TOOL_ERASER = 2
         const val INK_COLOR_BLACK = 0x000000FF // packed (r<<24|g<<16|b<<8|a): opaque black.
-        const val HIGHLIGHT_WIDTH_PX = 30f // wide marker band (vs INK_STROKE_WIDTH for the pen).
         // REAL colours are stored per stroke (packed r<<24|g<<16|b<<8|a) and persisted in the
         // .inkbin sidecar, so a colour device / a future PDF-annotation export shows true colour.
         // On the MONOCHROME Supernote they just render as greys. Re-tap a tool to cycle its colour.

--- a/app/src/main/res/drawable/ic_menu_search.xml
+++ b/app/src/main/res/drawable/ic_menu_search.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@android:color/black" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/inkread-epub/src/lib.rs
+++ b/inkread-epub/src/lib.rs
@@ -21,7 +21,7 @@ pub mod layout;
 pub mod render;
 pub use content::{parse_blocks, Block, Inline, TextRun};
 pub use layout::{paginate, LayoutLine, LayoutOpts, Metrics, Page, PlacedRun};
-pub use render::{render_page, AbFont, GrayCanvas};
+pub use render::{page_glyphs, render_page, AbFont, GrayCanvas, PlacedGlyph};
 
 /// The error surface for EPUB parsing — mirrors `inkread-dict`'s shape so the `reader-core` adapter
 /// maps it uniformly. Never panics across the boundary (RR21-FR3).

--- a/inkread-epub/src/render.rs
+++ b/inkread-epub/src/render.rs
@@ -139,6 +139,73 @@ pub fn render_page(page: &Page, opts: &LayoutOpts, font: &AbFont, canvas: &mut G
     }
 }
 
+/// A glyph with its pixel box on the page (top-left origin), mirroring [`render_page`]'s layout
+/// transform. Feeds text selection + in-document search in `reader-core` (which normalizes the box
+/// to `[0,1]`). The vertical extent is the **line box** (`top..top+height`) so boxes on a line
+/// align, matching the selection logic's "same line" grouping.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlacedGlyph {
+    pub ch: char,
+    pub x0: f32,
+    pub y0: f32,
+    pub x1: f32,
+    pub y1: f32,
+}
+
+/// Extract a laid-out [`Page`]'s glyphs as positioned boxes (pixel space), walking runs **exactly**
+/// like [`render_page`] so a selection/search highlight lands on the painted glyphs. A single space
+/// glyph is synthesized between consecutive runs on a line (the layout drops inter-word spaces into
+/// run `x` offsets) so multi-word selection/search reads with spaces. Rule lines contribute nothing.
+#[must_use]
+pub fn page_glyphs(page: &Page, opts: &LayoutOpts, font: &AbFont) -> Vec<PlacedGlyph> {
+    let margin = opts.margin;
+    let mut out = Vec::new();
+    for line in &page.lines {
+        if line.rule {
+            continue;
+        }
+        let y0 = margin + line.top;
+        let y1 = y0 + line.height;
+        let mut prev_run_end: Option<f32> = None;
+        for run in &line.runs {
+            let sf = font.font.as_scaled(PxScale::from(run.size_px));
+            let run_start = margin + run.x;
+            // Bridge the gap to the previous run on this line with a space glyph.
+            if let Some(end) = prev_run_end {
+                if run_start > end {
+                    out.push(PlacedGlyph {
+                        ch: ' ',
+                        x0: end,
+                        y0,
+                        x1: run_start,
+                        y1,
+                    });
+                }
+            }
+            let mut pen_x = run_start;
+            let mut prev = None;
+            for ch in run.text.chars() {
+                let id = font.font.glyph_id(ch);
+                if let Some(p) = prev {
+                    pen_x += sf.kern(p, id);
+                }
+                let adv = sf.h_advance(id);
+                out.push(PlacedGlyph {
+                    ch,
+                    x0: pen_x,
+                    y0,
+                    x1: pen_x + adv,
+                    y1,
+                });
+                pen_x += adv;
+                prev = Some(id);
+            }
+            prev_run_end = Some(pen_x);
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,6 +262,23 @@ mod tests {
             .filter(|&(y, x)| canvas.pixels[y * 400 + x] < 250)
             .count();
         assert_eq!(top_band, 0, "no ink above the top margin");
+    }
+
+    #[test]
+    fn page_glyphs_recovers_text_in_reading_order() {
+        let font = AbFont::default_font();
+        let opts = LayoutOpts::new(400.0, 600.0, 18.0);
+        let pages = paginate(&[paragraph("Hello reflowed world")], &opts, &font);
+        let glyphs = page_glyphs(&pages[0], &opts, &font);
+        let text: String = glyphs.iter().map(|g| g.ch).collect();
+        assert_eq!(text, "Hello reflowed world", "words rejoined with spaces");
+        // Boxes are inside the page and ordered left-to-right on the (single) line.
+        assert!(glyphs.iter().all(|g| g.x0 >= 0.0 && g.x1 <= 400.0));
+        let first_word = glyphs
+            .iter()
+            .take_while(|g| g.ch != ' ')
+            .collect::<Vec<_>>();
+        assert!(first_word.windows(2).all(|w| w[0].x0 <= w[1].x0));
     }
 
     #[test]

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -496,6 +496,10 @@ impl Document for PdfBackend {
     fn text_in_rect(&self, page: usize, rect: NormRect) -> TextSelection {
         text_select::text_in_rect(&self.page_chars(page), rect)
     }
+
+    fn search_page(&self, page: usize, query: &str) -> Vec<crate::document::SearchMatch> {
+        text_select::find_matches(&self.page_chars(page), query)
+    }
 }
 
 /// Resolve a pdfium link's target (RR11-FR3): a direct destination or a GoTo/URI action.

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -8,7 +8,7 @@ pub mod fixed;
 pub mod reflow;
 pub mod text_select;
 
-pub use text_select::{CharBox, NormRect, TextSelection};
+pub use text_select::{CharBox, NormRect, SearchMatch, TextSelection};
 
 use crate::error::CoreResult;
 use crate::render::PixelBuffer;
@@ -197,6 +197,36 @@ pub fn encode_selection_wire(sel: &TextSelection) -> Vec<u8> {
     out
 }
 
+/// Wire-format version for a page's [`SearchMatch`]es the JNI bridge ships to the shell (RR2 search).
+const SEARCH_WIRE_VERSION: u8 = 0x01;
+
+/// Encode one page's search matches for the shell — pure marshaling (no device/JNI types), so it is
+/// host-tested. Layout (little-endian): `[ver=1][match_count: u16]` then, per match,
+/// `[snippet_len: u16][snippet: utf-8 × snippet_len][box_count: u16]` followed by `box_count` ×
+/// `[x0 f32][y0 f32][x1 f32][y1 f32]`. Counts/lengths saturate rather than panic (RR21-FR3).
+#[must_use]
+pub fn encode_search_wire(matches: &[SearchMatch]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(SEARCH_WIRE_VERSION);
+    let count = u16::try_from(matches.len()).unwrap_or(u16::MAX);
+    out.extend_from_slice(&count.to_le_bytes());
+    for m in matches.iter().take(count as usize) {
+        let bytes = m.snippet.as_bytes();
+        let slen = u16::try_from(bytes.len()).unwrap_or(u16::MAX);
+        out.extend_from_slice(&slen.to_le_bytes());
+        out.extend_from_slice(&bytes[..slen as usize]);
+        let bcount = u16::try_from(m.boxes.len()).unwrap_or(u16::MAX);
+        out.extend_from_slice(&bcount.to_le_bytes());
+        for b in m.boxes.iter().take(bcount as usize) {
+            out.extend_from_slice(&b.x0.to_le_bytes());
+            out.extend_from_slice(&b.y0.to_le_bytes());
+            out.extend_from_slice(&b.x1.to_le_bytes());
+            out.extend_from_slice(&b.y1.to_le_bytes());
+        }
+    }
+    out
+}
+
 /// The core trait every format implements (M0 subset).
 ///
 /// Render targets a borrowed [`PixelBuffer`] (Fork 4); the backend white-fills before
@@ -270,6 +300,14 @@ pub trait Document {
     /// D1). Default: an empty selection.
     fn text_in_rect(&self, _page: usize, _rect: NormRect) -> TextSelection {
         TextSelection::default()
+    }
+
+    /// Find `query` on `page` (case-insensitive, whitespace-normalized substring) — RR2 in-document
+    /// search. Returns one [`SearchMatch`] per occurrence (highlight boxes + context snippet) in
+    /// reading order. The shell drives this page-by-page so the scan stays memory-bounded (RR19).
+    /// Default: empty — a format with no text layer is not searchable (never panics, RR21-FR3).
+    fn search_page(&self, _page: usize, _query: &str) -> Vec<SearchMatch> {
+        Vec::new()
     }
 
     /// Write `page_ink` into the document and save it to `out_path` (ADR-INKREAD-0005). [`ExportMode`]
@@ -492,5 +530,67 @@ mod tests {
         let w = encode_selection_wire(&TextSelection::default());
         // ver + text_len(0) + box_count(0)
         assert_eq!(w, vec![SELECTION_WIRE_VERSION, 0, 0, 0, 0]);
+    }
+
+    // RR2 search: a page's matches encode snippet + boxes, decoded here the way the Kotlin shell does.
+    #[test]
+    fn encode_search_wire_roundtrips_matches() {
+        let matches = vec![
+            SearchMatch {
+                boxes: vec![NormRect {
+                    x0: 0.1,
+                    y0: 0.2,
+                    x1: 0.4,
+                    y1: 0.25,
+                }],
+                snippet: "…the needle here…".into(),
+            },
+            SearchMatch {
+                boxes: vec![
+                    NormRect {
+                        x0: 0.0,
+                        y0: 0.5,
+                        x1: 0.3,
+                        y1: 0.55,
+                    },
+                    NormRect {
+                        x0: 0.0,
+                        y0: 0.56,
+                        x1: 0.2,
+                        y1: 0.61,
+                    },
+                ],
+                snippet: "two-line match".into(),
+            },
+        ];
+        let b = encode_search_wire(&matches);
+        assert_eq!(b[0], SEARCH_WIRE_VERSION);
+        assert_eq!(u16::from_le_bytes([b[1], b[2]]), 2);
+
+        let mut off = 3usize;
+        let read_f32 = |b: &[u8], o: usize| f32::from_le_bytes(b[o..o + 4].try_into().unwrap());
+        // match 0
+        let slen = u16::from_le_bytes([b[off], b[off + 1]]) as usize;
+        off += 2;
+        assert_eq!(
+            String::from_utf8(b[off..off + slen].to_vec()).unwrap(),
+            "…the needle here…"
+        );
+        off += slen;
+        assert_eq!(u16::from_le_bytes([b[off], b[off + 1]]), 1);
+        off += 2;
+        assert!((read_f32(&b, off) - 0.1).abs() < 1e-6);
+        off += 16;
+        // match 1: 2 boxes
+        let slen = u16::from_le_bytes([b[off], b[off + 1]]) as usize;
+        off += 2 + slen;
+        assert_eq!(u16::from_le_bytes([b[off], b[off + 1]]), 2);
+        off += 2 + 32;
+        assert_eq!(off, b.len(), "no trailing bytes");
+    }
+
+    #[test]
+    fn encode_search_wire_empty_is_header_only() {
+        assert_eq!(encode_search_wire(&[]), vec![SEARCH_WIRE_VERSION, 0, 0]);
     }
 }

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -13,10 +13,11 @@
 use std::cell::{Cell, RefCell};
 
 use inkread_epub::layout::{paginate, LayoutOpts, Page};
-use inkread_epub::render::{render_page as raster_page, AbFont, GrayCanvas};
+use inkread_epub::render::{page_glyphs, render_page as raster_page, AbFont, GrayCanvas};
 use inkread_epub::{parse_blocks, Block, EpubPackage, NavPoint};
 
-use crate::document::{Document, DocumentMetadata, TocEntry};
+use crate::document::text_select::{self, CharBox, NormRect, TextSelection};
+use crate::document::{Document, DocumentMetadata, SearchMatch, TocEntry};
 use crate::error::{CoreError, CoreResult};
 use crate::render::PixelBuffer;
 
@@ -107,6 +108,30 @@ impl EpubBackend {
         }
     }
 
+    /// The page's glyphs as normalized [`CharBox`]es — the input to the pure selection + search
+    /// logic (RR11 / RR2). Mirrors the PDF backend's `page_chars`: the layout's positioned glyphs
+    /// (pixel space) normalized to `[0,1]`. An out-of-range page contributes nothing (RR21-FR3).
+    fn page_chars(&self, index: usize) -> Vec<CharBox> {
+        let laid = self.laid.borrow();
+        let Some(page) = laid.pages.get(index) else {
+            return Vec::new();
+        };
+        let pw = laid.opts.page_w.max(1.0);
+        let ph = laid.opts.page_h.max(1.0);
+        page_glyphs(page, &laid.opts, &self.font)
+            .into_iter()
+            .map(|g| CharBox {
+                ch: g.ch,
+                rect: NormRect {
+                    x0: (g.x0 / pw).clamp(0.0, 1.0),
+                    y0: (g.y0 / ph).clamp(0.0, 1.0),
+                    x1: (g.x1 / pw).clamp(0.0, 1.0),
+                    y1: (g.y1 / ph).clamp(0.0, 1.0),
+                },
+            })
+            .collect()
+    }
+
     /// The chapter index that global `page` falls in (the last chapter whose start ≤ page).
     fn chapter_of(&self, page: usize) -> usize {
         let laid = self.laid.borrow();
@@ -154,6 +179,18 @@ impl Document for EpubBackend {
             .iter()
             .map(|n| resolve_nav(n, &self.chapter_keys, &laid.chapter_start))
             .collect()
+    }
+
+    fn word_at(&self, page: usize, x: f32, y: f32) -> Option<TextSelection> {
+        text_select::word_at(&self.page_chars(page), x, y)
+    }
+
+    fn text_in_rect(&self, page: usize, rect: NormRect) -> TextSelection {
+        text_select::text_in_rect(&self.page_chars(page), rect)
+    }
+
+    fn search_page(&self, page: usize, query: &str) -> Vec<SearchMatch> {
+        text_select::find_matches(&self.page_chars(page), query)
     }
 
     fn set_text_scale(&self, scale: f32, current_page: usize) -> Option<usize> {
@@ -307,6 +344,39 @@ mod tests {
         assert_eq!(new_page, b.toc()[1].target_page.unwrap());
         // PDF-style fixed layout would return None; EPUB returns Some.
         assert!(b.set_text_scale(1.0, 0).is_some());
+    }
+
+    #[test]
+    fn page_chars_recovers_words_for_selection() {
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        let _ = render(&b, 0, 400, 600); // settle layout at this viewport
+        let chars = b.page_chars(0);
+        assert!(!chars.is_empty(), "first page exposes glyphs");
+        let text: String = chars.iter().map(|c| c.ch).collect();
+        assert!(
+            text.contains(' '),
+            "inter-word spaces are synthesized: {text:?}"
+        );
+        // Every box is on-page and non-degenerate horizontally for non-space glyphs.
+        assert!(chars.iter().all(|c| c.rect.x0 >= 0.0 && c.rect.x1 <= 1.0));
+    }
+
+    #[test]
+    fn search_finds_text_on_the_page_it_lives_on() {
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        let _ = render(&b, 0, 400, 600);
+        // Pull a real word off page 0 and search for it.
+        let text: String = b.page_chars(0).iter().map(|c| c.ch).collect();
+        let word = text
+            .split_whitespace()
+            .find(|w| w.chars().all(|c| c.is_alphabetic()) && w.len() >= 4)
+            .expect("a searchable word on page 0")
+            .to_string();
+        let hits = b.search_page(0, &word);
+        assert!(!hits.is_empty(), "found {word:?} on page 0");
+        assert!(hits[0].boxes.iter().all(|bx| bx.x1 >= bx.x0));
+        // The same query in a wildly different case still matches (case-insensitive).
+        assert!(!b.search_page(0, &word.to_uppercase()).is_empty());
     }
 
     #[test]

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -75,6 +75,120 @@ impl TextSelection {
     }
 }
 
+/// One occurrence of a search query on a page (RR2 in-document search).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SearchMatch {
+    /// Highlight boxes, one per line run the match spans (like a [`TextSelection`]) — for
+    /// drawing the on-page highlight and the dirty-rect refresh when the reader jumps to it.
+    pub boxes: Vec<NormRect>,
+    /// A short context snippet around the match (for the results list), with `…` where trimmed.
+    pub snippet: String,
+}
+
+/// Context characters kept on each side of a match for its results-list snippet.
+const SNIPPET_CONTEXT: usize = 28;
+
+/// Case-insensitive, whitespace-normalized substring search over a page's `chars`. Returns one
+/// [`SearchMatch`] per **non-overlapping** occurrence, left to right, each with per-line highlight
+/// boxes and a context snippet. An empty or whitespace-only `query` yields no matches. Pure and
+/// dependency-free (host-tested) — the backend only supplies the page's `CharBox`es (RR21-FR3:
+/// never panics).
+#[must_use]
+pub fn find_matches(chars: &[CharBox], query: &str) -> Vec<SearchMatch> {
+    let needle: Vec<char> = normalize_query(query);
+    if needle.is_empty() {
+        return Vec::new();
+    }
+    // Normalized page text as chars, with a parallel map from each normalized char back to its
+    // source `chars` index (so a hit's positions resolve to highlight boxes + a snippet).
+    let mut hay: Vec<char> = Vec::with_capacity(chars.len());
+    let mut src: Vec<usize> = Vec::with_capacity(chars.len());
+    let mut prev_space = false;
+    let mut prev_rect: Option<NormRect> = None;
+    for (i, c) in chars.iter().enumerate() {
+        if c.ch.is_whitespace() {
+            if !prev_space && !hay.is_empty() {
+                hay.push(' ');
+                src.push(i);
+                prev_space = true;
+            }
+        } else {
+            // A line break with no explicit space glyph (text wrap) still separates words, so the
+            // query "foo bar" matches across the wrap.
+            if !prev_space {
+                if let Some(pr) = prev_rect {
+                    if !same_line(&pr, &c.rect) {
+                        hay.push(' ');
+                        src.push(i);
+                    }
+                }
+            }
+            for lc in c.ch.to_lowercase() {
+                hay.push(lc);
+                src.push(i);
+            }
+            prev_space = false;
+            prev_rect = Some(c.rect);
+        }
+    }
+
+    let n = needle.len();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + n <= hay.len() {
+        if hay[i..i + n] == needle[..] {
+            let s = src[i];
+            let e = src[i + n - 1];
+            out.push(SearchMatch {
+                boxes: line_boxes(&chars[s..=e]),
+                snippet: snippet_around(&hay, i, n),
+            });
+            i += n; // non-overlapping: resume past this match
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Lowercase + collapse internal whitespace + trim a query into its char sequence.
+fn normalize_query(query: &str) -> Vec<char> {
+    let mut out: Vec<char> = Vec::new();
+    let mut prev_space = false;
+    for c in query.chars() {
+        if c.is_whitespace() {
+            if !out.is_empty() && !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        } else {
+            for lc in c.to_lowercase() {
+                out.push(lc);
+            }
+            prev_space = false;
+        }
+    }
+    while out.last() == Some(&' ') {
+        out.pop();
+    }
+    out
+}
+
+/// A `…`-trimmed context window of `hay` around the match at `[start, start+len)`.
+fn snippet_around(hay: &[char], start: usize, len: usize) -> String {
+    let from = start.saturating_sub(SNIPPET_CONTEXT);
+    let to = (start + len + SNIPPET_CONTEXT).min(hay.len());
+    let mut s = String::new();
+    if from > 0 {
+        s.push('…');
+    }
+    s.extend(&hay[from..to]);
+    if to < hay.len() {
+        s.push('…');
+    }
+    s
+}
+
 /// Vertical tolerance (page-height fraction) for "same line" / nearest-on-line tap matching.
 const LINE_MARGIN: f32 = 0.012;
 /// Horizontal tolerance (page-width fraction) for snapping a near-miss tap to a glyph.
@@ -317,6 +431,61 @@ mod tests {
             },
         );
         assert!(sel.is_empty());
+    }
+
+    #[test]
+    fn find_matches_is_case_insensitive_and_non_overlapping() {
+        let chars = line("the Cat sat on the cat mat", 0.0, 1.0, 0.10, 0.03);
+        let m = find_matches(&chars, "cat");
+        assert_eq!(m.len(), 2, "both 'Cat' and 'cat' match, case-insensitively");
+        assert!(m[0].boxes.len() == 1 && m[1].boxes.len() == 1);
+    }
+
+    #[test]
+    fn find_matches_spans_words_with_normalized_whitespace() {
+        let chars = line("the quick fox", 0.0, 0.6, 0.10, 0.03);
+        // a multi-word query matches across the inter-word space
+        let m = find_matches(&chars, "quick fox");
+        assert_eq!(m.len(), 1);
+        assert!(m[0].snippet.contains("quick fox"));
+    }
+
+    #[test]
+    fn find_matches_spans_two_lines_into_two_boxes() {
+        let mut chars = line("hello", 0.0, 0.3, 0.10, 0.03);
+        chars.extend(line("world", 0.0, 0.3, 0.16, 0.03));
+        // The two words sit on different lines; "hello world" (normalized) spans both.
+        let m = find_matches(&chars, "hello world");
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0].boxes.len(), 2, "a match across two lines → two boxes");
+    }
+
+    #[test]
+    fn find_matches_empty_or_absent_query_is_empty() {
+        let chars = line("anything", 0.0, 0.4, 0.1, 0.03);
+        assert!(find_matches(&chars, "").is_empty());
+        assert!(find_matches(&chars, "   ").is_empty());
+        assert!(find_matches(&chars, "zzz").is_empty());
+    }
+
+    #[test]
+    fn find_matches_snippet_has_ellipses_when_trimmed() {
+        let chars = line(
+            "a very long line of text that completely surrounds the needle that is buried \
+             deep inside the middle of a long body of running text on the page",
+            0.0,
+            1.0,
+            0.1,
+            0.03,
+        );
+        let m = find_matches(&chars, "needle");
+        assert_eq!(m.len(), 1);
+        assert!(
+            m[0].snippet.starts_with('…') && m[0].snippet.ends_with('…'),
+            "snippet trimmed on both sides: {:?}",
+            m[0].snippet
+        );
+        assert!(m[0].snippet.contains("needle"));
     }
 
     #[test]

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -35,7 +35,9 @@ use std::sync::Arc;
 use inkread_ink::{InkColor, Tool};
 
 use crate::dict::{encode_definition_wire, Dict};
-use crate::document::{encode_links_wire, encode_selection_wire, encode_toc_wire, NormRect};
+use crate::document::{
+    encode_links_wire, encode_search_wire, encode_selection_wire, encode_toc_wire, NormRect,
+};
 use crate::error::{CoreError, CoreResult};
 use crate::persistence::ink_store::{FsInkStore, InkStore};
 use crate::persistence::sidecar::SidecarPaths;
@@ -938,6 +940,27 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeTextInRect<
         let target = if page < 0 { 0usize } else { page as usize };
         let sel = session.text_in_rect(target, NormRect { x0, y0, x1, y1 });
         env.byte_array_from_slice(&encode_selection_wire(&sel))
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+/// Find `query` on `page` (RR2 in-document search). Returns the search wire (decode:
+/// `WireCodec.decodeSearch`): the page's matches as snippet + highlight boxes. The shell calls this
+/// page-by-page so the scan stays memory-bounded.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSearchPage<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    page: jint,
+    query: JString<'local>,
+) -> JByteArray<'local> {
+    env.with_env(|env| -> jni::errors::Result<JByteArray<'local>> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let query: String = query.try_to_string(env)?;
+        let target = if page < 0 { 0usize } else { page as usize };
+        let matches = session.search_page(target, &query);
+        env.byte_array_from_slice(&encode_search_wire(&matches))
     })
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -440,6 +440,13 @@ impl ReaderSession {
         self.document.text_in_rect(page, rect)
     }
 
+    /// Find `query` on `page` (RR2 in-document search) — a pass-through to
+    /// [`Document::search_page`]. The shell drives the scan page-by-page so it stays memory-bounded.
+    #[must_use]
+    pub fn search_page(&self, page: usize, query: &str) -> Vec<crate::document::SearchMatch> {
+        self.document.search_page(page, query)
+    }
+
     /// Navigate to a TOC entry's target page (RR11-AC1). An unresolved entry (no
     /// `target_page`) does not move and returns no refresh commands.
     pub fn jump_to_toc(&mut self, entry: &TocEntry) -> Vec<RefreshCommand> {


### PR DESCRIPTION
In-document text search, host-built and verified end to end (PDF + EPUB).

## What
- `text_select::find_matches` — pure, host-tested: case-insensitive, whitespace- and line-break-normalized substring search; returns per-line highlight boxes + a `…`-trimmed context snippet (so `foo bar` matches across a wrap).
- `Document::search_page(page, query)` trait method; session pass-through.
- **PDF** searches via its existing `page_chars`.
- **EPUB**: new `inkread_epub::page_glyphs` (mirrors the render transform) → new `EpubBackend::page_chars`, which also gives EPUB `word_at`/`text_in_rect` for free (closes the `reflow.rs` selection follow-up).
- `encode_search_wire` codec + `nativeSearchPage` JNI.
- Kotlin: `WireCodec.decodeSearch` + `SearchMatch`/`SearchHit`, a Search control in the bottom bar (`ic_menu_search`), a query dialog, a results bottom-sheet with prev/next steppers, a memory-bounded page-by-page scan (capped at 1000 hits), and an on-page highlight overlay.

## Verification
- 175 reader-core tests pass; `cargo clippy --workspace -D warnings` clean; `cargo fmt --check` clean.
- JNI seam cross-compiles for `aarch64-linux-android`; `:app:compileDebugKotlin` succeeds.
- Not yet run on a Supernote (repo's known screencap-black constraint).