### PR TITLE
feat(lua): inkread-lua crate — embedded Lua 5.4 runtime scaffold (RR13, L1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "build-dict"
 version = "0.1.0"
 dependencies = [
@@ -262,10 +272,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -440,6 +466,13 @@ name = "inkread-ink"
 version = "0.1.0"
 
 [[package]]
+name = "inkread-lua"
+version = "0.1.0"
+dependencies = [
+ "mlua",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +594,25 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lua-src"
+version = "547.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.5.12+a4f56a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
+dependencies = [
+ "cc",
+ "which",
+]
 
 [[package]]
 name = "markup5ever"
@@ -587,6 +645,34 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mlua"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
+dependencies = [
+ "bstr",
+ "either",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -880,6 +966,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1285,6 +1384,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1471,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 # RR1-AC3: bare `cargo test -p reader-core` builds with `jni` absent from the resolved graph.
 [workspace]
 resolver = "2"
-members = ["build-dict", "device-eink", "inkread-dict", "inkread-epub", "inkread-ink", "reader-core", "reader-desktop"]
+members = ["build-dict", "device-eink", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "reader-core", "reader-desktop"]
 
 [workspace.package]
 version = "0.1.0"
@@ -23,6 +23,7 @@ device-eink = { path = "device-eink" }
 inkread-dict = { path = "inkread-dict" }
 inkread-epub = { path = "inkread-epub" }
 inkread-ink = { path = "inkread-ink" }
+inkread-lua = { path = "inkread-lua" }
 reader-core = { path = "reader-core" }
 
 # External — versions verified against docs.rs at implementation time.
@@ -40,6 +41,9 @@ serde_json = "1"
 # rusqlite with `bundled` SQLite (compiled from source) so the host build is hermetic and the
 # Android cdylib cross-compiles the same engine — no system-library dependency (ADR Decision 4).
 rusqlite = { version = "0.32", features = ["bundled"] }
+# mlua with vendored Lua 5.4 (compiled from source via cc, like rusqlite `bundled`) — the embedded
+# plugin runtime (RR13). MIT-licensed (Lua itself is MIT) → AGPL-compatible (check-licenses.sh).
+mlua = { version = "0.10", features = ["lua54", "vendored"] }
 
 [profile.release]
 # A reader on a battery e-ink device: optimize for size + speed, strip symbols.

--- a/LICENSES-3RDPARTY.md
+++ b/LICENSES-3RDPARTY.md
@@ -13,10 +13,12 @@ the dependency set changes.
 
 - **WordNet 3.0** (Princeton University) — the English dictionary corpus (definitions + synsets) imported into `app/src/main/assets/dict.db` by `scripts/stage-dict.sh`, sourced from the Hu Zheng StarDict packaging (`download.huzheng.org`). **WordNet License** — permissive: free use/redistribution provided the Princeton copyright + license notice is retained (ADR-INKREAD-0009 / RR22-FR5). The `dict.db` artifact is gitignored and regenerated at build time. Other languages are looked up online (opt-in) and cached, not bundled.
 
-## Rust dependencies (106 crates, all features)
+## Rust dependencies (163 crates, all features)
 
 | Crate | Version | License (SPDX) |
 |---|---|---|
+| ab_glyph | 0.2.32 | Apache-2.0 |
+| ab_glyph_rasterizer | 0.1.10 | Apache-2.0 |
 | adler2 | 2.0.1 | 0BSD OR MIT OR Apache-2.0 |
 | ahash | 0.8.12 | MIT OR Apache-2.0 |
 | android_system_properties | 0.1.5 | MIT/Apache-2.0 |
@@ -25,6 +27,7 @@ the dependency set changes.
 | autocfg | 1.5.1 | Apache-2.0 OR MIT |
 | bitflags | 1.3.2 | MIT/Apache-2.0 |
 | bitflags | 2.13.0 | MIT OR Apache-2.0 |
+| bstr | 1.12.1 | MIT OR Apache-2.0 |
 | bumpalo | 3.20.3 | MIT OR Apache-2.0 |
 | bytemuck | 1.25.0 | Zlib OR Apache-2.0 OR MIT |
 | byteorder | 1.5.0 | Unlicense OR MIT |
@@ -38,9 +41,20 @@ the dependency set changes.
 | console_log | 1.0.0 | MIT/Apache-2.0 |
 | core-foundation-sys | 0.8.7 | MIT OR Apache-2.0 |
 | crc32fast | 1.5.0 | MIT OR Apache-2.0 |
+| cssparser | 0.37.0 | MPL-2.0 |
+| cssparser-macros | 0.7.0 | MPL-2.0 |
+| derive_more | 2.1.1 | MIT |
+| derive_more-impl | 2.1.1 | MIT |
+| dtoa | 1.0.11 | MIT OR Apache-2.0 |
+| dtoa-short | 0.3.5 | MPL-2.0 |
+| ego-tree | 0.11.0 | ISC |
 | either | 1.16.0 | MIT OR Apache-2.0 |
+| env_home | 0.1.0 | MIT OR Apache-2.0 |
+| equivalent | 1.0.2 | Apache-2.0 OR MIT |
+| errno | 0.3.14 | MIT OR Apache-2.0 |
 | fallible-iterator | 0.3.0 | MIT/Apache-2.0 |
 | fallible-streaming-iterator | 0.1.9 | MIT/Apache-2.0 |
+| fastrand | 2.4.1 | Apache-2.0 OR MIT |
 | fdeflate | 0.3.7 | MIT OR Apache-2.0 |
 | find-msvc-tools | 0.1.9 | MIT OR Apache-2.0 |
 | flate2 | 1.1.9 | MIT OR Apache-2.0 |
@@ -48,10 +62,13 @@ the dependency set changes.
 | futures-task | 0.3.32 | MIT OR Apache-2.0 |
 | futures-util | 0.3.32 | MIT OR Apache-2.0 |
 | hashbrown | 0.14.5 | MIT OR Apache-2.0 |
+| hashbrown | 0.17.1 | MIT OR Apache-2.0 |
 | hashlink | 0.9.1 | MIT OR Apache-2.0 |
+| html5ever | 0.39.0 | MIT OR Apache-2.0 |
 | iana-time-zone | 0.1.65 | MIT OR Apache-2.0 |
 | iana-time-zone-haiku | 0.1.2 | MIT OR Apache-2.0 |
 | image | 0.25.10 | MIT OR Apache-2.0 |
+| indexmap | 2.14.0 | Apache-2.0 OR MIT |
 | itertools | 0.14.0 | MIT OR Apache-2.0 |
 | itoa | 1.0.18 | MIT OR Apache-2.0 |
 | jni | 0.22.4 | MIT OR Apache-2.0 |
@@ -62,43 +79,78 @@ the dependency set changes.
 | libc | 0.2.186 | MIT OR Apache-2.0 |
 | libloading | 0.9.0 | ISC |
 | libsqlite3-sys | 0.30.1 | MIT |
+| linux-raw-sys | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |
+| lock_api | 0.4.14 | MIT OR Apache-2.0 |
 | log | 0.4.32 | MIT OR Apache-2.0 |
+| lua-src | 547.0.0 | MIT |
+| luajit-src | 210.5.12+a4f56a4 | MIT |
+| markup5ever | 0.39.0 | MIT OR Apache-2.0 |
 | maybe-owned | 0.3.4 | MIT OR Apache-2.0 |
 | memchr | 2.8.1 | Unlicense OR MIT |
 | miniz_oxide | 0.8.9 | MIT OR Zlib OR Apache-2.0 |
+| mlua | 0.10.5 | MIT |
+| mlua-sys | 0.6.8 | MIT |
 | moxcms | 0.8.1 | BSD-3-Clause OR Apache-2.0 |
+| new_debug_unreachable | 1.0.6 | MIT |
 | num-traits | 0.2.19 | MIT OR Apache-2.0 |
 | once_cell | 1.21.4 | MIT OR Apache-2.0 |
+| owned_ttf_parser | 0.25.1 | Apache-2.0 |
+| parking_lot | 0.12.5 | MIT OR Apache-2.0 |
+| parking_lot_core | 0.9.12 | MIT OR Apache-2.0 |
 | pdfium-render | 0.9.1 | MIT OR Apache-2.0 |
+| percent-encoding | 2.3.2 | MIT OR Apache-2.0 |
+| phf | 0.13.1 | MIT |
+| phf_codegen | 0.13.1 | MIT |
+| phf_generator | 0.13.1 | MIT |
+| phf_macros | 0.13.1 | MIT |
+| phf_shared | 0.13.1 | MIT |
 | pin-project-lite | 0.2.17 | Apache-2.0 OR MIT |
 | piston-float | 1.0.1 | MIT |
 | pkg-config | 0.3.33 | MIT OR Apache-2.0 |
 | png | 0.17.16 | MIT OR Apache-2.0 |
+| precomputed-hash | 0.1.1 | MIT |
 | proc-macro2 | 1.0.106 | MIT OR Apache-2.0 |
 | pxfm | 0.1.29 | BSD-3-Clause OR Apache-2.0 |
+| quick-xml | 0.40.1 | MIT |
 | quote | 1.0.45 | MIT OR Apache-2.0 |
+| rbook | 0.7.9 | Apache-2.0 |
+| redox_syscall | 0.5.18 | MIT |
 | rusqlite | 0.32.1 | MIT |
+| rustc-hash | 2.1.2 | Apache-2.0 OR MIT |
 | rustc_version | 0.4.1 | MIT OR Apache-2.0 |
+| rustix | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |
 | rustversion | 1.0.22 | MIT OR Apache-2.0 |
 | same-file | 1.0.6 | Unlicense/MIT |
+| scopeguard | 1.2.0 | MIT OR Apache-2.0 |
+| scraper | 0.27.0 | ISC |
+| selectors | 0.38.0 | MPL-2.0 |
 | semver | 1.0.28 | MIT OR Apache-2.0 |
 | serde | 1.0.228 | MIT OR Apache-2.0 |
 | serde_core | 1.0.228 | MIT OR Apache-2.0 |
 | serde_derive | 1.0.228 | MIT OR Apache-2.0 |
 | serde_json | 1.0.150 | MIT OR Apache-2.0 |
+| servo_arc | 0.4.3 | MIT OR Apache-2.0 |
 | shlex | 2.0.1 | MIT OR Apache-2.0 |
 | simd-adler32 | 0.3.9 | MIT |
 | simd_cesu8 | 1.1.1 | Apache-2.0 OR MIT |
 | simdutf8 | 0.1.5 | MIT OR Apache-2.0 |
+| siphasher | 1.0.3 | MIT/Apache-2.0 |
 | slab | 0.4.12 | MIT |
 | smallvec | 1.15.2 | MIT OR Apache-2.0 |
+| stable_deref_trait | 1.2.1 | MIT OR Apache-2.0 |
 | strict-num | 0.1.1 | MIT |
+| string_cache | 0.9.0 | MIT OR Apache-2.0 |
+| string_cache_codegen | 0.6.1 | MIT OR Apache-2.0 |
 | syn | 2.0.117 | MIT OR Apache-2.0 |
+| tendril | 0.5.0 | MIT OR Apache-2.0 |
 | thiserror | 2.0.18 | MIT OR Apache-2.0 |
 | thiserror-impl | 2.0.18 | MIT OR Apache-2.0 |
 | tiny-skia | 0.11.4 | BSD-3-Clause |
 | tiny-skia-path | 0.11.4 | BSD-3-Clause |
+| ttf-parser | 0.25.1 | MIT OR Apache-2.0 |
+| typed-path | 0.12.3 | MIT OR Apache-2.0 |
 | unicode-ident | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |
+| utf-8 | 0.7.6 | MIT OR Apache-2.0 |
 | utf16string | 0.2.0 | MIT OR Apache-2.0 |
 | vcpkg | 0.2.15 | MIT/Apache-2.0 |
 | vecmath | 1.0.0 | MIT |
@@ -110,6 +162,8 @@ the dependency set changes.
 | wasm-bindgen-macro-support | 0.2.123 | MIT OR Apache-2.0 |
 | wasm-bindgen-shared | 0.2.123 | MIT OR Apache-2.0 |
 | web-sys | 0.3.100 | MIT OR Apache-2.0 |
+| web_atoms | 0.2.5 | MIT OR Apache-2.0 |
+| which | 7.0.3 | MIT |
 | winapi-util | 0.1.11 | Unlicense OR MIT |
 | windows-core | 0.62.2 | MIT OR Apache-2.0 |
 | windows-implement | 0.60.2 | MIT OR Apache-2.0 |
@@ -118,8 +172,11 @@ the dependency set changes.
 | windows-result | 0.4.1 | MIT OR Apache-2.0 |
 | windows-strings | 0.5.1 | MIT OR Apache-2.0 |
 | windows-sys | 0.61.2 | MIT OR Apache-2.0 |
+| winsafe | 0.0.19 | MIT |
 | zerocopy | 0.8.52 | BSD-2-Clause OR Apache-2.0 OR MIT |
 | zerocopy-derive | 0.8.52 | BSD-2-Clause OR Apache-2.0 OR MIT |
+| zip | 8.6.0 | MIT |
+| zlib-rs | 0.6.3 | Zlib |
 | zmij | 1.0.21 | MIT |
 | zune-core | 0.5.1 | MIT OR Apache-2.0 OR Zlib |
 | zune-jpeg | 0.5.15 | MIT OR Apache-2.0 OR Zlib |

--- a/inkread-lua/Cargo.toml
+++ b/inkread-lua/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "inkread-lua"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+# Embedded Lua plugin runtime (RR13 / ADR-INKREAD-0006 Decision 2). mlua with the `vendored`
+# feature compiles Lua 5.4 from source via `cc` (same hermetic, cross-compiling pattern as
+# rusqlite `bundled`), so the host build needs no system Lua and the Android cdylib builds the
+# same engine. No device/JNI types here (IR-4) — the runtime reaches the core only via services.
+[dependencies]
+mlua = { workspace = true }

--- a/inkread-lua/src/lib.rs
+++ b/inkread-lua/src/lib.rs
@@ -1,0 +1,119 @@
+//! `inkread-lua` — the embedded Lua plugin runtime (RR13 / ADR-INKREAD-0006 Decision 2).
+//!
+//! **Phase L1 (de-risk):** prove the `mlua` embedding (vendored Lua 5.4, compiled from source so it
+//! cross-compiles to `aarch64-linux-android` like rusqlite's bundled SQLite) builds and runs a real
+//! plugin script end to end. The full `inkread.{document,selection,annotations,ui,settings,storage,
+//! network}` API modules and the capability sandbox arrive in L2/L3 over the core **service layer**;
+//! L1 ships only `inkread.log` to exercise the host↔Lua seam.
+//!
+//! This crate holds **no device/JNI types** (IR-4): plugins reach the core only through services, so
+//! the runtime stays host-testable without hardware.
+
+use std::sync::{Arc, Mutex};
+
+use mlua::{Function, Lua, Result as LuaResult};
+
+/// A sink the host reads plugin log output from — a test seam now, the plugin console later.
+#[derive(Clone, Default)]
+pub struct LogSink(Arc<Mutex<Vec<String>>>);
+
+impl LogSink {
+    /// A snapshot of the messages logged so far (poison-safe: returns empty on a poisoned lock).
+    #[must_use]
+    pub fn messages(&self) -> Vec<String> {
+        self.0.lock().map(|g| g.clone()).unwrap_or_default()
+    }
+
+    fn push(&self, msg: String) {
+        if let Ok(mut g) = self.0.lock() {
+            g.push(msg);
+        }
+    }
+}
+
+/// An embedded Lua runtime hosting plugin code. L1 installs a minimal `inkread` global table; later
+/// phases bind `inkread.*` modules to core services behind a capability sandbox.
+pub struct PluginHost {
+    lua: Lua,
+    log: LogSink,
+}
+
+impl PluginHost {
+    /// Build a runtime with the `inkread` API table installed (L1: just `inkread.log`).
+    pub fn new() -> LuaResult<Self> {
+        let lua = Lua::new();
+        let log = LogSink::default();
+
+        let inkread = lua.create_table()?;
+        let sink = log.clone();
+        let log_fn = lua.create_function(move |_, msg: String| {
+            sink.push(msg);
+            Ok(())
+        })?;
+        inkread.set("log", log_fn)?;
+        lua.globals().set("inkread", inkread)?;
+
+        Ok(Self { lua, log })
+    }
+
+    /// The log sink, for the host to read what the plugin emitted.
+    #[must_use]
+    pub fn log_sink(&self) -> &LogSink {
+        &self.log
+    }
+
+    /// Load + execute a plugin's source (defining its functions and lifecycle hooks).
+    pub fn load(&self, src: &str) -> LuaResult<()> {
+        self.lua.load(src).exec()
+    }
+
+    /// Call a global no-argument lifecycle hook by `name` if the plugin defines one (e.g. `on_load`).
+    /// A missing hook is a no-op (not an error) so plugins opt into only the hooks they need.
+    pub fn call_hook(&self, name: &str) -> LuaResult<()> {
+        if let Ok(f) = self.lua.globals().get::<Function>(name) {
+            f.call::<()>(())?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runs_a_plugin_script_and_captures_log_output() {
+        let host = PluginHost::new().unwrap();
+        host.load(
+            r#"
+            function on_load()
+                inkread.log("hello from lua")
+                inkread.log("plugin loaded")
+            end
+        "#,
+        )
+        .unwrap();
+        host.call_hook("on_load").unwrap();
+        assert_eq!(
+            host.log_sink().messages(),
+            vec!["hello from lua".to_string(), "plugin loaded".to_string()]
+        );
+    }
+
+    #[test]
+    fn missing_hook_is_a_noop() {
+        let host = PluginHost::new().unwrap();
+        host.load("x = 1").unwrap();
+        host.call_hook("on_load").unwrap(); // not defined → no error
+        assert!(host.log_sink().messages().is_empty());
+    }
+
+    #[test]
+    fn lua_runtime_evaluates_real_lua() {
+        // Proves the vendored Lua 5.4 VM actually executes (not a stub): arithmetic + string lib.
+        let host = PluginHost::new().unwrap();
+        host.load(r#"inkread.log(tostring(2 + 3) .. "-" .. string.upper("ok"))"#)
+            .unwrap();
+        assert_eq!(host.log_sink().messages(), vec!["5-OK".to_string()]);
+    }
+}


### PR DESCRIPTION
Phase L1 (de-risk gate) of the plugin runtime, per ADR-INKREAD-0006 Decision 2.

## What
- New `inkread-lua` crate embedding **mlua 0.10** with the `vendored` feature — compiles Lua 5.4 from source via `cc`, the same hermetic, cross-compiling pattern as rusqlite `bundled`. No device/JNI types (IR-4): plugins will reach the core only through services (L2/L3).
- A minimal `PluginHost` proves the seam end to end: installs the `inkread` global table with `inkread.log`, loads a plugin script, runs a no-arg lifecycle hook, captures output. 3 host tests.
- Regenerated `LICENSES-3RDPARTY.md` (106 → 163 crates); `mlua` + `lua-src` + `luajit-src` are MIT (AGPL-compatible); `check-licenses.sh` passes.

## Verification (L1 de-risk = cleared)
- Host tests green; `clippy`/`fmt` clean.
- **Vendored Lua cross-compiles to `aarch64-linux-android`** — the central L1 risk, resolved.

## Next
L2 service layer → L3 `inkread.*` API + capability sandbox → L4 curated `.koplugin` shim → L5 examples + permission tests + compat matrix.