### PR TITLE
feat: KOReader-style document controls — Rotate/Crop/Zoom/Page/Font/Display (RR4)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -144,6 +144,10 @@ object NativeBridge {
      *  EPUB ignores it. Re-render after calling. */
     external fun nativeSetFit(handle: Long, mode: Int)
 
+    /** Auto-crop white margins (RR4). [auto] != 0 enables it; [marginStep] (0..8, 1%-of-page each)
+     *  keeps a margin around the detected content. PDF only; re-render after. */
+    external fun nativeSetCrop(handle: Long, auto: Int, marginStep: Int)
+
     // ---- ink annotation, persisted by the core to a sidecar (RR6/RR10 / ADR-INKREAD-0010) ----
 
     /** Attach a `.inkread` sidecar store for the open document so strokes persist (RR10). */

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -148,6 +148,10 @@ object NativeBridge {
      *  keeps a margin around the detected content. PDF only; re-render after. */
     external fun nativeSetCrop(handle: Long, auto: Int, marginStep: Int)
 
+    /** Render quality (0=low, 1=default, 2=high; RR4). High supersamples for smoother text.
+     *  Re-render after calling. */
+    external fun nativeSetRenderQuality(handle: Long, quality: Int)
+
     // ---- ink annotation, persisted by the core to a sidecar (RR6/RR10 / ADR-INKREAD-0010) ----
 
     /** Attach a `.inkread` sidecar store for the open document so strokes persist (RR10). */

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -132,6 +132,10 @@ object NativeBridge {
      *  fixed-layout document (PDF) that does not reflow. Re-render after calling. */
     external fun nativeSetTextScale(handle: Long, scale: Float): Int
 
+    /** Set the display-enhancement contrast [step] (0 = off; RR4). Applied as a post-render pixel
+     *  remap (works on PDF + EPUB); re-render after calling. */
+    external fun nativeSetContrast(handle: Long, step: Int)
+
     // ---- ink annotation, persisted by the core to a sidecar (RR6/RR10 / ADR-INKREAD-0010) ----
 
     /** Attach a `.inkread` sidecar store for the open document so strokes persist (RR10). */

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -140,6 +140,10 @@ object NativeBridge {
      *  the core renders into the new buffer size (PDF re-renders, EPUB repaginates). Re-render after. */
     external fun nativeSetViewport(handle: Long, width: Int, height: Int, dpi: Int)
 
+    /** Set the page fit mode (0=Page/contain, 1=Width, 2=Height; RR4). Aspect-preserving (PDF);
+     *  EPUB ignores it. Re-render after calling. */
+    external fun nativeSetFit(handle: Long, mode: Int)
+
     // ---- ink annotation, persisted by the core to a sidecar (RR6/RR10 / ADR-INKREAD-0010) ----
 
     /** Attach a `.inkread` sidecar store for the open document so strokes persist (RR10). */

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -136,6 +136,10 @@ object NativeBridge {
      *  remap (works on PDF + EPUB); re-render after calling. */
     external fun nativeSetContrast(handle: Long, step: Int)
 
+    /** Update the render viewport after a surface resize / screen rotation (RR21-FR4). Required so
+     *  the core renders into the new buffer size (PDF re-renders, EPUB repaginates). Re-render after. */
+    external fun nativeSetViewport(handle: Long, width: Int, height: Int, dpi: Int)
+
     // ---- ink annotation, persisted by the core to a sidecar (RR6/RR10 / ADR-INKREAD-0010) ----
 
     /** Attach a `.inkread` sidecar store for the open document so strokes persist (RR10). */

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -152,6 +152,14 @@ object NativeBridge {
      *  Re-render after calling. */
     external fun nativeSetRenderQuality(handle: Long, quality: Int)
 
+    /** Reflow line-spacing multiplier (RR4); repaginates EPUB. Returns the new page, or -1 for a
+     *  fixed-layout PDF. Re-render after. */
+    external fun nativeSetLineSpacing(handle: Long, mult: Float): Int
+
+    /** Reflow alignment (0=Left, 1=Justify, 2=Center, 3=Right; RR4); repaginates EPUB. Returns the
+     *  new page, or -1 for a fixed-layout PDF. Re-render after. */
+    external fun nativeSetAlignment(handle: Long, code: Int): Int
+
     // ---- ink annotation, persisted by the core to a sidecar (RR6/RR10 / ADR-INKREAD-0010) ----
 
     /** Attach a `.inkread` sidecar store for the open document so strokes persist (RR10). */

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -584,6 +584,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             try { NativeBridge.nativeSetContrast(docHandle, contrastPref()) } catch (e: RuntimeException) {}
             // Re-apply the saved page fit mode (RR4); default Page/contain.
             try { NativeBridge.nativeSetFit(docHandle, fitPref()) } catch (e: RuntimeException) {}
+            // Re-apply the saved auto-crop + margin (RR4); default off.
+            try { NativeBridge.nativeSetCrop(docHandle, if (cropAutoPref()) 1 else 0, cropMarginPref()) } catch (e: RuntimeException) {}
             pageCount = NativeBridge.nativePageCount(docHandle)
             Books.pushRecent(this, bookId, path)
             Log.i(
@@ -2552,6 +2554,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
         val panels: List<Triple<String, Int, () -> View>> = listOf(
             Triple("Rotate", R.drawable.ic_menu_rotate) { rotationPanel() },
+            Triple("Crop", R.drawable.ic_menu_crop) { cropPanel() },
             Triple("Zoom", R.drawable.ic_menu_fit) { zoomPanel() },
             Triple("Font", R.drawable.ic_menu_font) { fontPanel() },
             Triple("Display", R.drawable.ic_menu_display) { displayPanel() },
@@ -2734,6 +2737,40 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             }
         })
     }
+
+    /** The "Crop" tab: Page Crop (None/Auto) + a Margin cell bar (margin kept around the content). */
+    private fun cropPanel(): View {
+        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        container.addView(settingRow("Page Crop", segmented(listOf("None", "Auto"), if (cropAutoPref()) 1 else 0) { which ->
+            setCropAutoPref(which == 1)
+            Log.i(TAG, "DIAG crop auto=${which == 1}")
+            engine.execute {
+                try { NativeBridge.nativeSetCrop(docHandle, which, cropMarginPref()) } catch (e: RuntimeException) {}
+                renderAndBlit(); adapter.refreshFull()
+            }
+        }))
+        container.addView(settingRow("Margin", cellBar(8, cropMarginPref()) { level ->
+            setCropMarginPref(level)
+            Log.i(TAG, "DIAG crop margin=$level")
+            engine.execute {
+                try { NativeBridge.nativeSetCrop(docHandle, if (cropAutoPref()) 1 else 0, level) } catch (e: RuntimeException) {}
+                renderAndBlit(); adapter.refreshFull()
+            }
+        }))
+        return container
+    }
+
+    private fun cropAutoPref(): Boolean =
+        getSharedPreferences("display", MODE_PRIVATE).getBoolean("crop_auto", false)
+
+    private fun setCropAutoPref(v: Boolean) =
+        getSharedPreferences("display", MODE_PRIVATE).edit().putBoolean("crop_auto", v).apply()
+
+    private fun cropMarginPref(): Int =
+        getSharedPreferences("display", MODE_PRIVATE).getInt("crop_margin", 1).coerceIn(0, 8)
+
+    private fun setCropMarginPref(v: Int) =
+        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("crop_margin", v).apply()
 
     /** The "Zoom" tab: the Fit segmented row + a live zoom −/+ stepper (zoom moved off the bar). */
     private fun zoomPanel(): View {

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -3,6 +3,7 @@ package dev.jraghavan.inkread
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
@@ -214,6 +215,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private val inkDotPaint = Paint().apply { color = Color.BLACK; style = Paint.Style.FILL; isAntiAlias = true }
     private val bookmarkPaint = Paint().apply { color = Color.BLACK; style = Paint.Style.FILL; isAntiAlias = true }
     private val bookmarkOutlinePaint = Paint().apply { color = Color.parseColor("#9E9E9E"); style = Paint.Style.STROKE; strokeWidth = 2f; isAntiAlias = true }
+    /** White halo drawn under the ribbon so it stays visible over a dark page region (e.g. a black
+     *  title band) — without it a black/gray ribbon vanishes on dark backgrounds. */
+    private val bookmarkHaloPaint = Paint().apply { color = Color.WHITE; style = Paint.Style.STROKE; strokeWidth = 5f; isAntiAlias = true }
     /** Dashed box around the active lasso selection (ADR-INKREAD-0010). */
     private val selectionPaint = Paint().apply {
         color = Color.BLACK
@@ -272,6 +276,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Re-apply the saved page rotation (RR4) before the surface is created so the first render
+        // is at the right orientation. configChanges=orientation keeps us from recreating.
+        requestedOrientation = orientationPref()
         // Prove the JNI boundary up front (RR1-AC2). Cheap; fine on the UI thread.
         Log.i(TAG, "core: ${NativeBridge.nativeHello()}")
 
@@ -474,7 +481,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         renderBuffer = ByteBuffer.allocateDirect(width * height * 4).order(ByteOrder.LITTLE_ENDIAN)
 
         drawLoading() // quick feedback while the (slow) open runs
+        val wasOpen = docHandle != 0L
         openDocumentIfNeeded()
+        // A resize/rotation of an ALREADY-open doc: tell the core the new viewport so it renders at
+        // the new size (else the render is size-mismatched → the rotated smear). RR21-FR4.
+        if (wasOpen && docHandle != 0L) {
+            try { NativeBridge.nativeSetViewport(docHandle, width, height, DPI) } catch (e: RuntimeException) {
+                Log.e(TAG, "setViewport failed: ${e.message}")
+            }
+        }
         renderAndBlit()
         adapter.refreshFull() // first page carries no command stream → refresh the panel (RR2-FR4)
     }
@@ -908,6 +923,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             lineTo(left, len)
             close()
         }
+        // A white halo first so the ribbon reads on any background (e.g. a black title band).
+        canvas.drawPath(path, bookmarkHaloPaint)
         if (bookmarks?.has(currentPage) == true) {
             canvas.drawPath(path, bookmarkPaint)
         } else {
@@ -1189,6 +1206,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         control(R.drawable.ic_tool_define, "Dicts") { showDictionariesDialog() }
         control(R.drawable.ic_menu_font, "Font") { showTypographyDialog() }
         control(R.drawable.ic_menu_display, "Display") { showDisplayDialog() }
+        control(R.drawable.ic_menu_rotate, "Rotate") { showRotationDialog() }
         control(R.drawable.ic_menu_open, "Open") { openPicker() }
         container.addView(controls)
 
@@ -2585,7 +2603,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             setContrastPref(step)
             refresh()
             engine.execute {
-                try { NativeBridge.nativeSetContrast(docHandle, step) } catch (e: RuntimeException) {}
+                Log.i(TAG, "DIAG contrast step=$step → nativeSetContrast + render")
+                try { NativeBridge.nativeSetContrast(docHandle, step) } catch (e: RuntimeException) {
+                    Log.e(TAG, "setContrast failed: ${e.message}")
+                }
                 renderAndBlit(); adapter.refreshFull()
             }
         }
@@ -2609,7 +2630,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             })
             addView(row)
         }
-        AlertDialog.Builder(this).setTitle("Display").setView(container)
+        AlertDialog.Builder(this, R.style.InkDialog).setTitle("Display").setView(container)
             .setPositiveButton("Done", null).show()
     }
 
@@ -2618,6 +2639,47 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     private fun setContrastPref(step: Int) =
         getSharedPreferences("display", MODE_PRIVATE).edit().putInt("contrast", step).apply()
+
+    /**
+     * Page rotation (RR4 — KOReader's "Rotation"). Rotation is a **shell** concern on this device:
+     * we change the Activity's requested screen orientation; with `configChanges=orientation` the
+     * SurfaceView just resizes → `surfaceChanged` → re-render at the new viewport (PDF re-renders,
+     * EPUB repaginates). Persisted + re-applied on open. The four options mirror KOReader's 0/90/
+     * 180/270.
+     */
+    private fun showRotationDialog() {
+        val options = arrayOf("Portrait", "Landscape", "Portrait (flipped)", "Landscape (flipped)")
+        val orients = intArrayOf(
+            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
+            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
+            ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT,
+            ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
+        )
+        val current = orientationPref()
+        val checked = orients.indexOf(current).coerceAtLeast(0)
+        AlertDialog.Builder(this, R.style.InkDialog)
+            .setTitle("Rotation")
+            .setSingleChoiceItems(options, checked) { dialog, which ->
+                applyOrientation(orients[which])
+                Log.i(TAG, "DIAG rotation -> ${options[which]} (orient=${orients[which]})")
+                dialog.dismiss()
+            }
+            .setNegativeButton("Close", null)
+            .show()
+    }
+
+    /** Set + persist the screen orientation; the resize re-renders the page (engine via surfaceChanged). */
+    private fun applyOrientation(orientation: Int) {
+        setOrientationPref(orientation)
+        requestedOrientation = orientation
+    }
+
+    private fun orientationPref(): Int =
+        getSharedPreferences("display", MODE_PRIVATE)
+            .getInt("orientation", ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
+
+    private fun setOrientationPref(orientation: Int) =
+        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("orientation", orientation).apply()
 
     private fun textScalePref(): Float =
         getSharedPreferences("typography", MODE_PRIVATE).getFloat("scale", 1.0f)

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -582,6 +582,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             }
             // Re-apply the saved display contrast (RR4); 0 = off (a no-op in the core).
             try { NativeBridge.nativeSetContrast(docHandle, contrastPref()) } catch (e: RuntimeException) {}
+            // Re-apply the saved page fit mode (RR4); default Page/contain.
+            try { NativeBridge.nativeSetFit(docHandle, fitPref()) } catch (e: RuntimeException) {}
             pageCount = NativeBridge.nativePageCount(docHandle)
             Books.pushRecent(this, bookId, path)
             Log.i(
@@ -1207,6 +1209,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         control(R.drawable.ic_menu_font, "Font") { showTypographyDialog() }
         control(R.drawable.ic_menu_display, "Display") { showDisplayDialog() }
         control(R.drawable.ic_menu_rotate, "Rotate") { showRotationDialog() }
+        control(R.drawable.ic_menu_fit, "Fit") { showFitDialog() }
         control(R.drawable.ic_menu_open, "Open") { openPicker() }
         container.addView(controls)
 
@@ -2673,6 +2676,37 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         setOrientationPref(orientation)
         requestedOrientation = orientation
     }
+
+    /**
+     * Page fit (RR4 — KOReader's "Fit"). Aspect-preserving: whole page (contain) / fit width / fit
+     * height. Persisted + re-applied on open. PDF honors it; EPUB ignores it (it reflows already).
+     */
+    private fun showFitDialog() {
+        if (docHandle == 0L) { openPicker(); return }
+        val options = arrayOf("Whole page", "Fit width", "Fit height") // index = core FitMode code
+        val current = fitPref().coerceIn(0, options.size - 1)
+        AlertDialog.Builder(this, R.style.InkDialog)
+            .setTitle("Fit")
+            .setSingleChoiceItems(options, current) { dialog, which ->
+                setFitPref(which)
+                Log.i(TAG, "DIAG fit -> ${options[which]} (mode=$which)")
+                engine.execute {
+                    try { NativeBridge.nativeSetFit(docHandle, which) } catch (e: RuntimeException) {
+                        Log.e(TAG, "setFit failed: ${e.message}")
+                    }
+                    renderAndBlit(); adapter.refreshFull()
+                }
+                dialog.dismiss()
+            }
+            .setNegativeButton("Close", null)
+            .show()
+    }
+
+    private fun fitPref(): Int =
+        getSharedPreferences("display", MODE_PRIVATE).getInt("fit", 0)
+
+    private fun setFitPref(mode: Int) =
+        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("fit", mode).apply()
 
     private fun orientationPref(): Int =
         getSharedPreferences("display", MODE_PRIVATE)

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -586,6 +586,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             try { NativeBridge.nativeSetFit(docHandle, fitPref()) } catch (e: RuntimeException) {}
             // Re-apply the saved auto-crop + margin (RR4); default off.
             try { NativeBridge.nativeSetCrop(docHandle, if (cropAutoPref()) 1 else 0, cropMarginPref()) } catch (e: RuntimeException) {}
+            // Re-apply the saved render quality (RR4); default 1.
+            try { NativeBridge.nativeSetRenderQuality(docHandle, renderQualityPref()) } catch (e: RuntimeException) {}
             pageCount = NativeBridge.nativePageCount(docHandle)
             Books.pushRecent(this, bookId, path)
             Log.i(
@@ -2805,15 +2807,31 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     }
 
     private fun displayPanel(): View {
-        return settingRow("Contrast", cellBar(CONTRAST_MAX, contrastPref()) { level ->
+        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        container.addView(settingRow("Contrast", cellBar(CONTRAST_MAX, contrastPref()) { level ->
             setContrastPref(level)
             Log.i(TAG, "DIAG contrast step=$level")
             engine.execute {
                 try { NativeBridge.nativeSetContrast(docHandle, level) } catch (e: RuntimeException) {}
                 renderAndBlit(); adapter.refreshFull()
             }
-        })
+        }))
+        container.addView(settingRow("Quality", segmented(listOf("Low", "Default", "High"), renderQualityPref()) { which ->
+            setRenderQualityPref(which)
+            Log.i(TAG, "DIAG render quality=$which")
+            engine.execute {
+                try { NativeBridge.nativeSetRenderQuality(docHandle, which) } catch (e: RuntimeException) {}
+                renderAndBlit(); adapter.refreshFull()
+            }
+        }))
+        return container
     }
+
+    private fun renderQualityPref(): Int =
+        getSharedPreferences("display", MODE_PRIVATE).getInt("render_quality", 1).coerceIn(0, 2)
+
+    private fun setRenderQualityPref(q: Int) =
+        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("render_quality", q).apply()
 
     private fun fontPanel(): View {
         val d = resources.displayMetrics.density

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -588,6 +588,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             try { NativeBridge.nativeSetCrop(docHandle, if (cropAutoPref()) 1 else 0, cropMarginPref()) } catch (e: RuntimeException) {}
             // Re-apply the saved render quality (RR4); default 1.
             try { NativeBridge.nativeSetRenderQuality(docHandle, renderQualityPref()) } catch (e: RuntimeException) {}
+            // Re-apply saved reflow line-spacing + alignment (RR4; EPUB only — PDF returns -1).
+            if (lineSpacingPref() != 1) {
+                try { NativeBridge.nativeSetLineSpacing(docHandle, LINE_SPACINGS[lineSpacingPref()]) } catch (e: RuntimeException) {}
+            }
+            if (alignmentPref() != 0) {
+                try { NativeBridge.nativeSetAlignment(docHandle, alignmentPref()) } catch (e: RuntimeException) {}
+            }
             pageCount = NativeBridge.nativePageCount(docHandle)
             Books.pushRecent(this, bookId, path)
             Log.i(
@@ -2558,6 +2565,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             Triple("Rotate", R.drawable.ic_menu_rotate) { rotationPanel() },
             Triple("Crop", R.drawable.ic_menu_crop) { cropPanel() },
             Triple("Zoom", R.drawable.ic_menu_fit) { zoomPanel() },
+            Triple("Page", R.drawable.ic_menu_page) { pagePanel() },
             Triple("Font", R.drawable.ic_menu_font) { fontPanel() },
             Triple("Display", R.drawable.ic_menu_display) { displayPanel() },
         )
@@ -2774,6 +2782,45 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private fun setCropMarginPref(v: Int) =
         getSharedPreferences("display", MODE_PRIVATE).edit().putInt("crop_margin", v).apply()
 
+    /** The "Page" tab: reflow Line Spacing + Alignment (EPUB; a toast on fixed-layout PDF). */
+    private fun pagePanel(): View {
+        fun applyReflow(call: () -> Int) {
+            engine.execute {
+                val np = try { call() } catch (e: RuntimeException) { -1 }
+                if (np >= 0) {
+                    pageCount = NativeBridge.nativePageCount(docHandle)
+                    renderAndBlit(); adapter.refreshFull()
+                } else {
+                    runOnUiThread { Toast.makeText(this, "Page layout adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show() }
+                }
+            }
+        }
+        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        container.addView(settingRow("Line Spacing", segmented(listOf("Small", "Medium", "Large"), lineSpacingPref()) { which ->
+            setLineSpacingPref(which)
+            Log.i(TAG, "DIAG line spacing=$which")
+            applyReflow { NativeBridge.nativeSetLineSpacing(docHandle, LINE_SPACINGS[which]) }
+        }))
+        container.addView(settingRow("Alignment", segmented(listOf("Left", "Justify", "Center", "Right"), alignmentPref()) { which ->
+            setAlignmentPref(which)
+            Log.i(TAG, "DIAG alignment=$which")
+            applyReflow { NativeBridge.nativeSetAlignment(docHandle, which) }
+        }))
+        return container
+    }
+
+    private fun lineSpacingPref(): Int =
+        getSharedPreferences("typography", MODE_PRIVATE).getInt("line_spacing", 1).coerceIn(0, 2)
+
+    private fun setLineSpacingPref(i: Int) =
+        getSharedPreferences("typography", MODE_PRIVATE).edit().putInt("line_spacing", i).apply()
+
+    private fun alignmentPref(): Int =
+        getSharedPreferences("typography", MODE_PRIVATE).getInt("alignment", 0).coerceIn(0, 3)
+
+    private fun setAlignmentPref(i: Int) =
+        getSharedPreferences("typography", MODE_PRIVATE).edit().putInt("alignment", i).apply()
+
     /** The "Zoom" tab: the Fit segmented row + a live zoom −/+ stepper (zoom moved off the bar). */
     private fun zoomPanel(): View {
         val d = resources.displayMetrics.density
@@ -2953,6 +3000,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val SYNCED_DIRS = arrayOf("Document", "EXPORT", "Note", "INBOX", "MyStyle", "Download")
         const val SELECTION_HANDLE_PX = 8f // half-size of the square corner handles on the selection box.
         const val CONTRAST_MAX = 8 // mirrors reader-core render::contrast::MAX_CONTRAST_STEP (RR4).
+        val LINE_SPACINGS = floatArrayOf(1.2f, 1.4f, 1.7f) // Small / Medium / Large (RR4).
         const val STROKE_PAUSE_MS = 600L // commit a stroke after this pen-pause (swallowed-UP net).
         const val LONG_PRESS_MS = 500L // hold the pen this long (≈still) on a word → look it up.
         const val LONG_PRESS_SLOP_PX = 16f // movement beyond this cancels the long-press (it's a stroke).

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -1206,10 +1206,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         control(R.drawable.ic_menu_zoom_in, "Zoom +") { zoomBy(ZOOM_STEP) }
         control(R.drawable.ic_menu_export, "Export") { showExportDialog() }
         control(R.drawable.ic_tool_define, "Dicts") { showDictionariesDialog() }
-        control(R.drawable.ic_menu_font, "Font") { showTypographyDialog() }
-        control(R.drawable.ic_menu_display, "Display") { showDisplayDialog() }
-        control(R.drawable.ic_menu_rotate, "Rotate") { showRotationDialog() }
-        control(R.drawable.ic_menu_fit, "Fit") { showFitDialog() }
+        // Document controls consolidated into one KOReader-style tabbed sheet (Rotate/Fit/Font/Display).
+        control(R.drawable.ic_menu_adjust, "Adjust") { showAdjustSheet() }
         control(R.drawable.ic_menu_open, "Open") { openPicker() }
         container.addView(controls)
 
@@ -2531,175 +2529,262 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
     }
 
-    /**
-     * Reflow **font size** control (RR2-FR5) — A− / A+ over a set of scale steps, applied live via
-     * [NativeBridge.nativeSetTextScale] (EPUB repaginates, preserving the chapter). The scale
-     * persists and is re-applied on the next open. A no-op toast on fixed-layout PDF.
-     */
-    private fun showTypographyDialog() {
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        var idx = nearestScaleIndex(textScalePref())
-        val label = TextView(this).apply {
-            textSize = 18f; setTextColor(Color.BLACK); gravity = Gravity.CENTER
-            minWidth = dp(96)
-        }
-        fun refreshLabel() { label.text = "${(TEXT_SCALES[idx] * 100).toInt()}%" }
-        refreshLabel()
-        fun apply() {
-            val scale = TEXT_SCALES[idx]
-            setTextScalePref(scale)
-            refreshLabel()
-            engine.execute {
-                val np = try { NativeBridge.nativeSetTextScale(docHandle, scale) } catch (e: RuntimeException) { -1 }
-                if (np >= 0) {
-                    pageCount = NativeBridge.nativePageCount(docHandle)
-                    renderAndBlit(); adapter.refreshFull()
-                } else {
-                    runOnUiThread {
-                        Toast.makeText(this, "Font size adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show()
-                    }
-                }
-            }
-        }
-        fun stepButton(text: String, onTap: () -> Unit) = TextView(this).apply {
-            this.text = text; textSize = 22f; setTextColor(Color.BLACK); gravity = Gravity.CENTER
-            setPadding(dp(22), dp(6), dp(22), dp(10))
-            background = GradientDrawable().apply {
-                setColor(Color.WHITE); setStroke(maxOf(1, dp(1)), Color.BLACK); cornerRadius = dp(20).toFloat()
-            }
-            isClickable = true; setOnClickListener { onTap() }
-        }
-        val row = LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER
-            setPadding(dp(24), dp(22), dp(24), dp(10))
-            addView(stepButton("A−") { if (idx > 0) { idx--; apply() } })
-            addView(label, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
-                marginStart = dp(18); marginEnd = dp(18)
-            })
-            addView(stepButton("A+") { if (idx < TEXT_SCALES.size - 1) { idx++; apply() } })
-        }
-        AlertDialog.Builder(this, R.style.InkDialog)
-            .setTitle("Font size")
-            .setView(row)
-            .setPositiveButton("Done", null)
-            .show()
-    }
-
-    /**
-     * Display settings (RR4 — KOReader's "Contrast" tab). A contrast stepper (0 = off … MAX) that
-     * applies live and persists per the app (re-applied on open). The matching native control is a
-     * post-render pixel remap, so it works on PDF and EPUB and needs only a re-render.
-     */
-    private fun showDisplayDialog() {
-        if (docHandle == 0L) { openPicker(); return }
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        var step = contrastPref()
-
-        val label = TextView(this).apply {
-            textSize = 18f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(72)
-        }
-        fun refresh() { label.text = if (step == 0) "Off" else step.toString() }
-        refresh()
-        fun apply() {
-            setContrastPref(step)
-            refresh()
-            engine.execute {
-                Log.i(TAG, "DIAG contrast step=$step → nativeSetContrast + render")
-                try { NativeBridge.nativeSetContrast(docHandle, step) } catch (e: RuntimeException) {
-                    Log.e(TAG, "setContrast failed: ${e.message}")
-                }
-                renderAndBlit(); adapter.refreshFull()
-            }
-        }
-        fun button(txt: String, onTap: () -> Unit) = TextView(this).apply {
-            text = txt; textSize = 22f; gravity = Gravity.CENTER
-            setTextColor(Color.BLACK); setPadding(dp(20), dp(6), dp(20), dp(6)); isClickable = true
-            setOnClickListener { onTap() }
-        }
-        val row = LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
-            setPadding(dp(20), dp(8), dp(20), dp(8))
-            addView(button("−") { if (step > 0) { step--; apply() } })
-            addView(label)
-            addView(button("+") { if (step < CONTRAST_MAX) { step++; apply() } })
-        }
-        val container = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            addView(TextView(this@ReaderActivity).apply {
-                text = "Contrast"; textSize = 13f; setTextColor(Color.parseColor("#666666"))
-                setPadding(dp(20), dp(14), dp(20), 0)
-            })
-            addView(row)
-        }
-        AlertDialog.Builder(this, R.style.InkDialog).setTitle("Display").setView(container)
-            .setPositiveButton("Done", null).show()
-    }
-
     private fun contrastPref(): Int =
         getSharedPreferences("display", MODE_PRIVATE).getInt("contrast", 0).coerceIn(0, CONTRAST_MAX)
 
     private fun setContrastPref(step: Int) =
         getSharedPreferences("display", MODE_PRIVATE).edit().putInt("contrast", step).apply()
 
+    // ---- Document settings sheet (RR4 — KOReader-style tabbed controls) ----
+
     /**
-     * Page rotation (RR4 — KOReader's "Rotation"). Rotation is a **shell** concern on this device:
-     * we change the Activity's requested screen orientation; with `configChanges=orientation` the
-     * SurfaceView just resizes → `surfaceChanged` → re-render at the new viewport (PDF re-renders,
-     * EPUB repaginates). Persisted + re-applied on open. The four options mirror KOReader's 0/90/
-     * 180/270.
+     * A KOReader-style tabbed settings sheet that consolidates the document controls
+     * (Rotate / Fit / Font / Display) behind one bottom-bar entry — matching KOReader's bottom
+     * sheet structure. Each tab swaps an inline control panel; changes apply live + persist.
      */
-    private fun showRotationDialog() {
-        val options = arrayOf("Portrait", "Landscape", "Portrait (flipped)", "Landscape (flipped)")
+    private fun showAdjustSheet() {
+        if (docHandle == 0L) { openPicker(); return }
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+        val content = android.widget.FrameLayout(this)
+
+        val panels: List<Triple<String, Int, () -> View>> = listOf(
+            Triple("Rotate", R.drawable.ic_menu_rotate) { rotationPanel() },
+            Triple("Fit", R.drawable.ic_menu_fit) { fitPanel() },
+            Triple("Font", R.drawable.ic_menu_font) { fontPanel() },
+            Triple("Display", R.drawable.ic_menu_display) { displayPanel() },
+        )
+        val cells = ArrayList<LinearLayout>()
+        fun select(i: Int) {
+            content.removeAllViews()
+            content.addView(panels[i].third())
+            cells.forEachIndexed { j, c ->
+                // Active tab: white, boxed (connected to the panel) + bold label. Inactive: flat gray.
+                if (j == i) {
+                    c.background = GradientDrawable().apply {
+                        setColor(Color.WHITE); setStroke(maxOf(1, dp(2)), Color.BLACK)
+                    }
+                } else {
+                    c.background = null
+                    c.setBackgroundColor(Color.parseColor("#F2F2F2"))
+                }
+                (c.getChildAt(1) as? TextView)?.setTypeface(
+                    null, if (j == i) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL,
+                )
+            }
+        }
+        val tabRow = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setBackgroundColor(Color.parseColor("#F2F2F2"))
+        }
+        panels.forEachIndexed { i, (label, icon, _) ->
+            val cell = LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL; gravity = Gravity.CENTER
+                setPadding(dp(4), dp(10), dp(4), dp(10)); isClickable = true
+                setOnClickListener { select(i) }
+                addView(
+                    ImageView(this@ReaderActivity).apply { setImageResource(icon); setColorFilter(Color.BLACK) },
+                    LinearLayout.LayoutParams(dp(24), dp(24)),
+                )
+                addView(TextView(this@ReaderActivity).apply {
+                    text = label; textSize = 10f; setTextColor(Color.parseColor("#444444"))
+                    gravity = Gravity.CENTER; setPadding(0, dp(3), 0, 0)
+                })
+            }
+            cells.add(cell)
+            tabRow.addView(cell, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        }
+        val container = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.WHITE)
+            // Hairline top divider so the sheet reads as a surface (established bottom-bar template).
+            addView(
+                View(this@ReaderActivity).apply { setBackgroundColor(Color.parseColor("#33000000")) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(1).coerceAtLeast(1)),
+            )
+            // Active tab's panel — WRAP_CONTENT so the sheet GROWS UP per tab (KOReader-style),
+            // bottom-anchored, instead of a fixed box with dead space.
+            addView(
+                content,
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT),
+            )
+            addView(
+                View(this@ReaderActivity).apply { setBackgroundColor(Color.parseColor("#22000000")) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 1),
+            )
+            addView(tabRow)
+        }
+        select(0)
+        dialog.setContentView(container)
+        dialog.window?.apply {
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            setGravity(Gravity.BOTTOM)
+            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.WHITE))
+        }
+        dialog.show()
+    }
+
+    /** A KOReader-style **segmented control**: a rounded pill of [options] with the [selected]
+     *  segment filled dark. Updates its own highlight on tap, then calls [onSelect]. */
+    private fun segmented(options: List<String>, selected: Int, onSelect: (Int) -> Unit): View {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val radius = dp(20).toFloat()
+        var sel = selected
+        val segs = ArrayList<TextView>()
+        fun style(tv: TextView, on: Boolean) {
+            if (on) {
+                tv.setTextColor(Color.WHITE)
+                tv.setTypeface(null, android.graphics.Typeface.BOLD)
+                tv.background = GradientDrawable().apply { setColor(Color.parseColor("#5A5A5A")); cornerRadius = radius }
+            } else {
+                tv.setTextColor(Color.BLACK)
+                tv.setTypeface(null, android.graphics.Typeface.NORMAL)
+                tv.background = null
+            }
+        }
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            background = GradientDrawable().apply {
+                setColor(Color.WHITE); cornerRadius = radius
+                setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
+            }
+            val p = dp(3); setPadding(p, p, p, p)
+            options.forEachIndexed { i, opt ->
+                val tv = TextView(this@ReaderActivity).apply {
+                    text = opt; textSize = 15f; gravity = Gravity.CENTER
+                    setPadding(dp(6), dp(10), dp(6), dp(10)); isClickable = true
+                    setOnClickListener { sel = i; segs.forEachIndexed { j, t -> style(t, j == sel) }; onSelect(i) }
+                }
+                style(tv, i == sel)
+                segs.add(tv)
+                addView(tv, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            }
+        }
+    }
+
+    /** A KOReader-style **cell bar**: [count] boxes filled up to the current level; tapping box i
+     *  sets level i+1 (tapping the current top cell turns it off → 0). Repaints on tap. */
+    private fun cellBar(count: Int, initial: Int, onSet: (Int) -> Unit): View {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        var filled = initial
+        val draws = ArrayList<GradientDrawable>()
+        fun repaint() = draws.forEachIndexed { i, g ->
+            g.setColor(if (i < filled) Color.parseColor("#5A5A5A") else Color.WHITE)
+        }
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            for (i in 0 until count) {
+                val g = GradientDrawable().apply { setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E")) }
+                draws.add(g)
+                addView(View(this@ReaderActivity).apply {
+                    background = g; isClickable = true
+                    setOnClickListener {
+                        filled = if (i + 1 == filled) 0 else i + 1
+                        repaint(); invalidate()
+                        onSet(filled)
+                    }
+                }, LinearLayout.LayoutParams(0, dp(30), 1f).apply { val m = dp(2); setMargins(m, 0, m, 0) })
+            }
+            repaint()
+        }
+    }
+
+    /** A KOReader-style settings row: a right-aligned [label] on the left, the [control] on the right. */
+    private fun settingRow(label: String, control: View): View {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(16), dp(14), dp(16), dp(14))
+            addView(TextView(this@ReaderActivity).apply {
+                text = label; textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.END
+            }, LinearLayout.LayoutParams(dp(96), ViewGroup.LayoutParams.WRAP_CONTENT))
+            addView(control, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
+                marginStart = dp(14)
+            })
+        }
+    }
+
+    private fun rotationPanel(): View {
         val orients = intArrayOf(
             ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
             ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
             ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT,
             ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
         )
-        val current = orientationPref()
-        val checked = orients.indexOf(current).coerceAtLeast(0)
-        AlertDialog.Builder(this, R.style.InkDialog)
-            .setTitle("Rotation")
-            .setSingleChoiceItems(options, checked) { dialog, which ->
-                applyOrientation(orients[which])
-                Log.i(TAG, "DIAG rotation -> ${options[which]} (orient=${orients[which]})")
-                dialog.dismiss()
+        val sel = orients.indexOf(orientationPref()).coerceAtLeast(0)
+        return settingRow("Rotation", segmented(listOf("0°", "90°", "180°", "270°"), sel) { which ->
+            Log.i(TAG, "DIAG rotation -> $which")
+            applyOrientation(orients[which])
+        })
+    }
+
+    private fun fitPanel(): View {
+        val sel = fitPref().coerceIn(0, 2) // index = core FitMode code
+        return settingRow("Fit", segmented(listOf("Full", "Width", "Height"), sel) { which ->
+            setFitPref(which)
+            Log.i(TAG, "DIAG fit -> mode=$which")
+            engine.execute {
+                try { NativeBridge.nativeSetFit(docHandle, which) } catch (e: RuntimeException) {}
+                renderAndBlit(); adapter.refreshFull()
             }
-            .setNegativeButton("Close", null)
-            .show()
+        })
+    }
+
+    private fun displayPanel(): View {
+        return settingRow("Contrast", cellBar(CONTRAST_MAX, contrastPref()) { level ->
+            setContrastPref(level)
+            Log.i(TAG, "DIAG contrast step=$level")
+            engine.execute {
+                try { NativeBridge.nativeSetContrast(docHandle, level) } catch (e: RuntimeException) {}
+                renderAndBlit(); adapter.refreshFull()
+            }
+        })
+    }
+
+    private fun fontPanel(): View {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        var idx = nearestScaleIndex(textScalePref())
+        val value = TextView(this).apply {
+            textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
+        }
+        fun refresh() { value.text = "${(TEXT_SCALES[idx] * 100).toInt()}%" }
+        refresh()
+        fun apply() {
+            setTextScalePref(TEXT_SCALES[idx]); refresh()
+            engine.execute {
+                val np = try { NativeBridge.nativeSetTextScale(docHandle, TEXT_SCALES[idx]) } catch (e: RuntimeException) { -1 }
+                if (np >= 0) { pageCount = NativeBridge.nativePageCount(docHandle); renderAndBlit(); adapter.refreshFull() }
+                else runOnUiThread { Toast.makeText(this, "Font size adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show() }
+            }
+        }
+        fun pill(t: String, on: () -> Unit) = TextView(this).apply {
+            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
+            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
+            background = GradientDrawable().apply {
+                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
+            }
+            setOnClickListener { on() }
+        }
+        val control = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            addView(pill("A−") { if (idx > 0) { idx--; apply() } })
+            addView(value, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                val m = dp(10); setMargins(m, 0, m, 0)
+            })
+            addView(pill("A+") { if (idx < TEXT_SCALES.size - 1) { idx++; apply() } })
+        }
+        return settingRow("Font Size", control)
     }
 
     /** Set + persist the screen orientation; the resize re-renders the page (engine via surfaceChanged). */
     private fun applyOrientation(orientation: Int) {
         setOrientationPref(orientation)
         requestedOrientation = orientation
-    }
-
-    /**
-     * Page fit (RR4 — KOReader's "Fit"). Aspect-preserving: whole page (contain) / fit width / fit
-     * height. Persisted + re-applied on open. PDF honors it; EPUB ignores it (it reflows already).
-     */
-    private fun showFitDialog() {
-        if (docHandle == 0L) { openPicker(); return }
-        val options = arrayOf("Whole page", "Fit width", "Fit height") // index = core FitMode code
-        val current = fitPref().coerceIn(0, options.size - 1)
-        AlertDialog.Builder(this, R.style.InkDialog)
-            .setTitle("Fit")
-            .setSingleChoiceItems(options, current) { dialog, which ->
-                setFitPref(which)
-                Log.i(TAG, "DIAG fit -> ${options[which]} (mode=$which)")
-                engine.execute {
-                    try { NativeBridge.nativeSetFit(docHandle, which) } catch (e: RuntimeException) {
-                        Log.e(TAG, "setFit failed: ${e.message}")
-                    }
-                    renderAndBlit(); adapter.refreshFull()
-                }
-                dialog.dismiss()
-            }
-            .setNegativeButton("Close", null)
-            .show()
     }
 
     private fun fitPref(): Int =

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -1202,10 +1202,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // (Bookmark toggle moved to the top-right corner dog-ear; "Marks" lists them.)
         control(R.drawable.ic_menu_marks, "Marks") { showBookmarks() }
         control(R.drawable.ic_menu_contents, "Contents") { showContentsLazy() }
+        // Quick zoom (framed −/+ icons — not magnifiers, which are reserved for Search). Also in Adjust → Zoom.
         control(R.drawable.ic_menu_zoom_out, "Zoom −") { zoomBy(1f / ZOOM_STEP) }
         control(R.drawable.ic_menu_zoom_in, "Zoom +") { zoomBy(ZOOM_STEP) }
         control(R.drawable.ic_menu_export, "Export") { showExportDialog() }
-        control(R.drawable.ic_tool_define, "Dicts") { showDictionariesDialog() }
+        control(R.drawable.ic_menu_dict, "Dicts") { showDictionariesDialog() }
         // Document controls consolidated into one KOReader-style tabbed sheet (Rotate/Fit/Font/Display).
         control(R.drawable.ic_menu_adjust, "Adjust") { showAdjustSheet() }
         control(R.drawable.ic_menu_open, "Open") { openPicker() }
@@ -2551,7 +2552,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
         val panels: List<Triple<String, Int, () -> View>> = listOf(
             Triple("Rotate", R.drawable.ic_menu_rotate) { rotationPanel() },
-            Triple("Fit", R.drawable.ic_menu_fit) { fitPanel() },
+            Triple("Zoom", R.drawable.ic_menu_fit) { zoomPanel() },
             Triple("Font", R.drawable.ic_menu_font) { fontPanel() },
             Triple("Display", R.drawable.ic_menu_display) { displayPanel() },
         )
@@ -2732,6 +2733,38 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 renderAndBlit(); adapter.refreshFull()
             }
         })
+    }
+
+    /** The "Zoom" tab: the Fit segmented row + a live zoom −/+ stepper (zoom moved off the bar). */
+    private fun zoomPanel(): View {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val zlabel = TextView(this).apply {
+            textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
+        }
+        fun refresh() { zlabel.text = "${(zoom * 100).toInt()}%" }
+        refresh()
+        fun pill(t: String, on: () -> Unit) = TextView(this).apply {
+            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
+            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
+            background = GradientDrawable().apply {
+                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
+            }
+            setOnClickListener { on() }
+        }
+        val zoomControl = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            addView(pill("−") { zoomBy(1f / ZOOM_STEP); refresh() })
+            addView(zlabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                val m = dp(10); setMargins(m, 0, m, 0)
+            })
+            addView(pill("+") { zoomBy(ZOOM_STEP); refresh() })
+        }
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(fitPanel())
+            addView(settingRow("Zoom", zoomControl))
+        }
     }
 
     private fun displayPanel(): View {

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -565,6 +565,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 val np = try { NativeBridge.nativeSetTextScale(docHandle, savedScale) } catch (e: RuntimeException) { -1 }
                 if (np >= 0) Log.i(TAG, "applied text scale $savedScale → page $np")
             }
+            // Re-apply the saved display contrast (RR4); 0 = off (a no-op in the core).
+            try { NativeBridge.nativeSetContrast(docHandle, contrastPref()) } catch (e: RuntimeException) {}
             pageCount = NativeBridge.nativePageCount(docHandle)
             Books.pushRecent(this, bookId, path)
             Log.i(
@@ -1186,6 +1188,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         control(R.drawable.ic_menu_export, "Export") { showExportDialog() }
         control(R.drawable.ic_tool_define, "Dicts") { showDictionariesDialog() }
         control(R.drawable.ic_menu_font, "Font") { showTypographyDialog() }
+        control(R.drawable.ic_menu_display, "Display") { showDisplayDialog() }
         control(R.drawable.ic_menu_open, "Open") { openPicker() }
         container.addView(controls)
 
@@ -2562,6 +2565,60 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             .show()
     }
 
+    /**
+     * Display settings (RR4 — KOReader's "Contrast" tab). A contrast stepper (0 = off … MAX) that
+     * applies live and persists per the app (re-applied on open). The matching native control is a
+     * post-render pixel remap, so it works on PDF and EPUB and needs only a re-render.
+     */
+    private fun showDisplayDialog() {
+        if (docHandle == 0L) { openPicker(); return }
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        var step = contrastPref()
+
+        val label = TextView(this).apply {
+            textSize = 18f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(72)
+        }
+        fun refresh() { label.text = if (step == 0) "Off" else step.toString() }
+        refresh()
+        fun apply() {
+            setContrastPref(step)
+            refresh()
+            engine.execute {
+                try { NativeBridge.nativeSetContrast(docHandle, step) } catch (e: RuntimeException) {}
+                renderAndBlit(); adapter.refreshFull()
+            }
+        }
+        fun button(txt: String, onTap: () -> Unit) = TextView(this).apply {
+            text = txt; textSize = 22f; gravity = Gravity.CENTER
+            setTextColor(Color.BLACK); setPadding(dp(20), dp(6), dp(20), dp(6)); isClickable = true
+            setOnClickListener { onTap() }
+        }
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(20), dp(8), dp(20), dp(8))
+            addView(button("−") { if (step > 0) { step--; apply() } })
+            addView(label)
+            addView(button("+") { if (step < CONTRAST_MAX) { step++; apply() } })
+        }
+        val container = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(TextView(this@ReaderActivity).apply {
+                text = "Contrast"; textSize = 13f; setTextColor(Color.parseColor("#666666"))
+                setPadding(dp(20), dp(14), dp(20), 0)
+            })
+            addView(row)
+        }
+        AlertDialog.Builder(this).setTitle("Display").setView(container)
+            .setPositiveButton("Done", null).show()
+    }
+
+    private fun contrastPref(): Int =
+        getSharedPreferences("display", MODE_PRIVATE).getInt("contrast", 0).coerceIn(0, CONTRAST_MAX)
+
+    private fun setContrastPref(step: Int) =
+        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("contrast", step).apply()
+
     private fun textScalePref(): Float =
         getSharedPreferences("typography", MODE_PRIVATE).getFloat("scale", 1.0f)
 
@@ -2626,6 +2683,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // Supernote folders the Partner app syncs — searched to place the export beside the original.
         val SYNCED_DIRS = arrayOf("Document", "EXPORT", "Note", "INBOX", "MyStyle", "Download")
         const val SELECTION_HANDLE_PX = 8f // half-size of the square corner handles on the selection box.
+        const val CONTRAST_MAX = 8 // mirrors reader-core render::contrast::MAX_CONTRAST_STEP (RR4).
         const val STROKE_PAUSE_MS = 600L // commit a stroke after this pen-pause (swallowed-UP net).
         const val LONG_PRESS_MS = 500L // hold the pen this long (≈still) on a word → look it up.
         const val LONG_PRESS_SLOP_PX = 16f // movement beyond this cancels the long-press (it's a stroke).

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -23,7 +23,7 @@ enum class Tool(val label: String, val iconRes: Int, val phase2: Boolean) {
     HIGHLIGHTER("Highlight", R.drawable.ic_tool_highlighter, false),
     ERASER("Eraser", R.drawable.ic_tool_eraser, false),
     LASSO("Lasso", R.drawable.ic_tool_lasso, false),
-    DEFINE("Define", R.drawable.ic_tool_define, false),
+    DEFINE("Define", R.drawable.ic_menu_dict, false),
 }
 
 /**

--- a/app/src/main/res/drawable/ic_menu_adjust.xml
+++ b/app/src/main/res/drawable/ic_menu_adjust.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@android:color/black" android:pathData="M3,17v2h6v-2H3zM3,5v2h10V5H3zM13,21v-2h8v-2h-8v-2h-2v6h2zM7,9v2H3v2h4v2h2V9H7zM21,13v-2H11v2h10zM15,9h2V7h4V5h-4V3h-2v6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_menu_crop.xml
+++ b/app/src/main/res/drawable/ic_menu_crop.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@android:color/black" android:pathData="M7,17V1H5v4H1v2h4v10c0,1.1 0.9,2 2,2h10v4h2v-4h4v-2H7V17zM17,15h2V7c0,-1.1 -0.9,-2 -2,-2H9v2h8V15z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_menu_dict.xml
+++ b/app/src/main/res/drawable/ic_menu_dict.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <!-- An open book (dictionary), distinct from the search magnifier. -->
+    <path android:fillColor="@android:color/black" android:pathData="M21,5c-1.11,-0.35 -2.33,-0.5 -3.5,-0.5 -1.95,0 -4.05,0.4 -5.5,1.5 -1.45,-1.1 -3.55,-1.5 -5.5,-1.5S2.45,4.9 1,6v14.65c0,0.25 0.25,0.5 0.5,0.5 0.1,0 0.15,-0.05 0.25,-0.05C3.1,20.45 5.05,20 6.5,20c1.95,0 4.05,0.4 5.5,1.5 1.35,-0.85 3.8,-1.5 5.5,-1.5 1.65,0 3.35,0.3 4.75,1.05 0.1,0.05 0.15,0.05 0.25,0.05 0.25,0 0.5,-0.25 0.5,-0.5V6c-0.6,-0.45 -1.25,-0.75 -2,-1zM21,18.5c-1.1,-0.35 -2.3,-0.5 -3.5,-0.5 -1.7,0 -4.15,0.65 -5.5,1.5V8c1.35,-0.85 3.8,-1.5 5.5,-1.5 1.2,0 2.4,0.15 3.5,0.5v11.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_menu_display.xml
+++ b/app/src/main/res/drawable/ic_menu_display.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@android:color/black" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM4,12c0,-4.41 3.59,-8 8,-8v16c-4.41,0 -8,-3.59 -8,-8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_menu_fit.xml
+++ b/app/src/main/res/drawable/ic_menu_fit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <!-- Fit: a page contained within the screen frame (inner rect inside outer rect). -->
+    <path android:strokeColor="@android:color/black" android:strokeWidth="1.6"
+        android:fillColor="#00000000"
+        android:pathData="M3,4 h18 a0,0 0,0 1,0 0 v16 a0,0 0,0 1,0 0 H3 a0,0 0,0 1,0 0 V4 a0,0 0,0 1,0 0 Z"/>
+    <path android:fillColor="#22000000" android:strokeColor="@android:color/black"
+        android:strokeWidth="1.2" android:pathData="M8,7 h8 v10 h-8 z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_menu_page.xml
+++ b/app/src/main/res/drawable/ic_menu_page.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <!-- A page with text lines (reflow/page layout). -->
+    <path android:strokeColor="@android:color/black" android:strokeWidth="1.6"
+        android:fillColor="#00000000" android:pathData="M6,3 H18 V21 H6 Z"/>
+    <path android:fillColor="@android:color/black"
+        android:pathData="M8.5,7 h7 v1.4 h-7 z M8.5,10.3 h7 v1.4 h-7 z M8.5,13.6 h7 v1.4 h-7 z M8.5,16.9 h4.5 v1.4 h-4.5 z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_menu_rotate.xml
+++ b/app/src/main/res/drawable/ic_menu_rotate.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@android:color/black" android:pathData="M16.48,2.52c3.27,1.55 5.61,4.72 5.97,8.48h1.5C23.44,4.84 18.29,0 12,0l-0.66,0.03 3.81,3.81 1.33,-1.32zM10.23,1.75c-0.59,-0.59 -1.54,-0.59 -2.12,0L1.75,8.11c-0.59,0.59 -0.59,1.54 0,2.12l12.02,12.02c0.59,0.59 1.54,0.59 2.12,0l6.36,-6.36c0.59,-0.59 0.59,-1.54 0,-2.12L10.23,1.75zM14.83,21.19L2.81,9.17l6.36,-6.36 12.02,12.02 -6.36,6.36zM7.52,21.48C4.25,19.94 1.91,16.76 1.55,13H0.05C0.56,19.16 5.71,24 12,24l0.66,-0.03 -3.81,-3.81 -1.33,1.32z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_menu_zoom_in.xml
+++ b/app/src/main/res/drawable/ic_menu_zoom_in.xml
@@ -1,5 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp" android:height="24dp"
     android:viewportWidth="24" android:viewportHeight="24">
-    <path android:fillColor="@android:color/black" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14zM12,10h-2v2H9v-2H7V9h2V7h1v2h2v1z"/>
+    <!-- Zoom in: a circle with a plus (no magnifier — magnifier is reserved for Search). -->
+    <path android:strokeColor="@android:color/black" android:strokeWidth="1.8"
+        android:fillColor="#00000000"
+        android:pathData="M12,12 m-8,0 a8,8 0 1,0 16,0 a8,8 0 1,0 -16,0"/>
+    <path android:fillColor="@android:color/black"
+        android:pathData="M11,8 h2 v3 h3 v2 h-3 v3 h-2 v-3 h-3 v-2 h3 Z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_menu_zoom_out.xml
+++ b/app/src/main/res/drawable/ic_menu_zoom_out.xml
@@ -1,5 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp" android:height="24dp"
     android:viewportWidth="24" android:viewportHeight="24">
-    <path android:fillColor="@android:color/black" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14zM7,9h5v1H7z"/>
+    <!-- Zoom out: a circle with a minus (no magnifier — magnifier is reserved for Search). -->
+    <path android:strokeColor="@android:color/black" android:strokeWidth="1.8"
+        android:fillColor="#00000000"
+        android:pathData="M12,12 m-8,0 a8,8 0 1,0 16,0 a8,8 0 1,0 -16,0"/>
+    <path android:fillColor="@android:color/black" android:pathData="M8,11 h8 v2 h-8 Z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_tool_lasso.xml
+++ b/app/src/main/res/drawable/ic_tool_lasso.xml
@@ -1,6 +1,13 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp" android:height="24dp"
     android:viewportWidth="24" android:viewportHeight="24">
+    <!-- Lasso: an open rope loop with a dangling tail + knot (selection lasso). -->
+    <path android:strokeColor="@android:color/black" android:strokeWidth="1.6"
+        android:fillColor="#00000000" android:strokeLineCap="round"
+        android:pathData="M12,4.5 C16.7,4.5 20,7 20,10 C20,13 16.7,15.5 12,15.5 C7.3,15.5 4,13 4,10 C4,7 7.3,4.5 12,4.5 Z"/>
+    <path android:strokeColor="@android:color/black" android:strokeWidth="1.6"
+        android:fillColor="#00000000" android:strokeLineCap="round"
+        android:pathData="M8.4,15.0 C7.6,16.6 7.4,18.3 8.8,19.4"/>
     <path android:fillColor="@android:color/black"
-        android:pathData="M4.59,6.89c0.7,-0.71 1.4,-1.35 1.71,-1.22 0.5,0.2 0,1.03 -0.3,1.52 -0.25,0.42 -2.86,3.89 -2.86,6.31 0,1.28 0.48,2.34 1.34,2.98 0.75,0.56 1.74,0.73 2.64,0.46 1.07,-0.31 1.95,-1.4 3.06,-2.77 1.21,-1.49 2.83,-3.44 4.08,-3.44 1.63,0 1.65,1.01 1.76,1.79 -3.78,0.64 -5.38,3.67 -5.38,5.37 0,1.7 1.44,3.09 3.21,3.09 1.63,0 4.29,-1.33 4.69,-6.1H21v-2.5h-2.47c-0.15,-1.65 -1.09,-4.2 -4.03,-4.2 -2.25,0 -4.18,1.91 -4.94,2.84 -0.58,0.73 -2.06,2.48 -2.29,2.72 -0.25,0.3 -0.68,0.84 -1.11,0.84 -0.45,0 -0.72,-0.83 -0.36,-1.92 0.35,-1.09 1.4,-2.86 1.85,-3.52 0.78,-1.14 1.3,-1.92 1.3,-3.28C10.5,4.24 9.36,3 7.79,3 6.55,3 5.39,3.93 4.85,4.51c-0.81,0.85 -1.5,1.62 -1.5,1.62l1.24,0.76z"/>
+        android:pathData="M8.8,18.6 m-1.4,0 a1.4,1.4 0,1 0,2.8 0 a1.4,1.4 0,1 0,-2.8 0"/>
 </vector>

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -27,6 +27,33 @@ pub trait Metrics {
 }
 
 /// Viewport + typography for a layout pass (all pixels). Repagination on a font-size or margin
+/// Horizontal text alignment for reflowed lines (RR4 — KOReader's "Alignment").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Align {
+    /// Flush left, ragged right (default).
+    #[default]
+    Left,
+    /// Stretch inter-word gaps to fill the line (last line of a block stays left).
+    Justify,
+    /// Centered.
+    Center,
+    /// Flush right.
+    Right,
+}
+
+impl Align {
+    /// Decode the wire integer (`0=Left, 1=Justify, 2=Center, 3=Right`); unknown → `Left`.
+    #[must_use]
+    pub fn from_code(code: i32) -> Align {
+        match code {
+            1 => Align::Justify,
+            2 => Align::Center,
+            3 => Align::Right,
+            _ => Align::Left,
+        }
+    }
+}
+
 /// change just reruns [`paginate`] with new opts.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LayoutOpts {
@@ -42,6 +69,8 @@ pub struct LayoutOpts {
     pub line_spacing: f32,
     /// Vertical gap inserted after each block.
     pub para_gap: f32,
+    /// Horizontal alignment of reflowed lines (RR4).
+    pub align: Align,
 }
 
 impl LayoutOpts {
@@ -55,6 +84,7 @@ impl LayoutOpts {
             font_px,
             line_spacing: 1.4,
             para_gap: font_px * 0.7,
+            align: Align::Left,
         }
     }
 
@@ -224,7 +254,15 @@ impl<'o> Pager<'o> {
     ) {
         let lines = break_lines(inlines, size, indent, self.opts.content_w(), bold_all, m);
         let line_h = size * self.opts.line_spacing;
-        for runs in lines {
+        let n = lines.len();
+        for (i, mut runs) in lines.into_iter().enumerate() {
+            align_line(
+                &mut runs,
+                self.opts.align,
+                self.opts.content_w(),
+                i + 1 == n,
+                m,
+            );
             self.emit(runs, line_h, false);
         }
     }
@@ -317,6 +355,46 @@ fn tokenize(inlines: &[Inline], bold_all: bool) -> Vec<Tok<'_>> {
         }
     }
     toks
+}
+
+/// Re-position a line's runs for `align` (RR4). Runs come from [`break_lines`] flush-left; this
+/// shifts them (Center/Right) or distributes the slack across inter-word gaps (Justify). The last
+/// line of a block (`is_last`) stays left under Justify, as in normal typography.
+fn align_line(
+    runs: &mut [PlacedRun],
+    align: Align,
+    content_w: f32,
+    is_last: bool,
+    m: &dyn Metrics,
+) {
+    if runs.is_empty() || align == Align::Left {
+        return;
+    }
+    let left = runs[0].x; // the line's left edge (indent)
+    let right = runs
+        .iter()
+        .map(|r| r.x + m.advance(&r.text, r.size_px, r.bold, r.italic))
+        .fold(0.0f32, f32::max);
+    let slack = (content_w - right).max(0.0);
+    if slack <= 0.0 {
+        return;
+    }
+    match align {
+        Align::Left => {}
+        Align::Center => runs.iter_mut().for_each(|r| r.x += slack * 0.5),
+        Align::Right => runs.iter_mut().for_each(|r| r.x += slack),
+        Align::Justify => {
+            // Spread the slack across the N-1 word gaps; skip the block's last line.
+            if is_last || runs.len() < 2 {
+                let _ = left;
+                return;
+            }
+            let per = slack / (runs.len() - 1) as f32;
+            for (k, r) in runs.iter_mut().enumerate() {
+                r.x += per * k as f32;
+            }
+        }
+    }
 }
 
 /// Greedy line-break: returns each line as its positioned runs (x relative to content origin; the
@@ -423,6 +501,7 @@ mod tests {
             font_px: 10.0,
             line_spacing: 1.0,
             para_gap: 0.0,
+            align: Align::Left,
         };
         let words = "aaaa ".repeat(12); // 12 words of 4 chars → ~ wraps
         let pages = paginate(&[para(words.trim())], &opts, &Mono);
@@ -451,6 +530,7 @@ mod tests {
             font_px: 10.0,
             line_spacing: 1.0,
             para_gap: 0.0,
+            align: Align::Left,
         };
         let blocks: Vec<Block> = (0..7).map(|_| para("x")).collect();
         let pages = paginate(&blocks, &opts, &Mono);
@@ -468,6 +548,7 @@ mod tests {
             font_px: 10.0,
             line_spacing: 1.0,
             para_gap: 0.0,
+            align: Align::Left,
         };
         let pages = paginate(
             &[Block::Heading {

--- a/inkread-epub/src/lib.rs
+++ b/inkread-epub/src/lib.rs
@@ -20,7 +20,7 @@ pub mod content;
 pub mod layout;
 pub mod render;
 pub use content::{parse_blocks, Block, Inline, TextRun};
-pub use layout::{paginate, LayoutLine, LayoutOpts, Metrics, Page, PlacedRun};
+pub use layout::{paginate, Align, LayoutLine, LayoutOpts, Metrics, Page, PlacedRun};
 pub use render::{render_page, AbFont, GrayCanvas};
 
 /// The error surface for EPUB parsing — mirrors `inkread-dict`'s shape so the `reader-core` adapter

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -413,22 +413,8 @@ impl Document for PdfBackend {
             return self.render_page(index, buf);
         }
 
-        // Fitted render size (aspect-preserved). Page = contain; Width/Height fill that dimension.
-        let (tw, th) = match mode {
-            FitMode::Page => {
-                if (bw as f32 / bh as f32) > aspect {
-                    (((bh as f32) * aspect).round() as i32, bh)
-                } else {
-                    (bw, ((bw as f32) / aspect).round() as i32)
-                }
-            }
-            FitMode::Width => (bw, ((bw as f32) / aspect).round() as i32),
-            FitMode::Height => (((bh as f32) * aspect).round() as i32, bh),
-        };
-        let tw = tw.clamp(1, 1 << 15);
-        let th = th.clamp(1, 1 << 15);
-
-        // Render the page aspect-correct into a temp buffer, then composite into the white page.
+        // Render the page aspect-correct into a temp buffer, then composite it into the white page.
+        let (tw, th) = fit_dims(aspect, bw, bh, mode);
         let mut tmp = vec![0u8; (tw as usize) * (th as usize) * 4];
         {
             let mut tbuf = PixelBuffer::from_rgba(&mut tmp, tw as u32, th as u32)?;
@@ -439,17 +425,99 @@ impl Document for PdfBackend {
                     .set_reverse_byte_order(true)
             })?;
         }
+        composite_centered(buf, &tmp, tw, th, pan_x, pan_y);
+        Ok(())
+    }
 
-        // Center when the fitted page fits the axis; pan (scroll) when it overflows.
-        let (sx, dx, cw) = fit_place(tw, bw, pan_x);
-        let (sy, dy, ch) = fit_place(th, bh, pan_y);
-        let dst = buf.bytes_mut();
-        for row in 0..ch {
-            let s = (((sy + row) * tw + sx) * 4) as usize;
-            let d = (((dy + row) * bw + dx) * 4) as usize;
-            let n = (cw * 4) as usize;
-            dst[d..d + n].copy_from_slice(&tmp[s..s + n]);
+    fn content_bbox(&self, index: usize) -> Option<NormRect> {
+        let page = i32::try_from(index)
+            .ok()
+            .and_then(|i| self.document.pages().get(i).ok())?;
+        let (pw, ph) = (page.width().value, page.height().value);
+        if pw <= 0.0 || ph <= 0.0 {
+            return None;
         }
+        // Render the page small (aspect-correct) and scan for the non-white content box.
+        let aspect = pw / ph;
+        let probe_w = 480i32;
+        let probe_h = ((probe_w as f32 / aspect).round() as i32).clamp(1, 2000);
+        let mut px = vec![0u8; (probe_w as usize) * (probe_h as usize) * 4];
+        {
+            let mut pbuf = PixelBuffer::from_rgba(&mut px, probe_w as u32, probe_h as u32).ok()?;
+            self.render_with_config(index, &mut pbuf, |w, h| {
+                PdfRenderConfig::new()
+                    .set_target_size(w, h)
+                    .set_format(PdfBitmapFormat::BGRA)
+                    .set_reverse_byte_order(true)
+            })
+            .ok()?;
+        }
+        const INK: u8 = 235; // any channel below this counts as content (not paper white)
+        let (mut minx, mut miny, mut maxx, mut maxy) = (probe_w, probe_h, -1i32, -1i32);
+        for y in 0..probe_h {
+            for x in 0..probe_w {
+                let o = ((y * probe_w + x) * 4) as usize;
+                if px[o] < INK || px[o + 1] < INK || px[o + 2] < INK {
+                    minx = minx.min(x);
+                    maxx = maxx.max(x);
+                    miny = miny.min(y);
+                    maxy = maxy.max(y);
+                }
+            }
+        }
+        if maxx < minx || maxy < miny {
+            return None; // blank page
+        }
+        let pad = 0.01f32; // keep a hair of margin so glyph edges aren't clipped
+        let x0 = (minx as f32 / probe_w as f32 - pad).clamp(0.0, 1.0);
+        let y0 = (miny as f32 / probe_h as f32 - pad).clamp(0.0, 1.0);
+        let x1 = ((maxx + 1) as f32 / probe_w as f32 + pad).clamp(0.0, 1.0);
+        let y1 = ((maxy + 1) as f32 / probe_h as f32 + pad).clamp(0.0, 1.0);
+        if x1 - x0 < 0.05 || y1 - y0 < 0.05 {
+            return None; // implausibly tiny — ignore the crop
+        }
+        Some(NormRect { x0, y0, x1, y1 })
+    }
+
+    fn render_cropped(
+        &self,
+        index: usize,
+        buf: &mut PixelBuffer<'_>,
+        crop: NormRect,
+        mode: FitMode,
+        pan_x: f32,
+        pan_y: f32,
+    ) -> CoreResult<()> {
+        buf.fill_white();
+        let bw = i32::try_from(buf.width()).unwrap_or(0);
+        let bh = i32::try_from(buf.height()).unwrap_or(0);
+        let page = i32::try_from(index)
+            .ok()
+            .and_then(|i| self.document.pages().get(i).ok());
+        let (pw, ph) = match &page {
+            Some(p) => (p.width().value, p.height().value),
+            None => return self.render_fit(index, buf, mode, pan_x, pan_y),
+        };
+        let x0 = crop.x0.clamp(0.0, 1.0);
+        let y0 = crop.y0.clamp(0.0, 1.0);
+        let x1 = crop.x1.clamp(0.0, 1.0);
+        let y1 = crop.y1.clamp(0.0, 1.0);
+        let crop_w_pt = (x1 - x0) * pw;
+        let crop_h_pt = (y1 - y0) * ph;
+        if crop_w_pt <= 0.0 || crop_h_pt <= 0.0 || bw <= 0 || bh <= 0 {
+            return self.render_fit(index, buf, mode, pan_x, pan_y);
+        }
+        let (tw, th) = fit_dims(crop_w_pt / crop_h_pt, bw, bh, mode);
+        // Scale so the crop region becomes the temp size, then render just that window.
+        let s = tw as f32 / crop_w_pt;
+        let off_x = (x0 * pw * s).round() as i32;
+        let off_y = (y0 * ph * s).round() as i32;
+        let mut tmp = vec![0u8; (tw as usize) * (th as usize) * 4];
+        {
+            let mut tbuf = PixelBuffer::from_rgba(&mut tmp, tw as u32, th as u32)?;
+            self.render_region(index, &mut tbuf, s, off_x, off_y)?;
+        }
+        composite_centered(buf, &tmp, tw, th, pan_x, pan_y);
         Ok(())
     }
 
@@ -563,6 +631,46 @@ impl Document for PdfBackend {
 
     fn text_in_rect(&self, page: usize, rect: NormRect) -> TextSelection {
         text_select::text_in_rect(&self.page_chars(page), rect)
+    }
+}
+
+/// The aspect-preserving render size for `aspect` (w/h) inside a `bw`×`bh` buffer under [`FitMode`]
+/// (RR4). `Page` contains; `Width`/`Height` fill that axis (the other may overflow). Clamped sane.
+fn fit_dims(aspect: f32, bw: i32, bh: i32, mode: FitMode) -> (i32, i32) {
+    let (tw, th) = match mode {
+        FitMode::Page => {
+            if (bw as f32 / bh as f32) > aspect {
+                (((bh as f32) * aspect).round() as i32, bh)
+            } else {
+                (bw, ((bw as f32) / aspect).round() as i32)
+            }
+        }
+        FitMode::Width => (bw, ((bw as f32) / aspect).round() as i32),
+        FitMode::Height => (((bh as f32) * aspect).round() as i32, bh),
+    };
+    (tw.clamp(1, 1 << 15), th.clamp(1, 1 << 15))
+}
+
+/// Composite a `tw`×`th` RGBA `tmp` image into `buf` (RR4): centered with white letterbox when it
+/// fits, panned by the normalized `pan_*` when it overflows. Shared by fit + crop renders.
+fn composite_centered(
+    buf: &mut PixelBuffer<'_>,
+    tmp: &[u8],
+    tw: i32,
+    th: i32,
+    pan_x: f32,
+    pan_y: f32,
+) {
+    let bw = i32::try_from(buf.width()).unwrap_or(0);
+    let bh = i32::try_from(buf.height()).unwrap_or(0);
+    let (sx, dx, cw) = fit_place(tw, bw, pan_x);
+    let (sy, dy, ch) = fit_place(th, bh, pan_y);
+    let dst = buf.bytes_mut();
+    for row in 0..ch {
+        let s = (((sy + row) * tw + sx) * 4) as usize;
+        let d = (((dy + row) * bw + dx) * 4) as usize;
+        let n = (cw * 4) as usize;
+        dst[d..d + n].copy_from_slice(&tmp[s..s + n]);
     }
 }
 

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -20,7 +20,7 @@ use pdfium_render::prelude::*;
 
 use crate::document::text_select::{self, CharBox, NormRect, TextSelection};
 use crate::document::{
-    Document, DocumentMetadata, ExportMode, LinkTarget, PageInk, PageLink, TocEntry,
+    Document, DocumentMetadata, ExportMode, FitMode, LinkTarget, PageInk, PageLink, TocEntry,
 };
 use crate::error::{CoreError, CoreResult};
 use crate::render::PixelBuffer;
@@ -385,6 +385,74 @@ impl Document for PdfBackend {
         })
     }
 
+    fn render_fit(
+        &self,
+        index: usize,
+        buf: &mut PixelBuffer<'_>,
+        mode: FitMode,
+        pan_x: f32,
+        pan_y: f32,
+    ) -> CoreResult<()> {
+        buf.fill_white();
+        let bw = i32::try_from(buf.width()).unwrap_or(0);
+        let bh = i32::try_from(buf.height()).unwrap_or(0);
+        // The page's native aspect (points). Unknown/degenerate → fall back to the stretch render.
+        let aspect = i32::try_from(index)
+            .ok()
+            .and_then(|i| self.document.pages().get(i).ok())
+            .map(|p| {
+                let (pw, ph) = (p.width().value, p.height().value);
+                if pw > 0.0 && ph > 0.0 {
+                    pw / ph
+                } else {
+                    0.0
+                }
+            })
+            .unwrap_or(0.0);
+        if aspect <= 0.0 || bw <= 0 || bh <= 0 {
+            return self.render_page(index, buf);
+        }
+
+        // Fitted render size (aspect-preserved). Page = contain; Width/Height fill that dimension.
+        let (tw, th) = match mode {
+            FitMode::Page => {
+                if (bw as f32 / bh as f32) > aspect {
+                    (((bh as f32) * aspect).round() as i32, bh)
+                } else {
+                    (bw, ((bw as f32) / aspect).round() as i32)
+                }
+            }
+            FitMode::Width => (bw, ((bw as f32) / aspect).round() as i32),
+            FitMode::Height => (((bh as f32) * aspect).round() as i32, bh),
+        };
+        let tw = tw.clamp(1, 1 << 15);
+        let th = th.clamp(1, 1 << 15);
+
+        // Render the page aspect-correct into a temp buffer, then composite into the white page.
+        let mut tmp = vec![0u8; (tw as usize) * (th as usize) * 4];
+        {
+            let mut tbuf = PixelBuffer::from_rgba(&mut tmp, tw as u32, th as u32)?;
+            self.render_with_config(index, &mut tbuf, |w, h| {
+                PdfRenderConfig::new()
+                    .set_target_size(w, h)
+                    .set_format(PdfBitmapFormat::BGRA)
+                    .set_reverse_byte_order(true)
+            })?;
+        }
+
+        // Center when the fitted page fits the axis; pan (scroll) when it overflows.
+        let (sx, dx, cw) = fit_place(tw, bw, pan_x);
+        let (sy, dy, ch) = fit_place(th, bh, pan_y);
+        let dst = buf.bytes_mut();
+        for row in 0..ch {
+            let s = (((sy + row) * tw + sx) * 4) as usize;
+            let d = (((dy + row) * bw + dx) * 4) as usize;
+            let n = (cw * 4) as usize;
+            dst[d..d + n].copy_from_slice(&tmp[s..s + n]);
+        }
+        Ok(())
+    }
+
     fn render_zoom(
         &self,
         index: usize,
@@ -495,6 +563,19 @@ impl Document for PdfBackend {
 
     fn text_in_rect(&self, page: usize, rect: NormRect) -> TextSelection {
         text_select::text_in_rect(&self.page_chars(page), rect)
+    }
+}
+
+/// Placement of a fitted dimension `fit` inside a buffer dimension `buf` (RR4 Fit). Returns
+/// `(src_offset, dst_offset, count)`: **centered** with white letterbox when it fits, **panned** by
+/// the normalized `pan` when it overflows. Always in-bounds for both buffers.
+fn fit_place(fit: i32, buf: i32, pan: f32) -> (i32, i32, i32) {
+    if fit <= buf {
+        (0, (buf - fit) / 2, fit)
+    } else {
+        let over = fit - buf;
+        let src = (pan.clamp(0.0, 1.0) * over as f32).round() as i32;
+        (src.clamp(0, over), 0, buf)
     }
 }
 

--- a/reader-core/src/document/fixed/pdf_tests.rs
+++ b/reader-core/src/document/fixed/pdf_tests.rs
@@ -480,3 +480,43 @@ fn zoom_z1_matches_render_page_orientation() {
         "render_zoom(z=1) differs from render_page / is flipped (same={same} flipped={flipped})"
     );
 }
+
+// RR4 Fit: Page mode preserves aspect and letterboxes — a portrait/letter page rendered into a
+// WIDE buffer is centered with white left/right margins (not stretched edge-to-edge).
+#[test]
+fn render_fit_page_letterboxes_and_preserves_aspect() {
+    let _g = pdfium_serial();
+    if !host_pdfium_available() {
+        eprintln!("SKIP render_fit_page_letterboxes: host libpdfium UNVERIFIED");
+        return;
+    }
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/minimal.pdf"
+    ))
+    .expect("fixture present");
+    let doc = PdfBackend::open(bytes).unwrap();
+    let (w, h) = (400u32, 100u32); // wide buffer; a portrait/letter page must letterbox L/R
+    let mut pixels = vec![0u8; (w * h * 4) as usize];
+    let mut pb = PixelBuffer::from_rgba(&mut pixels, w, h).unwrap();
+    doc.render_fit(0, &mut pb, FitMode::Page, 0.0, 0.0).unwrap();
+
+    let px = pb.bytes();
+    let col_white = |x: u32| {
+        (0..h).all(|y| {
+            let o = ((y * w + x) * 4) as usize;
+            px[o] == 255 && px[o + 1] == 255 && px[o + 2] == 255
+        })
+    };
+    assert!(
+        col_white(0),
+        "left edge is white letterbox (page centered, not stretched)"
+    );
+    assert!(col_white(w - 1), "right edge is white letterbox");
+    assert!(
+        px.chunks_exact(4)
+            .any(|p| p[0] < 200 || p[1] < 200 || p[2] < 200),
+        "the page actually rendered (some ink)"
+    );
+    assert!(px.chunks_exact(4).all(|p| p[3] == 0xFF), "opaque");
+}

--- a/reader-core/src/document/fixed/pdf_tests.rs
+++ b/reader-core/src/document/fixed/pdf_tests.rs
@@ -520,3 +520,42 @@ fn render_fit_page_letterboxes_and_preserves_aspect() {
     );
     assert!(px.chunks_exact(4).all(|p| p[3] == 0xFF), "opaque");
 }
+
+// RR4 Crop: content_bbox finds a box tighter than the full page (text doesn't fill the sheet),
+// and render_cropped renders that region without error.
+#[test]
+fn content_bbox_is_tighter_than_full_page_and_crops() {
+    let _g = pdfium_serial();
+    if !host_pdfium_available() {
+        eprintln!("SKIP content_bbox: host libpdfium UNVERIFIED");
+        return;
+    }
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/minimal.pdf"
+    ))
+    .expect("fixture present");
+    let doc = PdfBackend::open(bytes).unwrap();
+    let bbox = doc
+        .content_bbox(0)
+        .expect("content detected on a non-blank page");
+    assert!(bbox.x0 >= 0.0 && bbox.y0 >= 0.0 && bbox.x1 <= 1.0 && bbox.y1 <= 1.0);
+    assert!(
+        (bbox.x1 - bbox.x0) < 1.0 || (bbox.y1 - bbox.y0) < 1.0,
+        "crop box is tighter than the whole page: {bbox:?}"
+    );
+
+    // Rendering the cropped region produces ink (the content fills the buffer), no error.
+    let (w, h) = (200u32, 260u32);
+    let mut pixels = vec![0u8; (w * h * 4) as usize];
+    let mut pb = PixelBuffer::from_rgba(&mut pixels, w, h).unwrap();
+    doc.render_cropped(0, &mut pb, bbox, FitMode::Page, 0.0, 0.0)
+        .unwrap();
+    assert!(
+        pb.bytes()
+            .chunks_exact(4)
+            .any(|p| p[0] < 200 || p[1] < 200 || p[2] < 200),
+        "cropped render shows content"
+    );
+    assert!(pb.bytes().chunks_exact(4).all(|p| p[3] == 0xFF), "opaque");
+}

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -305,6 +305,20 @@ pub trait Document {
         None
     }
 
+    /// Set the reflow **line spacing** multiplier (e.g. `1.2`/`1.4`/`1.7`) and repaginate, preserving
+    /// the chapter (RR4 — KOReader's "Line Spacing"). Returns the new page, or `None` for a
+    /// fixed-layout format (PDF). Default: unsupported.
+    fn set_line_spacing(&self, _mult: f32, _current_page: usize) -> Option<usize> {
+        None
+    }
+
+    /// Set the reflow **alignment** (`0=Left, 1=Justify, 2=Center, 3=Right`) and repaginate,
+    /// preserving the chapter (RR4 — KOReader's "Alignment"). Returns the new page, or `None` for a
+    /// fixed-layout format (PDF). Default: unsupported.
+    fn set_alignment(&self, _align_code: i32, _current_page: usize) -> Option<usize> {
+        None
+    }
+
     /// Prefetch hint (RR4-FR7): the core may call this after rendering the current page so a
     /// backend can warm an internal handle for the likely-next page, making a page turn blit a
     /// ready buffer. Default: a no-op (backends opt in). Must never panic on a bad index.

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -272,6 +272,29 @@ pub trait Document {
         self.render_page(index, buf)
     }
 
+    /// The page's **content bounding box** in normalized page coords `[0,1]` (RR4 — KOReader's
+    /// auto Crop): the tight rectangle around the non-white content, used to trim white margins.
+    /// `None` if undetectable or not applicable (blank page / reflowable backend). Never panics.
+    fn content_bbox(&self, _index: usize) -> Option<NormRect> {
+        None
+    }
+
+    /// Render the normalized `crop` sub-rect of page `index` fit to `buf` per [`FitMode`] (RR4 —
+    /// Crop). Like [`Self::render_fit`] but only the cropped region is shown (margins trimmed), so
+    /// the content fills the screen. `pan_x`/`pan_y` scroll an overflowing axis. Default: ignores
+    /// the crop and falls back to [`Self::render_fit`] (reflowable backends don't crop).
+    fn render_cropped(
+        &self,
+        index: usize,
+        buf: &mut PixelBuffer<'_>,
+        _crop: NormRect,
+        mode: FitMode,
+        pan_x: f32,
+        pan_y: f32,
+    ) -> CoreResult<()> {
+        self.render_fit(index, buf, mode, pan_x, pan_y)
+    }
+
     /// Adjust the reflow **text scale** (`1.0` = the backend default size) and repaginate (RR2-FR5
     /// font-size control). `current_page` is the page the reader is on *before* the change; the
     /// backend returns `Some(new_page)` to jump to so the reading position is preserved across the

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -46,6 +46,31 @@ pub enum ExportMode {
     Flatten,
 }
 
+/// How a fixed-layout page is fit to the viewport (RR4 — KOReader's "Fit"). All modes preserve the
+/// page's aspect ratio (unlike a raw stretch); the difference is which dimension is filled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FitMode {
+    /// Fit the whole page within the viewport (contain), centered with white letterbox. Default.
+    #[default]
+    Page,
+    /// Scale so the page **width** fills the viewport; taller pages overflow vertically (pannable).
+    Width,
+    /// Scale so the page **height** fills the viewport; wider pages overflow horizontally (pannable).
+    Height,
+}
+
+impl FitMode {
+    /// Decode the wire integer (`0=Page, 1=Width, 2=Height`); unknown → `Page`.
+    #[must_use]
+    pub fn from_code(code: i32) -> FitMode {
+        match code {
+            1 => FitMode::Width,
+            2 => FitMode::Height,
+            _ => FitMode::Page,
+        }
+    }
+}
+
 /// Document metadata (title/author) — the M0 subset (RR5-FR2).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DocumentMetadata {
@@ -227,6 +252,22 @@ pub trait Document {
         _zoom: f32,
         _offset_x: i32,
         _offset_y: i32,
+    ) -> CoreResult<()> {
+        self.render_page(index, buf)
+    }
+
+    /// Render page `index` fit to `buf` per [`FitMode`], preserving the page aspect ratio (RR4).
+    /// `pan_x`/`pan_y` are normalized `[0,1]` scroll positions used only when a mode overflows the
+    /// viewport (e.g. `Width` on a tall page); centered when the page fits. Default: ignores fit and
+    /// falls back to [`Self::render_page`] — correct for reflowable backends (EPUB), which already
+    /// fill the viewport. Fixed-layout backends (PDF) override this.
+    fn render_fit(
+        &self,
+        index: usize,
+        buf: &mut PixelBuffer<'_>,
+        _mode: FitMode,
+        _pan_x: f32,
+        _pan_y: f32,
     ) -> CoreResult<()> {
         self.render_page(index, buf)
     }

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -12,7 +12,7 @@
 
 use std::cell::{Cell, RefCell};
 
-use inkread_epub::layout::{paginate, LayoutOpts, Page};
+use inkread_epub::layout::{paginate, Align, LayoutOpts, Page};
 use inkread_epub::render::{render_page as raster_page, AbFont, GrayCanvas};
 use inkread_epub::{parse_blocks, Block, EpubPackage, NavPoint};
 
@@ -51,6 +51,10 @@ pub struct EpubBackend {
     font: AbFont,
     /// User text scale (font size); `1.0` = [`BASE_FONT_PX`]. Drives repagination.
     scale: Cell<f32>,
+    /// Line-spacing multiple (RR4 — default 1.4). Drives repagination.
+    line_spacing: Cell<f32>,
+    /// Text alignment (RR4 — default Left). Drives repagination.
+    align: Cell<Align>,
     /// The current pagination; recomputed when the viewport or scale changes.
     laid: RefCell<Laid>,
 }
@@ -74,6 +78,8 @@ impl EpubBackend {
             viewport.width,
             viewport.height,
             BASE_FONT_PX,
+            1.4,
+            Align::Left,
         );
         Ok(Self {
             chapters,
@@ -82,6 +88,8 @@ impl EpubBackend {
             meta,
             font,
             scale: Cell::new(1.0),
+            line_spacing: Cell::new(1.4),
+            align: Cell::new(Align::Left),
             laid: RefCell::new(laid),
         })
     }
@@ -102,9 +110,39 @@ impl EpubBackend {
                 || (laid.opts.font_px - font_px).abs() > 0.01
         };
         if needs {
-            let fresh = layout_all(&self.chapters, &self.font, w, h, font_px);
+            let fresh = layout_all(
+                &self.chapters,
+                &self.font,
+                w,
+                h,
+                font_px,
+                self.line_spacing.get(),
+                self.align.get(),
+            );
             *self.laid.borrow_mut() = fresh;
         }
+    }
+
+    /// Repaginate at the current viewport/scale, anchoring the reading position to the chapter
+    /// `current_page` is in, and return that chapter's new start page (RR4 line-spacing/alignment).
+    fn repaginate_keeping_chapter(&self, current_page: usize) -> Option<usize> {
+        let chapter = self.chapter_of(current_page);
+        let (w, h) = {
+            let laid = self.laid.borrow();
+            (laid.opts.page_w as u32, laid.opts.page_h as u32)
+        };
+        let fresh = layout_all(
+            &self.chapters,
+            &self.font,
+            w,
+            h,
+            self.font_px(),
+            self.line_spacing.get(),
+            self.align.get(),
+        );
+        let target = fresh.chapter_start.get(chapter).copied().unwrap_or(0);
+        *self.laid.borrow_mut() = fresh;
+        Some(target)
     }
 
     /// The chapter index that global `page` falls in (the last chapter whose start ≤ page).
@@ -164,22 +202,39 @@ impl Document for EpubBackend {
         };
         // Anchor the reading position to the current chapter, repaginate at the new size, then
         // return that chapter's new start page so the reader stays put across the reflow.
-        let chapter = self.chapter_of(current_page);
         self.scale.set(scale);
-        let (w, h) = {
-            let laid = self.laid.borrow();
-            (laid.opts.page_w as u32, laid.opts.page_h as u32)
+        self.repaginate_keeping_chapter(current_page)
+    }
+
+    fn set_line_spacing(&self, mult: f32, current_page: usize) -> Option<usize> {
+        let mult = if mult.is_finite() {
+            mult.clamp(1.0, 2.5)
+        } else {
+            1.4
         };
-        let fresh = layout_all(&self.chapters, &self.font, w, h, self.font_px());
-        let target = fresh.chapter_start.get(chapter).copied().unwrap_or(0);
-        *self.laid.borrow_mut() = fresh;
-        Some(target)
+        self.line_spacing.set(mult);
+        self.repaginate_keeping_chapter(current_page)
+    }
+
+    fn set_alignment(&self, align_code: i32, current_page: usize) -> Option<usize> {
+        self.align.set(Align::from_code(align_code));
+        self.repaginate_keeping_chapter(current_page)
     }
 }
 
-/// Paginate every chapter for `(w, h, font_px)`; each chapter starts a fresh page.
-fn layout_all(chapters: &[Vec<Block>], font: &AbFont, w: u32, h: u32, font_px: f32) -> Laid {
-    let opts = LayoutOpts::new(w as f32, h as f32, font_px);
+/// Paginate every chapter for `(w, h, font_px, line_spacing, align)`; each chapter starts a page.
+fn layout_all(
+    chapters: &[Vec<Block>],
+    font: &AbFont,
+    w: u32,
+    h: u32,
+    font_px: f32,
+    line_spacing: f32,
+    align: Align,
+) -> Laid {
+    let mut opts = LayoutOpts::new(w as f32, h as f32, font_px);
+    opts.line_spacing = line_spacing;
+    opts.align = align;
     let mut pages = Vec::new();
     let mut chapter_start = Vec::with_capacity(chapters.len());
     for blocks in chapters {

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -609,6 +609,46 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetTextScal
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSetLineSpacing(handle, mult) : int — reflow line spacing (RR4); repaginates EPUB. Returns
+// the new page index, or -1 for a fixed-layout PDF. Re-render after.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetLineSpacing<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    mult: jfloat,
+) -> jint {
+    env.with_env(|env| -> jni::errors::Result<jint> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        if session.set_line_spacing(mult) {
+            Ok(session.current_page() as jint)
+        } else {
+            Ok(-1)
+        }
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// nativeSetAlignment(handle, code) : int — reflow alignment (0=Left,1=Justify,2=Center,3=Right; RR4);
+// repaginates EPUB. Returns the new page index, or -1 for a fixed-layout PDF. Re-render after.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetAlignment<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    code: jint,
+) -> jint {
+    env.with_env(|env| -> jni::errors::Result<jint> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        if session.set_alignment(code) {
+            Ok(session.current_page() as jint)
+        } else {
+            Ok(-1)
+        }
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkBeginStroke<'local>(
     mut env: EnvUnowned<'local>,

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -530,6 +530,25 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetFit<'loc
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSetCrop(handle, auto, marginStep) — auto-crop white margins (RR4). auto!=0 enables it;
+// marginStep (0..8, 1%-of-page each) keeps a margin around the detected content. Re-render after.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetCrop<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    auto: jint,
+    margin_step: jint,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session.set_crop_auto(auto != 0);
+        session.set_crop_margin(u8::try_from(margin_step.max(0)).unwrap_or(u8::MAX));
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetViewport(handle, width, height, dpi) — update the render viewport after a surface
 // resize / screen rotation (RR21-FR4). Without this the core keeps the open-time viewport and a
 // render into the new (resized) buffer is rejected as a size mismatch. PDF re-renders at the new

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -513,6 +513,23 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetContrast
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSetFit(handle, mode) — page fit mode (0=Page/contain, 1=Width, 2=Height; RR4). Aspect-
+// preserving; the shell re-renders afterward. Never throws (mode decoded leniently).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetFit<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    mode: jint,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session.set_fit(crate::document::FitMode::from_code(mode));
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetViewport(handle, width, height, dpi) — update the render viewport after a surface
 // resize / screen rotation (RR21-FR4). Without this the core keeps the open-time viewport and a
 // render into the new (resized) buffer is rejected as a size mismatch. PDF re-renders at the new

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -530,6 +530,23 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetFit<'loc
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSetRenderQuality(handle, q) — render quality (0=low, 1=default, 2=high; RR4). High
+// supersamples then downscales for smoother e-ink text. Re-render after. Never throws (clamped).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetRenderQuality<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    q: jint,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session.set_render_quality(u8::try_from(q.max(0)).unwrap_or(u8::MAX));
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetCrop(handle, auto, marginStep) — auto-crop white margins (RR4). auto!=0 enables it;
 // marginStep (0..8, 1%-of-page each) keeps a margin around the detected content. Re-render after.
 #[unsafe(no_mangle)]

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -496,6 +496,23 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetZoom<'lo
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSetContrast(handle, step) — display-enhancement contrast (0 = off; RR4). Applied as a
+// post-render pixel remap; the shell re-renders afterward. Never throws (clamped in the core).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetContrast<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    step: jint,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session.set_contrast(u8::try_from(step.max(0)).unwrap_or(u8::MAX));
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetTextScale(handle, scale) : int — set reflow font size (1.0 = default) for an EPUB;
 // repaginates, preserving the chapter. Returns the new current page index, or -1 for a fixed-layout
 // document (PDF) that does not reflow. The shell re-renders afterward (RR2-FR5).

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -513,6 +513,28 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetContrast
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSetViewport(handle, width, height, dpi) — update the render viewport after a surface
+// resize / screen rotation (RR21-FR4). Without this the core keeps the open-time viewport and a
+// render into the new (resized) buffer is rejected as a size mismatch. PDF re-renders at the new
+// size; EPUB repaginates on the next render. The shell re-renders afterward.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetViewport<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    width: jint,
+    height: jint,
+    dpi: jint,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let viewport = read_viewport(env, width, height, dpi)?;
+        session.set_viewport(viewport);
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetTextScale(handle, scale) : int — set reflow font size (1.0 = default) for an EPUB;
 // repaginates, preserving the chapter. Returns the new current page index, or -1 for a fixed-layout
 // document (PDF) that does not reflow. The shell re-renders afterward (RR2-FR5).

--- a/reader-core/src/render/contrast.rs
+++ b/reader-core/src/render/contrast.rs
@@ -1,32 +1,35 @@
 //! Contrast / display enhancement for the rendered page (RR4 — KOReader's "Contrast" control).
 //!
-//! A pure per-pixel luminance remap on the final RGBA buffer, applied **after** the backend renders
-//! and **before** the shell blits. Format-agnostic (PDF + EPUB) because it works on pixels, not
-//! layout. The headline win is legibility of faint/low-contrast scanned PDFs on a grayscale e-ink
-//! panel. Host-tested, no device types (IR-4).
+//! A pure per-pixel **gamma-darken** remap on the final RGBA buffer, applied **after** the backend
+//! renders and **before** the shell blits. Format-agnostic (PDF + EPUB). A gamma curve
+//! `out = 255·(in/255)^γ` with `γ > 1` keeps pure white (255→255) and pure black (0→0) fixed while
+//! pushing every gray toward black — so it darkens/thickens faint text without graying the page
+//! background. The win is legibility of faint or low-contrast scans on a grayscale e-ink panel; on a
+//! crisp digital PDF it still darkens the anti-aliased glyph edges, reading as slightly bolder text.
+//! Host-tested, no device types (IR-4).
 
 use crate::render::PixelBuffer;
 
 /// Number of contrast steps the UI exposes; `0` = off (identity), matching KOReader's slider cells.
 pub const MAX_CONTRAST_STEP: u8 = 8;
 
-/// Map a UI step (`0..=MAX_CONTRAST_STEP`) to a multiplicative contrast factor (`1.0` = identity).
+/// Map a UI step (`0..=MAX_CONTRAST_STEP`) to a darkening gamma (`1.0` = identity; higher = darker).
 #[must_use]
-pub fn step_to_factor(step: u8) -> f32 {
-    1.0 + f32::from(step.min(MAX_CONTRAST_STEP)) * 0.25 // step 8 → 3.0×
+pub fn step_to_gamma(step: u8) -> f32 {
+    1.0 + f32::from(step.min(MAX_CONTRAST_STEP)) * 0.5 // step 8 → γ 5.0 (strong)
 }
 
-/// Apply contrast `factor` (`1.0` = no-op) to the RGBA pixels in `buf`, pivoting around mid-gray so
-/// lights stay light and darks get darker. Alpha is untouched. A factor `<= 1.0` is a no-op (cheap
-/// early return). Uses a 256-entry LUT so the per-pixel cost is a table lookup.
-pub fn apply_contrast(buf: &mut PixelBuffer<'_>, factor: f32) {
-    if factor <= 1.0 + 1e-3 || !factor.is_finite() {
+/// Apply a darkening `gamma` (`1.0` = no-op) to the RGBA pixels in `buf`. `gamma <= 1.0` is a cheap
+/// no-op. Endpoints are fixed (white stays white, black stays black); mid grays move toward black.
+/// Uses a 256-entry LUT so the per-pixel cost is a table lookup. Alpha is untouched.
+pub fn apply_contrast(buf: &mut PixelBuffer<'_>, gamma: f32) {
+    if gamma <= 1.0 + 1e-3 || !gamma.is_finite() {
         return;
     }
     let mut lut = [0u8; 256];
     for (i, slot) in lut.iter_mut().enumerate() {
-        let adj = ((i as f32 - 128.0) * factor + 128.0).round();
-        *slot = adj.clamp(0.0, 255.0) as u8;
+        let v = (i as f32 / 255.0).powf(gamma) * 255.0;
+        *slot = v.round().clamp(0.0, 255.0) as u8;
     }
     for px in buf.bytes_mut().chunks_exact_mut(4) {
         px[0] = lut[px[0] as usize];
@@ -46,15 +49,15 @@ mod tests {
     }
 
     #[test]
-    fn step_zero_is_identity_factor() {
-        assert!((step_to_factor(0) - 1.0).abs() < 1e-6);
-        assert!(step_to_factor(8) > step_to_factor(4));
+    fn step_zero_is_identity_gamma() {
+        assert!((step_to_gamma(0) - 1.0).abs() < 1e-6);
+        assert!(step_to_gamma(8) > step_to_gamma(4));
         // saturates beyond the max step
-        assert_eq!(step_to_factor(99), step_to_factor(MAX_CONTRAST_STEP));
+        assert_eq!(step_to_gamma(99), step_to_gamma(MAX_CONTRAST_STEP));
     }
 
     #[test]
-    fn identity_factor_leaves_pixels_untouched() {
+    fn identity_gamma_leaves_pixels_untouched() {
         let mut bytes = [10, 128, 240, 255, 60, 200, 90, 128];
         let before = bytes;
         apply_contrast(&mut buf_with(&mut bytes), 1.0);
@@ -62,21 +65,20 @@ mod tests {
     }
 
     #[test]
-    fn higher_contrast_darkens_darks_and_lightens_lights() {
-        // dark pixel (50) and light pixel (200); alpha 255.
-        let mut bytes = [50, 50, 50, 255, 200, 200, 200, 255];
-        apply_contrast(&mut buf_with(&mut bytes), 2.0);
-        assert!(bytes[0] < 50, "dark got darker: {}", bytes[0]);
-        assert!(bytes[4] > 200, "light got lighter: {}", bytes[4]);
+    fn gamma_darkens_grays_toward_black() {
+        // a light gray (200) and a mid gray (128) both move toward black; alpha preserved.
+        let mut bytes = [200, 200, 200, 255, 128, 128, 128, 255];
+        apply_contrast(&mut buf_with(&mut bytes), step_to_gamma(MAX_CONTRAST_STEP));
+        assert!(bytes[0] < 200, "light gray darkened: {}", bytes[0]);
+        assert!(bytes[4] < 128, "mid gray darkened: {}", bytes[4]);
         assert_eq!(bytes[3], 255, "alpha preserved");
-        assert_eq!(bytes[7], 255, "alpha preserved");
     }
 
     #[test]
-    fn extreme_values_clamp_not_panic() {
+    fn endpoints_are_fixed_and_clamped() {
         let mut bytes = [0, 0, 0, 255, 255, 255, 255, 255];
         apply_contrast(&mut buf_with(&mut bytes), 5.0);
-        assert_eq!(&bytes[0..3], &[0, 0, 0]); // already at floor
-        assert_eq!(&bytes[4..7], &[255, 255, 255]); // already at ceiling
+        assert_eq!(&bytes[0..3], &[0, 0, 0], "black stays black");
+        assert_eq!(&bytes[4..7], &[255, 255, 255], "white stays white");
     }
 }

--- a/reader-core/src/render/contrast.rs
+++ b/reader-core/src/render/contrast.rs
@@ -1,0 +1,82 @@
+//! Contrast / display enhancement for the rendered page (RR4 — KOReader's "Contrast" control).
+//!
+//! A pure per-pixel luminance remap on the final RGBA buffer, applied **after** the backend renders
+//! and **before** the shell blits. Format-agnostic (PDF + EPUB) because it works on pixels, not
+//! layout. The headline win is legibility of faint/low-contrast scanned PDFs on a grayscale e-ink
+//! panel. Host-tested, no device types (IR-4).
+
+use crate::render::PixelBuffer;
+
+/// Number of contrast steps the UI exposes; `0` = off (identity), matching KOReader's slider cells.
+pub const MAX_CONTRAST_STEP: u8 = 8;
+
+/// Map a UI step (`0..=MAX_CONTRAST_STEP`) to a multiplicative contrast factor (`1.0` = identity).
+#[must_use]
+pub fn step_to_factor(step: u8) -> f32 {
+    1.0 + f32::from(step.min(MAX_CONTRAST_STEP)) * 0.25 // step 8 → 3.0×
+}
+
+/// Apply contrast `factor` (`1.0` = no-op) to the RGBA pixels in `buf`, pivoting around mid-gray so
+/// lights stay light and darks get darker. Alpha is untouched. A factor `<= 1.0` is a no-op (cheap
+/// early return). Uses a 256-entry LUT so the per-pixel cost is a table lookup.
+pub fn apply_contrast(buf: &mut PixelBuffer<'_>, factor: f32) {
+    if factor <= 1.0 + 1e-3 || !factor.is_finite() {
+        return;
+    }
+    let mut lut = [0u8; 256];
+    for (i, slot) in lut.iter_mut().enumerate() {
+        let adj = ((i as f32 - 128.0) * factor + 128.0).round();
+        *slot = adj.clamp(0.0, 255.0) as u8;
+    }
+    for px in buf.bytes_mut().chunks_exact_mut(4) {
+        px[0] = lut[px[0] as usize];
+        px[1] = lut[px[1] as usize];
+        px[2] = lut[px[2] as usize];
+        // px[3] (alpha) unchanged
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buf_with(bytes: &mut [u8]) -> PixelBuffer<'_> {
+        let n = (bytes.len() / 4) as u32;
+        PixelBuffer::from_rgba(bytes, n, 1).unwrap()
+    }
+
+    #[test]
+    fn step_zero_is_identity_factor() {
+        assert!((step_to_factor(0) - 1.0).abs() < 1e-6);
+        assert!(step_to_factor(8) > step_to_factor(4));
+        // saturates beyond the max step
+        assert_eq!(step_to_factor(99), step_to_factor(MAX_CONTRAST_STEP));
+    }
+
+    #[test]
+    fn identity_factor_leaves_pixels_untouched() {
+        let mut bytes = [10, 128, 240, 255, 60, 200, 90, 128];
+        let before = bytes;
+        apply_contrast(&mut buf_with(&mut bytes), 1.0);
+        assert_eq!(bytes, before);
+    }
+
+    #[test]
+    fn higher_contrast_darkens_darks_and_lightens_lights() {
+        // dark pixel (50) and light pixel (200); alpha 255.
+        let mut bytes = [50, 50, 50, 255, 200, 200, 200, 255];
+        apply_contrast(&mut buf_with(&mut bytes), 2.0);
+        assert!(bytes[0] < 50, "dark got darker: {}", bytes[0]);
+        assert!(bytes[4] > 200, "light got lighter: {}", bytes[4]);
+        assert_eq!(bytes[3], 255, "alpha preserved");
+        assert_eq!(bytes[7], 255, "alpha preserved");
+    }
+
+    #[test]
+    fn extreme_values_clamp_not_panic() {
+        let mut bytes = [0, 0, 0, 255, 255, 255, 255, 255];
+        apply_contrast(&mut buf_with(&mut bytes), 5.0);
+        assert_eq!(&bytes[0..3], &[0, 0, 0]); // already at floor
+        assert_eq!(&bytes[4..7], &[255, 255, 255]); // already at ceiling
+    }
+}

--- a/reader-core/src/render/mod.rs
+++ b/reader-core/src/render/mod.rs
@@ -3,6 +3,7 @@
 //! M0 is the single-copy full-page render path (Fork 4); dirty-rect/cache/prefetch are M1b.
 
 pub mod cache;
+pub mod contrast;
 pub mod gray;
 pub mod pixel_buffer;
 pub mod viewport;

--- a/reader-core/src/render/mod.rs
+++ b/reader-core/src/render/mod.rs
@@ -6,6 +6,7 @@ pub mod cache;
 pub mod contrast;
 pub mod gray;
 pub mod pixel_buffer;
+pub mod resample;
 pub mod viewport;
 
 pub use cache::{ByteLru, PageHash, RenderCache};

--- a/reader-core/src/render/resample.rs
+++ b/reader-core/src/render/resample.rs
@@ -1,0 +1,90 @@
+//! Bilinear image resampling (RR4 — KOReader's "Render Quality").
+//!
+//! Render quality is realized by rendering the page into an off-size buffer (smaller for "low",
+//! larger for "high") and resampling it to the panel resolution: rendering **above** panel res then
+//! downsampling smooths text/edges on e-ink (supersampling); rendering **below** is faster/softer.
+//! Pure pixel math, host-tested, no device types (IR-4).
+
+use crate::render::PixelBuffer;
+
+/// Resample the `sw`×`sh` RGBA `src` into `dst` (its own dimensions) with bilinear filtering.
+/// A size match is a straight copy. Out-of-range taps clamp to the edge; never panics on sane sizes.
+pub fn resample_bilinear(src: &[u8], sw: u32, sh: u32, dst: &mut PixelBuffer<'_>) {
+    let (dw, dh) = (dst.width(), dst.height());
+    if sw == 0 || sh == 0 || dw == 0 || dh == 0 {
+        return;
+    }
+    let need = (sw as usize) * (sh as usize) * 4;
+    if src.len() < need {
+        return; // malformed source; leave dst untouched (RR21-FR3)
+    }
+    let out = dst.bytes_mut();
+    if sw == dw && sh == dh {
+        out.copy_from_slice(&src[..need]);
+        return;
+    }
+    let fx = sw as f32 / dw as f32;
+    let fy = sh as f32 / dh as f32;
+    for y in 0..dh {
+        let syf = (y as f32 + 0.5) * fy - 0.5;
+        let sy0 = syf.floor().clamp(0.0, (sh - 1) as f32) as u32;
+        let sy1 = (sy0 + 1).min(sh - 1);
+        let wy = (syf - sy0 as f32).clamp(0.0, 1.0);
+        for x in 0..dw {
+            let sxf = (x as f32 + 0.5) * fx - 0.5;
+            let sx0 = sxf.floor().clamp(0.0, (sw - 1) as f32) as u32;
+            let sx1 = (sx0 + 1).min(sw - 1);
+            let wx = (sxf - sx0 as f32).clamp(0.0, 1.0);
+            let i00 = ((sy0 * sw + sx0) * 4) as usize;
+            let i10 = ((sy0 * sw + sx1) * 4) as usize;
+            let i01 = ((sy1 * sw + sx0) * 4) as usize;
+            let i11 = ((sy1 * sw + sx1) * 4) as usize;
+            let o = ((y * dw + x) * 4) as usize;
+            for c in 0..4 {
+                let top = src[i00 + c] as f32 + (src[i10 + c] as f32 - src[i00 + c] as f32) * wx;
+                let bot = src[i01 + c] as f32 + (src[i11 + c] as f32 - src[i01 + c] as f32) * wx;
+                out[o + c] = (top + (bot - top) * wy).round().clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equal_size_is_a_copy() {
+        let src = vec![10u8, 20, 30, 255, 40, 50, 60, 255]; // 2x1
+        let mut dbytes = vec![0u8; 8];
+        let mut dst = PixelBuffer::from_rgba(&mut dbytes, 2, 1).unwrap();
+        resample_bilinear(&src, 2, 1, &mut dst);
+        assert_eq!(dbytes, src);
+    }
+
+    #[test]
+    fn upscale_preserves_solid_color() {
+        let src = vec![100u8, 150, 200, 255]; // 1x1 solid
+        let mut dbytes = vec![0u8; 4 * 4 * 4];
+        let mut dst = PixelBuffer::from_rgba(&mut dbytes, 4, 4).unwrap();
+        resample_bilinear(&src, 1, 1, &mut dst);
+        assert!(dbytes.chunks_exact(4).all(|p| p == [100, 150, 200, 255]));
+    }
+
+    #[test]
+    fn downscale_averages_toward_the_middle() {
+        // 2x2: black, white / white, black → 1x1 should be mid-gray-ish.
+        let src = vec![
+            0, 0, 0, 255, 255, 255, 255, 255, // row 0
+            255, 255, 255, 255, 0, 0, 0, 255, // row 1
+        ];
+        let mut dbytes = vec![0u8; 4];
+        let mut dst = PixelBuffer::from_rgba(&mut dbytes, 1, 1).unwrap();
+        resample_bilinear(&src, 2, 2, &mut dst);
+        assert!(
+            dbytes[0] > 80 && dbytes[0] < 175,
+            "averaged gray: {}",
+            dbytes[0]
+        );
+    }
+}

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -347,7 +347,7 @@ impl ReaderSession {
         // Display enhancement (RR4): remap pixels for contrast after the backend renders.
         crate::render::contrast::apply_contrast(
             buf,
-            crate::render::contrast::step_to_factor(self.contrast),
+            crate::render::contrast::step_to_gamma(self.contrast),
         );
         Ok(())
     }

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -105,6 +105,9 @@ pub struct ReaderSession {
     /// The opened document's content identity (RR10-FR6), computed from its bytes at open. `None`
     /// for a byte-less test session ([`Self::with_document`]). Used to stamp/verify the sidecar.
     identity: Option<DocIdentity>,
+    /// Contrast/display-enhancement step (`0` = off; RR4 — KOReader's "Contrast"). Applied as a
+    /// per-pixel remap after render so faint scans read better on e-ink.
+    contrast: u8,
 }
 
 impl ReaderSession {
@@ -192,6 +195,7 @@ impl ReaderSession {
             erase_changed: false,
             clipboard: Vec::new(),
             identity,
+            contrast: 0,
         }
     }
 
@@ -330,15 +334,34 @@ impl ReaderSession {
             )));
         }
         if self.zoom <= 1.0 + 1e-3 {
-            return self.document.render_page(self.page, buf);
+            self.document.render_page(self.page, buf)?;
+        } else {
+            // Magnified view: content is buf*zoom; show a buf-sized window panned over the overscan.
+            let bw = self.viewport.width as f32;
+            let bh = self.viewport.height as f32;
+            let off_x = (self.pan_x * bw * (self.zoom - 1.0)).round() as i32;
+            let off_y = (self.pan_y * bh * (self.zoom - 1.0)).round() as i32;
+            self.document
+                .render_zoom(self.page, buf, self.zoom, off_x, off_y)?;
         }
-        // Magnified view: the content is buf*zoom; show a buf-sized window panned over the overscan.
-        let bw = self.viewport.width as f32;
-        let bh = self.viewport.height as f32;
-        let off_x = (self.pan_x * bw * (self.zoom - 1.0)).round() as i32;
-        let off_y = (self.pan_y * bh * (self.zoom - 1.0)).round() as i32;
-        self.document
-            .render_zoom(self.page, buf, self.zoom, off_x, off_y)
+        // Display enhancement (RR4): remap pixels for contrast after the backend renders.
+        crate::render::contrast::apply_contrast(
+            buf,
+            crate::render::contrast::step_to_factor(self.contrast),
+        );
+        Ok(())
+    }
+
+    /// Set the contrast/display-enhancement step (`0` = off, clamped to
+    /// [`MAX_CONTRAST_STEP`](crate::render::contrast::MAX_CONTRAST_STEP)) — RR4. Re-render to apply.
+    pub fn set_contrast(&mut self, step: u8) {
+        self.contrast = step.min(crate::render::contrast::MAX_CONTRAST_STEP);
+    }
+
+    /// The current contrast step (`0` = off).
+    #[must_use]
+    pub fn contrast(&self) -> u8 {
+        self.contrast
     }
 
     /// Set the pinch-zoom factor (clamped to `[1.0, MAX_ZOOM]`) and normalized pan `[0,1]`

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -117,6 +117,18 @@ pub struct ReaderSession {
     /// Per-page content-bbox memo for auto-crop (recomputed when the page changes). Interior-mutable
     /// so the `&self` render path can cache the probe render.
     crop_cache: std::cell::RefCell<Option<(usize, Option<NormRect>)>>,
+    /// Render quality (RR4 — KOReader): `0` = low (sub-sample), `1` = default, `2` = high
+    /// (supersample then downscale → smoother e-ink text).
+    render_quality: u8,
+}
+
+/// Render-quality step → render-scale factor (RR4): low `0.75×`, default `1.0×`, high `1.5×`.
+fn render_quality_factor(q: u8) -> f32 {
+    match q {
+        0 => 0.75,
+        2 => 1.5,
+        _ => 1.0,
+    }
 }
 
 impl ReaderSession {
@@ -209,6 +221,7 @@ impl ReaderSession {
             crop_auto: false,
             crop_margin: 0,
             crop_cache: std::cell::RefCell::new(None),
+            render_quality: 1,
         }
     }
 
@@ -346,44 +359,31 @@ impl ReaderSession {
                 self.viewport.height
             )));
         }
-        if self.zoom <= 1.0 + 1e-3 {
-            // At fit (no pinch-zoom): aspect-preserving fit per the chosen mode (RR4). With
-            // auto-crop on, trim the white margins to the detected content box first. PDF honors
-            // both; reflowable backends fall back to a full-buffer render.
-            match self
-                .crop_auto
-                .then(|| self.cached_crop_bbox(self.page))
-                .flatten()
-            {
-                Some(b) => {
-                    let crop = self.expand_crop(b);
-                    self.document.render_cropped(
-                        self.page,
-                        buf,
-                        crop,
-                        self.fit_mode,
-                        self.pan_x,
-                        self.pan_y,
-                    )?;
-                }
-                None => {
-                    self.document.render_fit(
-                        self.page,
-                        buf,
-                        self.fit_mode,
-                        self.pan_x,
-                        self.pan_y,
-                    )?;
-                }
-            }
-        } else {
+        if self.zoom > 1.0 + 1e-3 {
             // Magnified view: content is buf*zoom; show a buf-sized window panned over the overscan.
+            // (Render quality is not applied during a transient pinch-zoom.)
             let bw = self.viewport.width as f32;
             let bh = self.viewport.height as f32;
             let off_x = (self.pan_x * bw * (self.zoom - 1.0)).round() as i32;
             let off_y = (self.pan_y * bh * (self.zoom - 1.0)).round() as i32;
             self.document
                 .render_zoom(self.page, buf, self.zoom, off_x, off_y)?;
+        } else {
+            let q = render_quality_factor(self.render_quality);
+            if (q - 1.0).abs() < 1e-3 {
+                self.render_fit_or_crop(buf)?;
+            } else {
+                // Render at q× the panel resolution, then bilinear-resample down/up to the panel —
+                // supersampling (high) smooths e-ink text; sub-sampling (low) is faster/softer.
+                let qw = ((self.viewport.width as f32 * q).round() as u32).clamp(1, 8000);
+                let qh = ((self.viewport.height as f32 * q).round() as u32).clamp(1, 8000);
+                let mut tmp = vec![0u8; (qw as usize) * (qh as usize) * 4];
+                {
+                    let mut tbuf = PixelBuffer::from_rgba(&mut tmp, qw, qh)?;
+                    self.render_fit_or_crop(&mut tbuf)?;
+                }
+                crate::render::resample::resample_bilinear(&tmp, qw, qh, buf);
+            }
         }
         // Display enhancement (RR4): remap pixels for contrast after the backend renders.
         crate::render::contrast::apply_contrast(
@@ -391,6 +391,32 @@ impl ReaderSession {
             crate::render::contrast::step_to_gamma(self.contrast),
         );
         Ok(())
+    }
+
+    /// Render the current page fit (or auto-cropped) into `buf` (RR4). With auto-crop on, the white
+    /// margins are trimmed to the detected content box; otherwise an aspect-preserving fit. PDF
+    /// honors both; reflowable backends fall back to a full-buffer render.
+    fn render_fit_or_crop(&self, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+        match self
+            .crop_auto
+            .then(|| self.cached_crop_bbox(self.page))
+            .flatten()
+        {
+            Some(b) => {
+                let crop = self.expand_crop(b);
+                self.document.render_cropped(
+                    self.page,
+                    buf,
+                    crop,
+                    self.fit_mode,
+                    self.pan_x,
+                    self.pan_y,
+                )
+            }
+            None => self
+                .document
+                .render_fit(self.page, buf, self.fit_mode, self.pan_x, self.pan_y),
+        }
     }
 
     /// Set the contrast/display-enhancement step (`0` = off, clamped to
@@ -436,6 +462,17 @@ impl ReaderSession {
     #[must_use]
     pub fn crop_margin(&self) -> u8 {
         self.crop_margin
+    }
+
+    /// Set render quality (`0` = low, `1` = default, `2` = high; clamped) — RR4. Re-render to apply.
+    pub fn set_render_quality(&mut self, q: u8) {
+        self.render_quality = q.min(2);
+    }
+
+    /// The current render quality step.
+    #[must_use]
+    pub fn render_quality(&self) -> u8 {
+        self.render_quality
     }
 
     /// The content bounding box for `page`, memoized per page (recomputed on a page change).

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use crate::budget::{Caches, ResourceBudget, TrimLevel};
 use crate::document::fixed::PdfBackend;
 use crate::document::{
-    Document, DocumentMetadata, ExportMode, ExportStroke, NormRect, PageInk, PageLink,
+    Document, DocumentMetadata, ExportMode, ExportStroke, FitMode, NormRect, PageInk, PageLink,
     TextSelection, TocEntry,
 };
 use crate::error::{CoreError, CoreResult};
@@ -108,6 +108,8 @@ pub struct ReaderSession {
     /// Contrast/display-enhancement step (`0` = off; RR4 — KOReader's "Contrast"). Applied as a
     /// per-pixel remap after render so faint scans read better on e-ink.
     contrast: u8,
+    /// How a fixed-layout page is fit to the viewport (RR4 — KOReader's "Fit"). Default: contain.
+    fit_mode: FitMode,
 }
 
 impl ReaderSession {
@@ -196,6 +198,7 @@ impl ReaderSession {
             clipboard: Vec::new(),
             identity,
             contrast: 0,
+            fit_mode: FitMode::Page,
         }
     }
 
@@ -334,7 +337,10 @@ impl ReaderSession {
             )));
         }
         if self.zoom <= 1.0 + 1e-3 {
-            self.document.render_page(self.page, buf)?;
+            // At fit (no pinch-zoom): aspect-preserving fit per the chosen mode (RR4). PDF honors
+            // it; reflowable backends fall back to a full-buffer render.
+            self.document
+                .render_fit(self.page, buf, self.fit_mode, self.pan_x, self.pan_y)?;
         } else {
             // Magnified view: content is buf*zoom; show a buf-sized window panned over the overscan.
             let bw = self.viewport.width as f32;
@@ -362,6 +368,17 @@ impl ReaderSession {
     #[must_use]
     pub fn contrast(&self) -> u8 {
         self.contrast
+    }
+
+    /// Set the page fit mode (RR4 — KOReader's "Fit"). Re-render to apply.
+    pub fn set_fit(&mut self, mode: FitMode) {
+        self.fit_mode = mode;
+    }
+
+    /// The current page fit mode.
+    #[must_use]
+    pub fn fit_mode(&self) -> FitMode {
+        self.fit_mode
     }
 
     /// Set the pinch-zoom factor (clamped to `[1.0, MAX_ZOOM]`) and normalized pan `[0,1]`

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -531,6 +531,32 @@ impl ReaderSession {
         }
     }
 
+    /// Set the reflow line-spacing multiplier (RR4); repaginates EPUB preserving the chapter.
+    /// `false` for a fixed-layout PDF. Re-render after.
+    pub fn set_line_spacing(&mut self, mult: f32) -> bool {
+        match self.document.set_line_spacing(mult, self.page) {
+            Some(new_page) => {
+                self.page = new_page.min(self.page_count().saturating_sub(1));
+                self.load_ink_for_current_page();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Set the reflow alignment (`0=Left,1=Justify,2=Center,3=Right`; RR4); repaginates EPUB
+    /// preserving the chapter. `false` for a fixed-layout PDF. Re-render after.
+    pub fn set_alignment(&mut self, align_code: i32) -> bool {
+        match self.document.set_alignment(align_code, self.page) {
+            Some(new_page) => {
+                self.page = new_page.min(self.page_count().saturating_sub(1));
+                self.load_ink_for_current_page();
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Apply a navigation gesture: move the position (clamped at the document ends), then
     /// delegate to the policy's `on_page_turn` for the refresh stream (Amendment 6).
     ///

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -110,6 +110,13 @@ pub struct ReaderSession {
     contrast: u8,
     /// How a fixed-layout page is fit to the viewport (RR4 — KOReader's "Fit"). Default: contain.
     fit_mode: FitMode,
+    /// Auto-crop the page's white margins (RR4 — KOReader Crop = auto). `false` = full page.
+    crop_auto: bool,
+    /// Margin kept around the auto-crop, in 1%-of-page steps (RR4 — KOReader Margin).
+    crop_margin: u8,
+    /// Per-page content-bbox memo for auto-crop (recomputed when the page changes). Interior-mutable
+    /// so the `&self` render path can cache the probe render.
+    crop_cache: std::cell::RefCell<Option<(usize, Option<NormRect>)>>,
 }
 
 impl ReaderSession {
@@ -199,6 +206,9 @@ impl ReaderSession {
             identity,
             contrast: 0,
             fit_mode: FitMode::Page,
+            crop_auto: false,
+            crop_margin: 0,
+            crop_cache: std::cell::RefCell::new(None),
         }
     }
 
@@ -337,10 +347,35 @@ impl ReaderSession {
             )));
         }
         if self.zoom <= 1.0 + 1e-3 {
-            // At fit (no pinch-zoom): aspect-preserving fit per the chosen mode (RR4). PDF honors
-            // it; reflowable backends fall back to a full-buffer render.
-            self.document
-                .render_fit(self.page, buf, self.fit_mode, self.pan_x, self.pan_y)?;
+            // At fit (no pinch-zoom): aspect-preserving fit per the chosen mode (RR4). With
+            // auto-crop on, trim the white margins to the detected content box first. PDF honors
+            // both; reflowable backends fall back to a full-buffer render.
+            match self
+                .crop_auto
+                .then(|| self.cached_crop_bbox(self.page))
+                .flatten()
+            {
+                Some(b) => {
+                    let crop = self.expand_crop(b);
+                    self.document.render_cropped(
+                        self.page,
+                        buf,
+                        crop,
+                        self.fit_mode,
+                        self.pan_x,
+                        self.pan_y,
+                    )?;
+                }
+                None => {
+                    self.document.render_fit(
+                        self.page,
+                        buf,
+                        self.fit_mode,
+                        self.pan_x,
+                        self.pan_y,
+                    )?;
+                }
+            }
         } else {
             // Magnified view: content is buf*zoom; show a buf-sized window panned over the overscan.
             let bw = self.viewport.width as f32;
@@ -379,6 +414,51 @@ impl ReaderSession {
     #[must_use]
     pub fn fit_mode(&self) -> FitMode {
         self.fit_mode
+    }
+
+    /// Enable/disable auto-crop of the page's white margins (RR4). Re-render to apply.
+    pub fn set_crop_auto(&mut self, auto: bool) {
+        self.crop_auto = auto;
+    }
+
+    /// Whether auto-crop is on.
+    #[must_use]
+    pub fn crop_auto(&self) -> bool {
+        self.crop_auto
+    }
+
+    /// Set the margin kept around the auto-crop (1%-of-page steps, clamped 0..=8). Re-render to apply.
+    pub fn set_crop_margin(&mut self, step: u8) {
+        self.crop_margin = step.min(8);
+    }
+
+    /// The current crop margin step.
+    #[must_use]
+    pub fn crop_margin(&self) -> u8 {
+        self.crop_margin
+    }
+
+    /// The content bounding box for `page`, memoized per page (recomputed on a page change).
+    fn cached_crop_bbox(&self, page: usize) -> Option<NormRect> {
+        if let Some((p, b)) = self.crop_cache.borrow().as_ref() {
+            if *p == page {
+                return *b;
+            }
+        }
+        let b = self.document.content_bbox(page);
+        *self.crop_cache.borrow_mut() = Some((page, b));
+        b
+    }
+
+    /// Expand a content box by the current margin (kept within the page).
+    fn expand_crop(&self, b: NormRect) -> NormRect {
+        let m = f32::from(self.crop_margin) * 0.01;
+        NormRect {
+            x0: (b.x0 - m).clamp(0.0, 1.0),
+            y0: (b.y0 - m).clamp(0.0, 1.0),
+            x1: (b.x1 + m).clamp(0.0, 1.0),
+            y1: (b.y1 + m).clamp(0.0, 1.0),
+        }
     }
 
     /// Set the pinch-zoom factor (clamped to `[1.0, MAX_ZOOM]`) and normalized pan `[0,1]`

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -601,3 +601,63 @@ fn lasso_rejects_an_unknown_mode_code() {
     let s = session(1, DeviceCapabilities::supernote_full());
     assert!(s.ink_select_in_polygon(&centre_box(), 9).is_err());
 }
+
+// RR4: contrast is a post-render pixel remap. A gray page renders darker (below mid-gray) at a
+// higher contrast step; step 0 is identity. Uses a gray-filling doc so the effect is visible.
+struct GrayDoc(u8);
+impl Document for GrayDoc {
+    fn page_count(&self) -> usize {
+        1
+    }
+    fn metadata(&self) -> DocumentMetadata {
+        DocumentMetadata::default()
+    }
+    fn render_page(&self, _index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+        for px in buf.bytes_mut().chunks_exact_mut(4) {
+            px[0] = self.0;
+            px[1] = self.0;
+            px[2] = self.0;
+            px[3] = 0xFF;
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn contrast_step_clamps_and_round_trips() {
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    assert_eq!(s.contrast(), 0);
+    s.set_contrast(99); // clamps to MAX
+    assert_eq!(s.contrast(), crate::render::contrast::MAX_CONTRAST_STEP);
+    s.set_contrast(3);
+    assert_eq!(s.contrast(), 3);
+}
+
+#[test]
+fn contrast_darkens_a_gray_page_after_render() {
+    let mut s = ReaderSession::with_document(
+        Box::new(GrayDoc(80)), // below mid-gray → contrast pushes it darker
+        DeviceCapabilities::supernote_full(),
+        Viewport::new(8, 8, 226),
+    );
+    let mut bytes = vec![0u8; 8 * 8 * 4];
+
+    s.set_contrast(0);
+    {
+        let mut buf = PixelBuffer::from_rgba(&mut bytes, 8, 8).unwrap();
+        s.render_current(&mut buf).unwrap();
+    }
+    assert_eq!(bytes[0], 80, "step 0 is identity");
+
+    s.set_contrast(crate::render::contrast::MAX_CONTRAST_STEP);
+    {
+        let mut buf = PixelBuffer::from_rgba(&mut bytes, 8, 8).unwrap();
+        s.render_current(&mut buf).unwrap();
+    }
+    assert!(
+        bytes[0] < 80,
+        "higher contrast darkened the gray page: {}",
+        bytes[0]
+    );
+    assert_eq!(bytes[3], 0xFF, "alpha preserved");
+}


### PR DESCRIPTION
This sprint adds KOReader's document-control surface natively (on pdfium), consolidated into one **Adjust** bottom-bar entry that opens a KOReader-style tabbed sheet. All controls were built one-at-a-time and **verified on a Supernote Nomad**.

## Controls (the Adjust sheet)
The sheet grows up from the bottom; the active tab is a white boxed cell with a bold label; controls use segmented pills + cell bars (matching KOReader).

| Tab | Controls |
|---|---|
| **Rotate** | 0/90/180/270 — via screen orientation (configChanges, no recreate) |
| **Crop** | Page Crop None/Auto (content-bbox detection) + Margin |
| **Zoom** | Fit Full/Width/Height (aspect-preserving) + Zoom −/+ stepper |
| **Page** | Line Spacing + Alignment Left/Justify/Center/Right (EPUB reflow) |
| **Font** | Size (EPUB reflow) |
| **Display** | Contrast (gamma cell-bar) + Render Quality Low/Default/High (supersampling) |

## Core (reader-core / inkread-epub)
- `FitMode` + aspect-preserving `render_fit` (temp-render → composite; default replaces stretch — landscape no longer distorts).
- `content_bbox` + `render_cropped` for auto-crop; `render_quality` supersampling via a bilinear resampler.
- Contrast gamma remap; EPUB `Align` + `align_line` + configurable line-spacing.
- `set_viewport` over JNI (fixes the rotation/resize render smear).
- New JNI: `nativeSetFit` / `nativeSetCrop` / `nativeSetRenderQuality` / `nativeSetViewport` / `nativeSetLineSpacing` / `nativeSetAlignment`.

## UI cleanup
Bottom bar decluttered: circle ± zoom icons, book icon for Dicts (+ the Define tool), and the magnifier is now **reserved for Search** (PR #9).

## Scope / not in this PR
- **Deferred to dedicated heavy-engine work:** PDF Reflow (k2pdfopt-class), OCR (tesseract), Continuous/scroll view, Deskew + Columns, manual/semi-auto crop, RTL/vertical writing direction, Dewatermark.

## Verification
- reader-core + inkread-epub host tests pass (incl. new fit/crop/resample/align tests); `cargo clippy -D warnings` + `cargo fmt --check` clean.
- `libreader.so` links for arm64-v8a; APK builds; each control device-tested on the Supernote.