### PR TITLE
PDF reflow engine (k2pdfopt-class) — reflow text PDFs via the EPUB layout engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkread-pdftext"
+version = "0.1.0"
+dependencies = [
+ "inkread-epub",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "inkread-dict",
  "inkread-epub",
  "inkread-ink",
+ "inkread-pdftext",
  "jni",
  "pdfium-render",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 # RR1-AC3: bare `cargo test -p reader-core` builds with `jni` absent from the resolved graph.
 [workspace]
 resolver = "2"
-members = ["build-dict", "device-eink", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "reader-core", "reader-desktop"]
+members = ["build-dict", "device-eink", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "inkread-pdftext", "reader-core", "reader-desktop"]
 
 [workspace.package]
 version = "0.1.0"
@@ -24,6 +24,7 @@ inkread-dict = { path = "inkread-dict" }
 inkread-epub = { path = "inkread-epub" }
 inkread-ink = { path = "inkread-ink" }
 inkread-lua = { path = "inkread-lua" }
+inkread-pdftext = { path = "inkread-pdftext" }
 reader-core = { path = "reader-core" }
 
 # External — versions verified against docs.rs at implementation time.

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -167,6 +167,16 @@ object NativeBridge {
      *  new page, or -1 for a fixed-layout PDF. Re-render after. */
     external fun nativeSetAlignment(handle: Long, code: Int): Int
 
+    /** Whether the open document can be reflowed — a text-layer PDF (ADR-INKREAD-0011). Use to
+     *  enable/disable the Reflow control (false for scanned PDFs and for EPUB, already reflowable). */
+    external fun nativeSupportsReflow(handle: Long): Boolean
+
+    /** Toggle reflow mode on a text-layer PDF (ADR-INKREAD-0011): reconstructs the page text and flows
+     *  it like a book so font/spacing/alignment take effect; off restores the fixed page. Returns the
+     *  new current page index (page count changes across the toggle), or -1 if reflow is unavailable.
+     *  Re-render after. */
+    external fun nativeSetReflow(handle: Long, on: Boolean): Int
+
     // ---- ink annotation, persisted by the core to a sidecar (RR6/RR10 / ADR-INKREAD-0010) ----
 
     /** Attach a `.inkread` sidecar store for the open document so strokes persist (RR10). */

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -106,6 +106,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     @Volatile private var pageCount = 0
     /** Stable id of the open book (its file name); keys thumbnails + the bookmarks file. */
     @Volatile private var currentBookId = ""
+    /** Whether PDF reflow mode is on (ADR-INKREAD-0011). Session-scoped: defaults off on each open
+     *  (the fixed page is the faithful view; reflow is an opt-in toggle on the Page tab). */
+    @Volatile private var reflowOn = false
 
     // ---- dictionary (RR12 / D4) ----
     /** Open `Dict` handle (0 = not opened). Engine-thread only. */
@@ -587,6 +590,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             // Bookmarks remain a Kotlin sidecar (RR16), keyed by the book id.
             bookmarks = Bookmarks(File(filesDir, "bookmarks/${bookId.hashCode()}.json")).also { it.load() }
             currentBookId = bookId
+            reflowOn = false // a fresh document opens in fixed-layout view (ADR-INKREAD-0011)
             // Re-apply the saved reflow text scale (EPUB); a no-op (-1) on fixed-layout PDF.
             val savedScale = textScalePref()
             if (savedScale != 1.0f) {
@@ -2990,6 +2994,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             }
         }
         val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        // Reflow toggle — only for a text-layer PDF (EPUB is always reflowable; a scanned PDF can't).
+        // It gates whether the Line Spacing / Alignment / Font Size controls take effect on a PDF.
+        val supportsReflow = try { NativeBridge.nativeSupportsReflow(docHandle) } catch (e: RuntimeException) { false }
+        if (supportsReflow) {
+            container.addView(settingRow("Reflow", segmented(listOf("Off", "On"), if (reflowOn) 1 else 0) { which ->
+                Log.i(TAG, "DIAG reflow=${which == 1}")
+                setReflowMode(which == 1)
+            }))
+        }
         container.addView(settingRow("Line Spacing", segmented(listOf("Small", "Medium", "Large"), lineSpacingPref()) { which ->
             setLineSpacingPref(which)
             Log.i(TAG, "DIAG line spacing=$which")
@@ -3001,6 +3014,33 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             applyReflow { NativeBridge.nativeSetAlignment(docHandle, which) }
         }))
         return container
+    }
+
+    /** Toggle PDF reflow (ADR-INKREAD-0011). On enable, re-apply the saved typography so the
+     *  reflowed PDF respects the user's font size / spacing / alignment; the page count and position
+     *  change across the toggle, so refresh both. A `-1` means no text layer (scanned PDF). */
+    private fun setReflowMode(on: Boolean) {
+        engine.execute {
+            val np = try { NativeBridge.nativeSetReflow(docHandle, on) } catch (e: RuntimeException) { -1 }
+            if (np >= 0) {
+                reflowOn = on
+                if (on) {
+                    if (textScalePref() != 1.0f) {
+                        try { NativeBridge.nativeSetTextScale(docHandle, textScalePref()) } catch (e: RuntimeException) {}
+                    }
+                    if (lineSpacingPref() != 1) {
+                        try { NativeBridge.nativeSetLineSpacing(docHandle, LINE_SPACINGS[lineSpacingPref()]) } catch (e: RuntimeException) {}
+                    }
+                    if (alignmentPref() != 0) {
+                        try { NativeBridge.nativeSetAlignment(docHandle, alignmentPref()) } catch (e: RuntimeException) {}
+                    }
+                }
+                pageCount = NativeBridge.nativePageCount(docHandle)
+                renderAndBlit(); adapter.refreshFull()
+            } else {
+                runOnUiThread { Toast.makeText(this, "This PDF has no text layer to reflow", Toast.LENGTH_SHORT).show() }
+            }
+        }
     }
 
     private fun lineSpacingPref(): Int =

--- a/inkread-pdftext/Cargo.toml
+++ b/inkread-pdftext/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "inkread-pdftext"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "PDF text reflow reconstruction (ADR-INKREAD-0011): glyph geometry -> reflowable Block model, fed to the inkread-epub layout engine. Pure geometry; host-testable; no pdfium, no Android, no vendor (IR-7)."
+
+[dependencies]
+# Block/Inline/TextRun — the reflow content model shared with the EPUB engine. This crate produces
+# that model from PDF glyph geometry so the existing inkread-epub layout/render/pagination pipeline
+# is reused verbatim (ADR-INKREAD-0011 Decision 1). No other deps: pure geometry, host-testable.
+inkread-epub = { workspace = true }

--- a/inkread-pdftext/src/lib.rs
+++ b/inkread-pdftext/src/lib.rs
@@ -1,0 +1,452 @@
+//! `inkread-pdftext` — PDF text **reflow reconstruction** (ADR-INKREAD-0011 Decision 1).
+//!
+//! A reflowed PDF is an EPUB-style flow whose [`Block`] sequence is reconstructed from the page's
+//! **glyph geometry** instead of from XHTML. This crate owns exactly that reconstruction —
+//! `&[Glyph]` → `Vec<Block>` — so the existing `inkread-epub` layout/render/pagination pipeline
+//! (font-size, line-spacing, alignment, selection, search) is reused verbatim on PDF text.
+//!
+//! Pure geometry: no pdfium, no Android, no `reader-core` — host-testable in isolation, names no
+//! vendor (IR-7). The `reader-core` adapter maps pdfium's per-page `CharBox`es into [`Glyph`]s.
+//!
+//! ## Coordinate contract
+//! [`Glyph`] coordinates may be in **any consistent units** (pdfium point-space or the normalized
+//! `[0,1]` the core already produces), with **`y` increasing downward** (reading order top→bottom)
+//! and `x` increasing rightward. Because the core normalizes `x` and `y` independently (by page
+//! width/height), all thresholds are derived **per-axis** from glyph medians — horizontal gaps from
+//! the median glyph *width*, vertical gaps from the median glyph *height* — so the reconstruction is
+//! robust to non-square normalization and to DPI/scale.
+//!
+//! ## Stages (single column in v1; column segmentation is the next phase, ADR-0011 Decision 3)
+//! 1. cluster glyphs into baseline **lines**;
+//! 2. split each line into **words** by inter-glyph x-gap (synthesizing spaces);
+//! 3. group lines into **paragraphs** by vertical gap / first-line indent;
+//! 4. join end-of-line **hyphenation**;
+//! 5. classify **headings** by font-size outlier.
+
+use inkread_epub::{Block, Inline, TextRun};
+
+/// One positioned glyph — the reconstruction input. See the crate-level coordinate contract.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Glyph {
+    /// The Unicode character.
+    pub ch: char,
+    /// Left edge.
+    pub x0: f32,
+    /// Top edge (`y` increases downward).
+    pub y0: f32,
+    /// Right edge.
+    pub x1: f32,
+    /// Bottom edge.
+    pub y1: f32,
+}
+
+impl Glyph {
+    fn width(&self) -> f32 {
+        (self.x1 - self.x0).max(0.0)
+    }
+    fn height(&self) -> f32 {
+        (self.y1 - self.y0).max(0.0)
+    }
+    fn y_center(&self) -> f32 {
+        (self.y0 + self.y1) * 0.5
+    }
+}
+
+/// Tunable thresholds for reconstruction. All are **multiples of a per-axis glyph median**, so they
+/// transfer across page sizes and DPI. Defaults are tuned for prose; the device phase refines them.
+#[derive(Debug, Clone, Copy)]
+pub struct ReconstructOpts {
+    /// New line when a glyph's vertical center jumps more than this × the median glyph height.
+    pub line_split_mult: f32,
+    /// Insert a space when the horizontal gap between adjacent glyphs exceeds this × median width.
+    pub word_gap_mult: f32,
+    /// New paragraph when the vertical gap between lines exceeds this × the median line height.
+    pub para_gap_mult: f32,
+    /// New paragraph when a line's left edge is indented more than this × median width past the
+    /// block's left margin (first-line indent — the common no-spacing paragraph convention).
+    pub indent_mult: f32,
+    /// A line is a heading when its height exceeds this × the body (median) line height.
+    pub heading_ratio: f32,
+}
+
+impl Default for ReconstructOpts {
+    fn default() -> Self {
+        Self {
+            line_split_mult: 0.6,
+            word_gap_mult: 0.3,
+            para_gap_mult: 0.65,
+            indent_mult: 1.5,
+            heading_ratio: 1.3,
+        }
+    }
+}
+
+/// Reconstruct a reflowable [`Block`] sequence from a page's glyphs with default options.
+#[must_use]
+pub fn reconstruct(glyphs: &[Glyph]) -> Vec<Block> {
+    reconstruct_with(glyphs, &ReconstructOpts::default())
+}
+
+/// Reconstruct with explicit [`ReconstructOpts`]. Never panics; an empty/degenerate page → `[]`.
+#[must_use]
+pub fn reconstruct_with(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Block> {
+    let lines = cluster_lines(glyphs, opts);
+    group_blocks(&lines, opts)
+}
+
+/// A reconstructed text line: its glyph-derived text plus the geometry the paragraph/heading stage
+/// needs (vertical extent, representative height, left edge).
+struct Line {
+    text: String,
+    y_top: f32,
+    y_bottom: f32,
+    height: f32,
+    x_left: f32,
+}
+
+/// Stage 1+2 — cluster glyphs into baseline lines (top→bottom) and render each to text with
+/// x-gap-synthesized spaces. Glyphs are grouped by vertical-center proximity (relative to the median
+/// glyph height), then ordered left→right within a line.
+fn cluster_lines(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Line> {
+    if glyphs.is_empty() {
+        return Vec::new();
+    }
+    let h_med = median(glyphs.iter().map(Glyph::height)).max(f32::EPSILON);
+    let split = opts.line_split_mult * h_med;
+
+    // Sort by vertical center, then left edge, so same-baseline glyphs are adjacent.
+    let mut order: Vec<&Glyph> = glyphs.iter().collect();
+    order.sort_by(|a, b| {
+        a.y_center()
+            .partial_cmp(&b.y_center())
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.x0.partial_cmp(&b.x0).unwrap_or(std::cmp::Ordering::Equal))
+    });
+
+    // Greedily break into lines when the vertical center jumps past the split threshold.
+    let mut groups: Vec<Vec<&Glyph>> = Vec::new();
+    let mut mean_y = order[0].y_center();
+    let mut cur: Vec<&Glyph> = Vec::new();
+    for g in order {
+        if cur.is_empty() || (g.y_center() - mean_y).abs() <= split {
+            cur.push(g);
+            let n = cur.len() as f32;
+            mean_y = (mean_y * (n - 1.0) + g.y_center()) / n;
+        } else {
+            groups.push(std::mem::take(&mut cur));
+            cur.push(g);
+            mean_y = g.y_center();
+        }
+    }
+    if !cur.is_empty() {
+        groups.push(cur);
+    }
+
+    groups
+        .into_iter()
+        .filter_map(|mut g| {
+            g.sort_by(|a, b| a.x0.partial_cmp(&b.x0).unwrap_or(std::cmp::Ordering::Equal));
+            line_from_glyphs(&g, opts)
+        })
+        .collect()
+}
+
+/// Build a [`Line`] from one cluster's left-ordered glyphs, synthesizing inter-word spaces from
+/// horizontal gaps. Returns `None` for an all-whitespace line (contributes no block content).
+fn line_from_glyphs(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Option<Line> {
+    let w_med = median(glyphs.iter().map(|g| g.width())).max(f32::EPSILON);
+    let word_gap = opts.word_gap_mult * w_med;
+
+    let mut text = String::new();
+    let mut prev_x1: Option<f32> = None;
+    for g in glyphs {
+        if let Some(px1) = prev_x1 {
+            if g.x0 - px1 > word_gap {
+                text.push(' ');
+            }
+        }
+        if g.ch.is_whitespace() {
+            text.push(' ');
+        } else {
+            text.push(g.ch);
+        }
+        prev_x1 = Some(g.x1);
+    }
+
+    let text = collapse_ws(&text);
+    if text.is_empty() {
+        return None;
+    }
+    let y_top = glyphs.iter().map(|g| g.y0).fold(f32::INFINITY, f32::min);
+    let y_bottom = glyphs
+        .iter()
+        .map(|g| g.y1)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let height = median(glyphs.iter().map(|g| g.height())).max(f32::EPSILON);
+    let x_left = glyphs.iter().map(|g| g.x0).fold(f32::INFINITY, f32::min);
+    Some(Line {
+        text,
+        y_top,
+        y_bottom,
+        height,
+        x_left,
+    })
+}
+
+/// Stages 3–5 — group lines into paragraphs (vertical gap / first-line indent), join hyphenation,
+/// and split out headings (font-size outliers) as their own blocks.
+fn group_blocks(lines: &[Line], opts: &ReconstructOpts) -> Vec<Block> {
+    if lines.is_empty() {
+        return Vec::new();
+    }
+    let body_h = median(lines.iter().map(|l| l.height)).max(f32::EPSILON);
+    let left_margin = lines.iter().map(|l| l.x_left).fold(f32::INFINITY, f32::min);
+    let w_med = median(lines.iter().map(|l| l.height)).max(f32::EPSILON); // height ≈ font size proxy
+    let para_gap = opts.para_gap_mult * body_h;
+    let indent = opts.indent_mult * w_med;
+
+    let mut out: Vec<Block> = Vec::new();
+    let mut para = String::new();
+    let mut prev_bottom: Option<f32> = None;
+
+    for line in lines {
+        // Headings stand alone — flush any open paragraph first.
+        if line.height > opts.heading_ratio * body_h {
+            flush_paragraph(&mut out, &mut para);
+            out.push(text_block(
+                &line.text,
+                Some(heading_level(line.height / body_h)),
+            ));
+            prev_bottom = Some(line.y_bottom);
+            continue;
+        }
+
+        let starts_paragraph = para.is_empty()
+            || prev_bottom.is_some_and(|pb| line.y_top - pb > para_gap)
+            || line.x_left - left_margin > indent;
+
+        if starts_paragraph {
+            flush_paragraph(&mut out, &mut para);
+            para.push_str(&line.text);
+        } else {
+            join_wrapped(&mut para, &line.text);
+        }
+        prev_bottom = Some(line.y_bottom);
+    }
+    flush_paragraph(&mut out, &mut para);
+    out
+}
+
+/// Append a wrapped continuation line, undoing end-of-line hyphenation: a trailing `-` preceded by
+/// an alphabetic char is a split word, so drop the hyphen and join directly; otherwise join with a
+/// space.
+fn join_wrapped(acc: &mut String, next: &str) {
+    let hyphenated =
+        acc.ends_with('-') && acc.chars().rev().nth(1).is_some_and(|c| c.is_alphabetic());
+    if hyphenated {
+        acc.pop(); // drop the '-'
+        acc.push_str(next);
+    } else {
+        if !acc.is_empty() {
+            acc.push(' ');
+        }
+        acc.push_str(next);
+    }
+}
+
+/// Emit the accumulated paragraph (if any) and clear it.
+fn flush_paragraph(out: &mut Vec<Block>, para: &mut String) {
+    if !para.is_empty() {
+        out.push(text_block(para, None));
+        para.clear();
+    }
+}
+
+/// One reflow [`Block`] from plain `text` — a [`Block::Heading`] when `heading` is set, else a
+/// [`Block::Paragraph`]. v1 emits a single unstyled [`TextRun`] (emphasis/links are later
+/// refinements once glyph font flags are surfaced).
+fn text_block(text: &str, heading: Option<u8>) -> Block {
+    let content = vec![Inline::Run(TextRun {
+        text: text.to_string(),
+        bold: false,
+        italic: false,
+        href: None,
+    })];
+    match heading {
+        Some(level) => Block::Heading { level, content },
+        None => Block::Paragraph { content },
+    }
+}
+
+/// Map a line-height ratio (line height ÷ body height) to a heading level (bigger ⇒ lower level).
+fn heading_level(ratio: f32) -> u8 {
+    if ratio >= 2.0 {
+        1
+    } else if ratio >= 1.6 {
+        2
+    } else {
+        3
+    }
+}
+
+/// Collapse runs of whitespace to single spaces and trim — normalizes synthesized + source spaces.
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// The median of an iterator of finite `f32`s (`0.0` if empty). Used for the per-axis glyph metrics
+/// the thresholds scale against.
+fn median(values: impl Iterator<Item = f32>) -> f32 {
+    let mut v: Vec<f32> = values.filter(|x| x.is_finite()).collect();
+    if v.is_empty() {
+        return 0.0;
+    }
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    v[v.len() / 2]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Advance + box-width used by [`lay_line`]: each char box is 8 wide on a 10 pitch, so an
+    /// intra-word gap is 2 and a (skipped) space slot opens a ~12 gap — unambiguous either side of
+    /// the default `word_gap_mult`.
+    const ADV: f32 = 10.0;
+    const BOX_W: f32 = 8.0;
+
+    /// Lay a string onto one line at `(x_start, y_top)` with glyph height `h`. Space characters
+    /// consume a pitch slot but emit no glyph (creating the inter-word x-gap), mirroring how pdfium
+    /// reports word spacing as position, not a glyph.
+    fn lay_line(text: &str, x_start: f32, y_top: f32, h: f32) -> Vec<Glyph> {
+        let mut out = Vec::new();
+        for (i, ch) in text.chars().enumerate() {
+            let x0 = x_start + i as f32 * ADV;
+            if ch == ' ' {
+                continue;
+            }
+            out.push(Glyph {
+                ch,
+                x0,
+                y0: y_top,
+                x1: x0 + BOX_W,
+                y1: y_top + h,
+            });
+        }
+        out
+    }
+
+    /// Pull the plain text out of a block (heading or paragraph) for assertions.
+    fn block_text(b: &Block) -> String {
+        let content = match b {
+            Block::Heading { content, .. } | Block::Paragraph { content } => content,
+            _ => return String::new(),
+        };
+        content
+            .iter()
+            .filter_map(|i| match i {
+                Inline::Run(r) => Some(r.text.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn empty_input_yields_no_blocks() {
+        assert!(reconstruct(&[]).is_empty());
+    }
+
+    #[test]
+    fn x_gaps_become_word_spaces() {
+        let line = lay_line("ab cd", 0.0, 0.0, 10.0);
+        let blocks = reconstruct(&line);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(block_text(&blocks[0]), "ab cd");
+        assert!(matches!(blocks[0], Block::Paragraph { .. }));
+    }
+
+    #[test]
+    fn wrapped_lines_join_into_one_paragraph() {
+        // Two tightly-stacked lines (leading 2) with no indent, no big gap → one paragraph.
+        let mut g = lay_line("Hello world", 0.0, 0.0, 10.0);
+        g.extend(lay_line("again here", 0.0, 12.0, 10.0));
+        let blocks = reconstruct(&g);
+        assert_eq!(blocks.len(), 1, "wrapped lines merge");
+        assert_eq!(block_text(&blocks[0]), "Hello world again here");
+    }
+
+    #[test]
+    fn large_vertical_gap_splits_paragraphs() {
+        let mut g = lay_line("first para", 0.0, 0.0, 10.0);
+        // Next line sits a full body-height below the previous baseline → paragraph break.
+        g.extend(lay_line("second para", 0.0, 30.0, 10.0));
+        let blocks = reconstruct(&g);
+        assert_eq!(blocks.len(), 2, "gap splits paragraphs");
+        assert_eq!(block_text(&blocks[0]), "first para");
+        assert_eq!(block_text(&blocks[1]), "second para");
+    }
+
+    #[test]
+    fn first_line_indent_starts_a_paragraph() {
+        // Same tight leading, but the second line is indented well past the margin → new paragraph.
+        let mut g = lay_line("opening line", 0.0, 0.0, 10.0);
+        g.extend(lay_line("indented start", 40.0, 12.0, 10.0));
+        let blocks = reconstruct(&g);
+        assert_eq!(blocks.len(), 2, "indent splits paragraphs");
+        assert_eq!(block_text(&blocks[1]), "indented start");
+    }
+
+    #[test]
+    fn end_of_line_hyphenation_is_joined() {
+        let mut g = lay_line("an exam-", 0.0, 0.0, 10.0);
+        g.extend(lay_line("ple here", 0.0, 12.0, 10.0));
+        let blocks = reconstruct(&g);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(block_text(&blocks[0]), "an example here");
+    }
+
+    #[test]
+    fn larger_glyphs_classify_as_heading() {
+        // A double-height title line, then several body lines (so the body height is the median the
+        // title stands out against — matching real prose where body lines dominate).
+        let mut g = lay_line("Title", 0.0, 0.0, 20.0);
+        g.extend(lay_line("body line one", 0.0, 40.0, 10.0));
+        g.extend(lay_line("body line two", 0.0, 52.0, 10.0));
+        g.extend(lay_line("body line three", 0.0, 64.0, 10.0));
+        let blocks = reconstruct(&g);
+        assert!(
+            matches!(blocks[0], Block::Heading { level: 1, .. }),
+            "title is an h1: {:?}",
+            blocks[0]
+        );
+        assert_eq!(block_text(&blocks[0]), "Title");
+        assert!(
+            blocks[1..]
+                .iter()
+                .all(|b| matches!(b, Block::Paragraph { .. })),
+            "body lines are paragraphs: {blocks:?}"
+        );
+    }
+
+    #[test]
+    fn never_panics_on_degenerate_geometry() {
+        // Zero-size and overlapping boxes must not panic or produce NaN-driven ordering crashes.
+        let g = vec![
+            Glyph {
+                ch: 'a',
+                x0: 0.0,
+                y0: 0.0,
+                x1: 0.0,
+                y1: 0.0,
+            },
+            Glyph {
+                ch: 'b',
+                x0: 1.0,
+                y0: 1.0,
+                x1: 0.5,
+                y1: 0.5,
+            },
+        ];
+        let _ = reconstruct(&g); // must return without panicking
+    }
+}

--- a/inkread-pdftext/src/lib.rs
+++ b/inkread-pdftext/src/lib.rs
@@ -16,12 +16,13 @@
 //! the median glyph *width*, vertical gaps from the median glyph *height* — so the reconstruction is
 //! robust to non-square normalization and to DPI/scale.
 //!
-//! ## Stages (single column in v1; column segmentation is the next phase, ADR-0011 Decision 3)
-//! 1. cluster glyphs into baseline **lines**;
-//! 2. split each line into **words** by inter-glyph x-gap (synthesizing spaces);
-//! 3. group lines into **paragraphs** by vertical gap / first-line indent;
-//! 4. join end-of-line **hyphenation**;
-//! 5. classify **headings** by font-size outlier.
+//! ## Pipeline
+//! - **Multi-page** ([`reconstruct_pages`]): strip recurring running headers/footers and page
+//!   numbers across pages, then reconstruct each page.
+//! - **Per page** ([`reconstruct`]): segment into reading-order column/band regions (XY-cut), then
+//!   per region: cluster glyphs into baseline **lines** → split into **words** by inter-glyph x-gap
+//!   → group lines into **paragraphs** (vertical gap / first-line indent) → join end-of-line
+//!   **hyphenation** → classify **headings** (font-size outliers and short bold lines).
 
 use inkread_epub::{Block, Inline, TextRun};
 
@@ -38,6 +39,10 @@ pub struct Glyph {
     pub x1: f32,
     /// Bottom edge.
     pub y1: f32,
+    /// Whether this glyph's font is bold — used to classify body-sized **bold section headings**
+    /// that font-size-outlier detection alone would miss (the adapter reads this from the PDF font
+    /// weight; a non-PDF caller may leave it `false`).
+    pub bold: bool,
 }
 
 impl Glyph {
@@ -107,7 +112,7 @@ pub fn reconstruct_with(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Block> 
     // word-boundary signal — letters can butt together with no gap), dropping only non-finite boxes.
     // The ordering hazard they pose (a zero-width space shares an x0 with the next letter and, at a
     // slightly different baseline, can be tie-broken *after* it) is handled where lines are ordered:
-    // the x-sort tie-breaks on the right edge, and the pen tracks a running max. Median metrics below
+    // the x-sort orders by glyph center, and the pen tracks a running max. Median metrics below
     // ignore these as a minority (spaces are < half of glyphs), so zero heights don't skew them.
     let glyphs: Vec<&Glyph> = glyphs
         .iter()
@@ -123,14 +128,150 @@ pub fn reconstruct_with(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Block> 
     // full-width line and erase the gutter.
     let body_h = median(glyphs.iter().map(|g| g.height())).max(f32::EPSILON);
     let glyph_w = median(glyphs.iter().map(|g| g.width())).max(f32::EPSILON);
+    // Typical body line width (median across all baseline lines) — the reference a *short* bold
+    // section heading is measured against. Global, so a heading later isolated into its own
+    // single-line region still reads as short relative to the body. (For multi-column pages this
+    // over-estimates, since cross-column lines merge; bold body text — the only false-positive risk
+    // — is rare, so the trade-off is acceptable for v1.)
+    let body_width = median(cluster_lines(&glyphs, opts).iter().map(Line::width)).max(f32::EPSILON);
+    let metrics = Metrics {
+        body_h,
+        body_width,
+        glyph_w,
+    };
     let mut out = Vec::new();
-    xy_cut(&glyphs, opts, body_h, glyph_w, 0, &mut out);
+    xy_cut(&glyphs, opts, &metrics, 0, &mut out);
     out
+}
+
+/// Page-global reference metrics held fixed across the recursive segmentation, so per-region leaves
+/// classify headings and gutters against a stable document-wide baseline rather than their own
+/// (possibly single-line) contents.
+struct Metrics {
+    body_h: f32,
+    body_width: f32,
+    glyph_w: f32,
 }
 
 /// Recursion depth bound for [`xy_cut`] — far beyond any real page's column/band nesting; a guard
 /// against pathological geometry, never reached in practice.
 const MAX_CUT_DEPTH: usize = 16;
+
+/// Fraction of page height at the top/bottom treated as the header/footer margin band.
+const MARGIN_BAND_FRAC: f32 = 0.12;
+/// Below this page count there is no basis to call a margin line a *recurring* header/footer, so
+/// stripping is skipped (avoids removing a one-off margin line from a short document).
+const MIN_PAGES_FOR_MARGIN_STRIP: usize = 3;
+
+/// Which page margin a candidate header/footer line sits in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Band {
+    Top,
+    Bottom,
+}
+
+/// Reconstruct a **multi-page document** (one [`Glyph`] vec per source page), stripping recurring
+/// running **headers/footers and page numbers** before per-page reconstruction (ADR-INKREAD-0011).
+/// A margin-band line whose alphabetic-normalized text recurs across enough pages — a running title,
+/// or every page number once digits are normalized away — is chrome, not content, and is removed.
+#[must_use]
+pub fn reconstruct_pages(pages: &[Vec<Glyph>]) -> Vec<Vec<Block>> {
+    reconstruct_pages_with(pages, &ReconstructOpts::default())
+}
+
+/// [`reconstruct_pages`] with explicit options.
+#[must_use]
+pub fn reconstruct_pages_with(pages: &[Vec<Glyph>], opts: &ReconstructOpts) -> Vec<Vec<Block>> {
+    if pages.len() < MIN_PAGES_FOR_MARGIN_STRIP {
+        return pages.iter().map(|g| reconstruct_with(g, opts)).collect();
+    }
+
+    // One candidate per margin line: which band, its alphabetic-normalized text, and its y-extent.
+    let per_page: Vec<Vec<(Band, String, f32, f32)>> =
+        pages.iter().map(|g| margin_lines(g, opts)).collect();
+
+    // Tally how many distinct pages each (band, normalized-text) appears on.
+    let mut tally: std::collections::HashMap<(Band, String), usize> =
+        std::collections::HashMap::new();
+    for cands in &per_page {
+        let mut seen = std::collections::HashSet::new();
+        for (band, norm, _, _) in cands {
+            if seen.insert((*band, norm.clone())) {
+                *tally.entry((*band, norm.clone())).or_default() += 1;
+            }
+        }
+    }
+    let threshold = (pages.len() / 2).max(2);
+
+    pages
+        .iter()
+        .zip(&per_page)
+        .map(|(glyphs, cands)| {
+            // y-bands of this page's margin lines that recur across the document → strip them.
+            let strip: Vec<(f32, f32)> = cands
+                .iter()
+                .filter(|(b, n, _, _)| {
+                    tally.get(&(*b, n.clone())).copied().unwrap_or(0) >= threshold
+                })
+                .map(|(_, _, y0, y1)| (*y0, *y1))
+                .collect();
+            if strip.is_empty() {
+                return reconstruct_with(glyphs, opts);
+            }
+            let kept: Vec<Glyph> = glyphs
+                .iter()
+                .filter(|g| {
+                    let yc = g.y_center();
+                    !strip.iter().any(|&(t, b)| yc >= t && yc <= b)
+                })
+                .copied()
+                .collect();
+            reconstruct_with(&kept, opts)
+        })
+        .collect()
+}
+
+/// The page's header/footer-candidate lines: lines lying wholly within the top or bottom margin
+/// band, as `(band, alphabetic-normalized text, y_top, y_bottom)`.
+fn margin_lines(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<(Band, String, f32, f32)> {
+    let refs: Vec<&Glyph> = glyphs
+        .iter()
+        .filter(|g| g.x0.is_finite() && g.y0.is_finite() && g.x1.is_finite() && g.y1.is_finite())
+        .collect();
+    if refs.is_empty() {
+        return Vec::new();
+    }
+    let y_min = refs.iter().map(|g| g.y0).fold(f32::INFINITY, f32::min);
+    let y_max = refs.iter().map(|g| g.y1).fold(f32::NEG_INFINITY, f32::max);
+    let h = (y_max - y_min).max(f32::EPSILON);
+    let top_limit = y_min + MARGIN_BAND_FRAC * h;
+    let bottom_limit = y_max - MARGIN_BAND_FRAC * h;
+
+    group_by_baseline(&refs, opts)
+        .into_iter()
+        .filter_map(|g| {
+            let line = line_from_glyphs(&g, opts)?;
+            let band = if line.y_bottom <= top_limit {
+                Band::Top
+            } else if line.y_top >= bottom_limit {
+                Band::Bottom
+            } else {
+                return None; // body line, never chrome
+            };
+            Some((band, margin_norm(&line.text), line.y_top, line.y_bottom))
+        })
+        .collect()
+}
+
+/// Normalize a margin line for recurrence comparison: keep only lowercase letters. This makes every
+/// page number collapse to the same empty key (so they tally together) while a running title keeps
+/// its alphabetic signature.
+fn margin_norm(text: &str) -> String {
+    text.chars()
+        .filter(|c| c.is_alphabetic())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
 
 /// **Column/band segmentation (XY-cut).** Recursively split a region of glyphs by the most salient
 /// *clean* separator — a vertical column gutter (no glyph crosses it) or a full-width horizontal
@@ -142,8 +283,7 @@ const MAX_CUT_DEPTH: usize = 16;
 fn xy_cut(
     glyphs: &[&Glyph],
     opts: &ReconstructOpts,
-    body_h: f32,
-    glyph_w: f32,
+    metrics: &Metrics,
     depth: usize,
     out: &mut Vec<Block>,
 ) {
@@ -151,10 +291,10 @@ fn xy_cut(
         return;
     }
     let vert = (depth < MAX_CUT_DEPTH)
-        .then(|| best_vertical_gutter(glyphs, opts, glyph_w))
+        .then(|| best_vertical_gutter(glyphs, opts, metrics.glyph_w))
         .flatten();
     let horiz = (depth < MAX_CUT_DEPTH)
-        .then(|| best_horizontal_band(glyphs, opts, body_h))
+        .then(|| best_horizontal_band(glyphs, opts, metrics.body_h))
         .flatten();
 
     // Prefer the separator with the larger axis-normalized score; vertical wins ties (a clean
@@ -165,7 +305,7 @@ fn xy_cut(
         (None, Some(_)) => false,
         (None, None) => {
             let lines = cluster_lines(glyphs, opts);
-            out.extend(group_blocks(&lines, body_h, opts));
+            out.extend(group_blocks(&lines, metrics, opts));
             return;
         }
     };
@@ -174,14 +314,14 @@ fn xy_cut(
         let (mid, _) = vert.unwrap();
         let (left, right): (Vec<&Glyph>, Vec<&Glyph>) =
             glyphs.iter().copied().partition(|g| g.x_center() < mid);
-        xy_cut(&left, opts, body_h, glyph_w, depth + 1, out);
-        xy_cut(&right, opts, body_h, glyph_w, depth + 1, out);
+        xy_cut(&left, opts, metrics, depth + 1, out);
+        xy_cut(&right, opts, metrics, depth + 1, out);
     } else {
         let (mid, _) = horiz.unwrap();
         let (top, bottom): (Vec<&Glyph>, Vec<&Glyph>) =
             glyphs.iter().copied().partition(|g| g.y_center() < mid);
-        xy_cut(&top, opts, body_h, glyph_w, depth + 1, out);
-        xy_cut(&bottom, opts, body_h, glyph_w, depth + 1, out);
+        xy_cut(&top, opts, metrics, depth + 1, out);
+        xy_cut(&bottom, opts, metrics, depth + 1, out);
     }
 }
 
@@ -234,19 +374,29 @@ fn largest_interior_gap(spans: &[(f32, f32)], min: f32) -> Option<(f32, f32)> {
 }
 
 /// A reconstructed text line: its glyph-derived text plus the geometry the paragraph/heading stage
-/// needs (vertical extent, representative height, left edge).
+/// needs (vertical extent, representative height, horizontal extent, and whether it is mostly bold).
 struct Line {
     text: String,
     y_top: f32,
     y_bottom: f32,
     height: f32,
     x_left: f32,
+    x_right: f32,
+    /// Majority of the line's visible glyphs are bold — a body-sized **section heading** signal.
+    bold: bool,
 }
 
-/// Stage 1+2 — cluster glyphs into baseline lines (top→bottom) and render each to text with
-/// x-gap-synthesized spaces. Glyphs are grouped by vertical-center proximity (relative to the median
-/// glyph height), then ordered left→right within a line.
-fn cluster_lines(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Vec<Line> {
+impl Line {
+    fn width(&self) -> f32 {
+        (self.x_right - self.x_left).max(0.0)
+    }
+}
+
+/// Group glyphs into baseline lines (top→bottom); each line's glyphs are ordered left→right by
+/// **center** (a zero-width space sits at the word gap, its center falling cleanly between the
+/// neighbouring letters' — whereas its left edge ties to sub-pixel noise and would sort it mid-word).
+/// Shared by line reconstruction ([`cluster_lines`]) and margin/header-footer detection.
+fn group_by_baseline<'a>(glyphs: &[&'a Glyph], opts: &ReconstructOpts) -> Vec<Vec<&'a Glyph>> {
     if glyphs.is_empty() {
         return Vec::new();
     }
@@ -280,21 +430,22 @@ fn cluster_lines(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Vec<Line> {
     if !cur.is_empty() {
         groups.push(cur);
     }
-
+    for g in &mut groups {
+        g.sort_by(|a, b| {
+            a.x_center()
+                .partial_cmp(&b.x_center())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
     groups
+}
+
+/// Stage 1+2 — cluster glyphs into baseline lines and render each to text with x-gap-synthesized
+/// spaces (empty lines dropped).
+fn cluster_lines(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Vec<Line> {
+    group_by_baseline(glyphs, opts)
         .into_iter()
-        .filter_map(|mut g| {
-            // Order left→right by glyph **center**, not left edge: a zero-width space sits at the
-            // word gap, and its center falls cleanly between the neighbouring letters' centers —
-            // whereas its left edge ties (to sub-pixel noise) with the next letter's, which would
-            // sort it mid-word and split the word.
-            g.sort_by(|a, b| {
-                a.x_center()
-                    .partial_cmp(&b.x_center())
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
-            line_from_glyphs(&g, opts)
-        })
+        .filter_map(|g| line_from_glyphs(&g, opts))
         .collect()
 }
 
@@ -337,24 +488,39 @@ fn line_from_glyphs(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Option<Line> {
         .fold(f32::NEG_INFINITY, f32::max);
     let height = median(glyphs.iter().map(|g| g.height())).max(f32::EPSILON);
     let x_left = glyphs.iter().map(|g| g.x0).fold(f32::INFINITY, f32::min);
+    let x_right = glyphs
+        .iter()
+        .map(|g| g.x1)
+        .fold(f32::NEG_INFINITY, f32::max);
+    // Majority of the *visible* (non-space) glyphs bold → a section-heading signal.
+    let visible = glyphs.iter().filter(|g| !g.ch.is_whitespace()).count();
+    let bold_n = glyphs
+        .iter()
+        .filter(|g| !g.ch.is_whitespace() && g.bold)
+        .count();
+    let bold = visible > 0 && bold_n * 2 > visible;
     Some(Line {
         text,
         y_top,
         y_bottom,
         height,
         x_left,
+        x_right,
+        bold,
     })
 }
 
 /// Stages 3–5 — group a single region's lines into paragraphs (vertical gap / first-line indent),
-/// join hyphenation, and split out headings (font-size outliers) as their own blocks. `body_h` is
-/// the **global** body line height (so heading detection is stable even when a region holds only a
-/// heading); the left margin is taken **locally** so a right column's indent is measured against its
-/// own edge, not the page's.
-fn group_blocks(lines: &[Line], body_h: f32, opts: &ReconstructOpts) -> Vec<Block> {
+/// join hyphenation, and split out headings (font-size outliers and short bold lines) as their own
+/// blocks. `metrics` carries the **global** body line height/width (so heading detection is stable
+/// even when a region holds only a heading); the left margin is taken **locally** so a right column's
+/// indent is measured against its own edge, not the page's.
+fn group_blocks(lines: &[Line], metrics: &Metrics, opts: &ReconstructOpts) -> Vec<Block> {
     if lines.is_empty() {
         return Vec::new();
     }
+    let body_h = metrics.body_h;
+    let body_width = metrics.body_width;
     let left_margin = lines.iter().map(|l| l.x_left).fold(f32::INFINITY, f32::min);
     let para_gap = opts.para_gap_mult * body_h;
     let indent = opts.indent_mult * body_h; // body height ≈ font size — the indent length scale
@@ -364,13 +530,14 @@ fn group_blocks(lines: &[Line], body_h: f32, opts: &ReconstructOpts) -> Vec<Bloc
     let mut prev_bottom: Option<f32> = None;
 
     for line in lines {
-        // Headings stand alone — flush any open paragraph first.
-        if line.height > opts.heading_ratio * body_h {
+        // A heading is either a font-size outlier, or a *short, mostly-bold* line — a body-sized
+        // bold section heading. The shortness guard (well under the widest line) keeps a fully-bold
+        // body paragraph, whose lines run full width, from being misread as a stack of headings.
+        let size_ratio = line.height / body_h;
+        let bold_heading = line.bold && line.width() < 0.6 * body_width;
+        if size_ratio > opts.heading_ratio || bold_heading {
             flush_paragraph(&mut out, &mut para);
-            out.push(text_block(
-                &line.text,
-                Some(heading_level(line.height / body_h)),
-            ));
+            out.push(text_block(&line.text, Some(heading_level(size_ratio))));
             prev_bottom = Some(line.y_bottom);
             continue;
         }
@@ -485,9 +652,18 @@ mod tests {
                 y0: y_top,
                 x1: x0 + BOX_W,
                 y1: y_top + h,
+                bold: false,
             });
         }
         out
+    }
+
+    /// Mark every glyph bold (a bold line/heading fixture).
+    fn bold(mut glyphs: Vec<Glyph>) -> Vec<Glyph> {
+        for g in &mut glyphs {
+            g.bold = true;
+        }
+        glyphs
     }
 
     /// Pull the plain text out of a block (heading or paragraph) for assertions.
@@ -629,6 +805,7 @@ mod tests {
                 y0: 0.0,
                 x1: 0.0,
                 y1: 0.0,
+                bold: false,
             },
             Glyph {
                 ch: 'b',
@@ -636,8 +813,114 @@ mod tests {
                 y0: 1.0,
                 x1: 0.5,
                 y1: 0.5,
+                bold: false,
             },
         ];
         let _ = reconstruct(&g); // must return without panicking
+    }
+
+    #[test]
+    fn short_bold_line_is_a_heading() {
+        // A body-sized but bold short line above full-width body prose → a section heading, even
+        // though it is not a font-size outlier.
+        let mut g = bold(lay_line("Model Architecture", 0.0, 0.0, 10.0));
+        g.extend(lay_line(
+            "this is a much longer body line of ordinary prose",
+            0.0,
+            30.0,
+            10.0,
+        ));
+        g.extend(lay_line(
+            "that wraps and continues across the column width",
+            0.0,
+            42.0,
+            10.0,
+        ));
+        let blocks = reconstruct(&g);
+        assert!(
+            matches!(blocks[0], Block::Heading { .. }),
+            "bold short line is a heading: {blocks:?}"
+        );
+        assert_eq!(block_text(&blocks[0]), "Model Architecture");
+        assert!(blocks[1..]
+            .iter()
+            .all(|b| matches!(b, Block::Paragraph { .. })));
+    }
+
+    #[test]
+    fn fully_bold_paragraph_is_not_all_headings() {
+        // A bold paragraph whose lines run the full body width must stay a paragraph, not become a
+        // stack of headings (the shortness guard).
+        let mut g = bold(lay_line(
+            "this entire paragraph is set in bold yet it is",
+            0.0,
+            0.0,
+            10.0,
+        ));
+        g.extend(bold(lay_line(
+            "ordinary running prose spanning the whole width",
+            0.0,
+            12.0,
+            10.0,
+        )));
+        let blocks = reconstruct(&g);
+        assert!(
+            blocks.iter().all(|b| matches!(b, Block::Paragraph { .. })),
+            "full-width bold lines stay paragraphs: {blocks:?}"
+        );
+    }
+
+    #[test]
+    fn recurring_page_numbers_and_running_header_are_stripped() {
+        // Five pages, each with a running header line at top, a body line, and a page number at
+        // bottom. The header (same text) and the page numbers (different digits) both recur in their
+        // margin bands → stripped; only the body survives.
+        let pages: Vec<Vec<Glyph>> = (1..=5)
+            .map(|n| {
+                let mut g = lay_line("Running Header Title", 0.0, 0.0, 10.0); // top band
+                g.extend(lay_line("body content of this page", 0.0, 150.0, 10.0)); // middle
+                g.extend(lay_line(&format!("{n}"), 0.0, 290.0, 10.0)); // bottom page number
+                g
+            })
+            .collect();
+        let docs = reconstruct_pages(&pages);
+        assert_eq!(docs.len(), 5);
+        for (i, blocks) in docs.iter().enumerate() {
+            let text: String = blocks
+                .iter()
+                .map(block_text)
+                .collect::<Vec<_>>()
+                .join(" | ");
+            assert!(
+                text.contains("body content"),
+                "page {i} keeps its body: {text:?}"
+            );
+            assert!(
+                !text.contains("Running Header"),
+                "page {i} strips the running header: {text:?}"
+            );
+            assert!(
+                !text.chars().any(|c| c.is_ascii_digit()),
+                "page {i} strips the page number: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn few_pages_keep_margin_lines() {
+        // With only two pages there is no basis to call a margin line recurring chrome — keep it.
+        let pages: Vec<Vec<Glyph>> = (1..=2)
+            .map(|_| {
+                let mut g = lay_line("Header", 0.0, 0.0, 10.0);
+                g.extend(lay_line("body content here", 0.0, 150.0, 10.0));
+                g
+            })
+            .collect();
+        let docs = reconstruct_pages(&pages);
+        let text: String = docs[0].iter().map(block_text).collect();
+        assert!(
+            text.contains("Header"),
+            "short doc keeps margin line: {text:?}"
+        );
     }
 }

--- a/inkread-pdftext/src/lib.rs
+++ b/inkread-pdftext/src/lib.rs
@@ -66,9 +66,14 @@ impl Glyph {
 pub struct ReconstructOpts {
     /// New line when a glyph's vertical center jumps more than this × the median glyph height.
     pub line_split_mult: f32,
-    /// Insert a space when the horizontal gap between adjacent glyphs exceeds this × the line's
-    /// median glyph **height** (font size) — a space is ~0.25 em (see [`line_from_glyphs`]).
+    /// On a line with **no explicit space glyphs**, synthesize a space when the gap between adjacent
+    /// glyphs exceeds this × the line's median glyph **height** (font size) — a space is ~0.25 em.
     pub word_gap_mult: f32,
+    /// On a line that **does** have explicit space glyphs (the common case — they already mark every
+    /// word boundary), only synthesize across a gap this much larger × the median height. Kept high
+    /// so loose tracking, bold headings, or punctuation side-bearing can't fabricate intra-word
+    /// splits; genuine large gaps (tabs/columns missing a space glyph) still break.
+    pub word_gap_mult_spaced: f32,
     /// New paragraph when the vertical gap between lines exceeds this × the median line height.
     pub para_gap_mult: f32,
     /// New paragraph when a line's left edge is indented more than this × median width past the
@@ -90,6 +95,7 @@ impl Default for ReconstructOpts {
         Self {
             line_split_mult: 0.6,
             word_gap_mult: 0.25,
+            word_gap_mult_spaced: 1.0,
             para_gap_mult: 0.65,
             indent_mult: 1.5,
             heading_ratio: 1.3,
@@ -114,9 +120,20 @@ pub fn reconstruct_with(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Block> 
     // slightly different baseline, can be tie-broken *after* it) is handled where lines are ordered:
     // the x-sort orders by glyph center, and the pen tracks a running max. Median metrics below
     // ignore these as a minority (spaces are < half of glyphs), so zero heights don't skew them.
+    // Also drop control characters (CR/LF/TAB): PDFs emit them at line ends with an unreliable box
+    // — the device's pdfium places the line-break glyph *back over the last letter* (negative gap),
+    // so ordering by x-center would sort that zero-width whitespace *before* the final glyph and
+    // inject a mid-word space ("value" → "valu e"). Lines are formed by geometry, not newlines, so
+    // these carry no information and are pure noise.
     let glyphs: Vec<&Glyph> = glyphs
         .iter()
-        .filter(|g| g.x0.is_finite() && g.y0.is_finite() && g.x1.is_finite() && g.y1.is_finite())
+        .filter(|g| {
+            g.x0.is_finite()
+                && g.y0.is_finite()
+                && g.x1.is_finite()
+                && g.y1.is_finite()
+                && !g.ch.is_control()
+        })
         .collect();
     if glyphs.is_empty() {
         return Vec::new();
@@ -236,7 +253,13 @@ pub fn reconstruct_pages_with(pages: &[Vec<Glyph>], opts: &ReconstructOpts) -> V
 fn margin_lines(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<(Band, String, f32, f32)> {
     let refs: Vec<&Glyph> = glyphs
         .iter()
-        .filter(|g| g.x0.is_finite() && g.y0.is_finite() && g.x1.is_finite() && g.y1.is_finite())
+        .filter(|g| {
+            g.x0.is_finite()
+                && g.y0.is_finite()
+                && g.x1.is_finite()
+                && g.y1.is_finite()
+                && !g.ch.is_control()
+        })
         .collect();
     if refs.is_empty() {
         return Vec::new();
@@ -457,7 +480,17 @@ fn line_from_glyphs(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Option<Line> {
     // by narrow glyphs (i, l, t, f, .) on text-heavy lines, over-splitting words. Height is uniform
     // across a line's font and aspect-correct in point space.
     let h_med = median(glyphs.iter().map(|g| g.height())).max(f32::EPSILON);
-    let word_gap = opts.word_gap_mult * h_med;
+    // PDFs that emit explicit space glyphs (most) already mark every word boundary; trust them and
+    // only *synthesize* across a clearly large gap, so loose tracking / bold headings / punctuation
+    // side-bearing can't fabricate intra-word splits. Lines with no space glyphs use the sensitive
+    // positional threshold.
+    let has_space = glyphs.iter().any(|g| g.ch.is_whitespace());
+    let mult = if has_space {
+        opts.word_gap_mult_spaced
+    } else {
+        opts.word_gap_mult
+    };
+    let word_gap = mult * h_med;
 
     let mut text = String::new();
     // Running max of right edges seen so far — a glyph that sits behind a wider predecessor (kerning
@@ -465,7 +498,9 @@ fn line_from_glyphs(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Option<Line> {
     let mut pen_x1: Option<f32> = None;
     for g in glyphs {
         if let Some(px1) = pen_x1 {
-            if g.x0 - px1 > word_gap {
+            // Never synthesize a space *before* closing punctuation — a space before '.'/',' is
+            // always wrong (the glyph's left side-bearing reads as a gap).
+            if g.x0 - px1 > word_gap && !is_closing_punct(g.ch) {
                 text.push(' ');
             }
         }
@@ -608,6 +643,16 @@ fn heading_level(ratio: f32) -> u8 {
     } else {
         3
     }
+}
+
+/// Closing punctuation that must never be preceded by a synthesized space (its left side-bearing can
+/// read as a word gap). Limited to unambiguous closers — quotes/apostrophes are excluded (they open
+/// as often as they close).
+fn is_closing_punct(c: char) -> bool {
+    matches!(
+        c,
+        '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '%' | '…'
+    )
 }
 
 /// Collapse runs of whitespace to single spaces and trim — normalizes synthesized + source spaces.
@@ -922,5 +967,91 @@ mod tests {
             text.contains("Header"),
             "short doc keeps margin line: {text:?}"
         );
+    }
+
+    /// A glyph with explicit geometry on a single line (y 0..10), not bold.
+    fn gx(ch: char, x0: f32, x1: f32) -> Glyph {
+        Glyph {
+            ch,
+            x0,
+            y0: 0.0,
+            x1,
+            y1: 10.0,
+            bold: false,
+        }
+    }
+    /// A zero-width explicit space glyph at `x` (as pdfium emits).
+    fn sp(x: f32) -> Glyph {
+        Glyph {
+            ch: ' ',
+            x0: x,
+            y0: 5.0,
+            x1: x,
+            y1: 5.0,
+            bold: false,
+        }
+    }
+
+    #[test]
+    fn explicit_spaces_suppress_intraword_split() {
+        // "hello world" with an explicit space and a wide intra-word gap inside "world" (loose
+        // tracking / a bold heading). Because the line carries explicit spaces, the wide gap must
+        // NOT be read as a word break — the word stays whole. (At the sensitive no-space threshold
+        // it would split into "wor ld".)
+        let g = vec![
+            gx('h', 0.0, 8.0),
+            gx('e', 8.0, 16.0),
+            gx('l', 16.0, 24.0),
+            gx('l', 24.0, 32.0),
+            gx('o', 32.0, 40.0),
+            sp(43.0),
+            gx('w', 43.0, 51.0),
+            gx('o', 51.0, 59.0),
+            gx('r', 59.0, 67.0),
+            gx('l', 75.0, 83.0),
+            gx('d', 83.0, 91.0), // 8px gap before 'l' (< 1.0×height)
+        ];
+        let blocks = reconstruct(&g);
+        assert_eq!(block_text(&blocks[0]), "hello world", "{blocks:?}");
+    }
+
+    #[test]
+    fn line_end_control_glyph_does_not_split_last_word() {
+        // Device repro: "value" at a line end, followed by a CR/LF glyph whose box sits *back over*
+        // the last letter (negative gap) — at a slightly lower baseline. Ordered by x-center it would
+        // land between 'u' and 'e' and inject a space ("valu e"); dropping control chars fixes it.
+        let g = vec![
+            gx('v', 0.0, 9.0),
+            gx('a', 9.0, 18.0),
+            gx('l', 18.0, 27.0),
+            gx('u', 27.0, 36.0),
+            gx('e', 36.0, 45.0),
+            // CR/LF: zero-width, x backed up 8.3 over 'e', baseline 5.4 lower (h≈9 → still same line).
+            Glyph {
+                ch: '\n',
+                x0: 36.7,
+                y0: 5.4,
+                x1: 36.7,
+                y1: 5.4,
+                bold: false,
+            },
+        ];
+        let blocks = reconstruct(&g);
+        assert_eq!(block_text(&blocks[0]), "value", "{blocks:?}");
+    }
+
+    #[test]
+    fn no_synthesized_space_before_period() {
+        // "loss." with no explicit spaces and a gap before the period (its left side-bearing). The
+        // closing-punctuation guard must suppress a synthesized "loss ." → keep "loss.".
+        let g = vec![
+            gx('l', 0.0, 8.0),
+            gx('o', 8.0, 16.0),
+            gx('s', 16.0, 24.0),
+            gx('s', 24.0, 32.0),
+            gx('.', 35.0, 38.0), // 3px gap before '.' (> 0.25×height)
+        ];
+        let blocks = reconstruct(&g);
+        assert_eq!(block_text(&blocks[0]), "loss.", "{blocks:?}");
     }
 }

--- a/inkread-pdftext/src/lib.rs
+++ b/inkread-pdftext/src/lib.rs
@@ -47,6 +47,9 @@ impl Glyph {
     fn height(&self) -> f32 {
         (self.y1 - self.y0).max(0.0)
     }
+    fn x_center(&self) -> f32 {
+        (self.x0 + self.x1) * 0.5
+    }
     fn y_center(&self) -> f32 {
         (self.y0 + self.y1) * 0.5
     }
@@ -67,6 +70,13 @@ pub struct ReconstructOpts {
     pub indent_mult: f32,
     /// A line is a heading when its height exceeds this × the body (median) line height.
     pub heading_ratio: f32,
+    /// A vertical **column gutter** must be at least this × the median glyph width (an interior
+    /// whitespace band crossed by no line — the separator between columns).
+    pub column_gap_mult: f32,
+    /// A horizontal **band** cut needs a full-width vertical gap of at least this × the body line
+    /// height (clearly larger than a paragraph gap, so it fires only at major separators — e.g. a
+    /// spanning title above multiple columns — not between ordinary paragraphs).
+    pub band_gap_mult: f32,
 }
 
 impl Default for ReconstructOpts {
@@ -77,6 +87,8 @@ impl Default for ReconstructOpts {
             para_gap_mult: 0.65,
             indent_mult: 1.5,
             heading_ratio: 1.3,
+            column_gap_mult: 1.5,
+            band_gap_mult: 1.5,
         }
     }
 }
@@ -90,8 +102,125 @@ pub fn reconstruct(glyphs: &[Glyph]) -> Vec<Block> {
 /// Reconstruct with explicit [`ReconstructOpts`]. Never panics; an empty/degenerate page → `[]`.
 #[must_use]
 pub fn reconstruct_with(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Block> {
-    let lines = cluster_lines(glyphs, opts);
-    group_blocks(&lines, opts)
+    if glyphs.is_empty() {
+        return Vec::new();
+    }
+    // Body line height and glyph width are estimated **globally** from raw glyph geometry (so
+    // heading detection has a stable body baseline and gutter/band thresholds a stable scale) and
+    // held fixed across the recursive segmentation below. Segmentation must run on glyphs *before*
+    // line clustering — otherwise glyphs sharing a baseline across columns would merge into one
+    // full-width line and erase the gutter.
+    let body_h = median(glyphs.iter().map(Glyph::height)).max(f32::EPSILON);
+    let glyph_w = median(glyphs.iter().map(Glyph::width)).max(f32::EPSILON);
+    let refs: Vec<&Glyph> = glyphs.iter().collect();
+    let mut out = Vec::new();
+    xy_cut(&refs, opts, body_h, glyph_w, 0, &mut out);
+    out
+}
+
+/// Recursion depth bound for [`xy_cut`] — far beyond any real page's column/band nesting; a guard
+/// against pathological geometry, never reached in practice.
+const MAX_CUT_DEPTH: usize = 16;
+
+/// **Column/band segmentation (XY-cut).** Recursively split a region of glyphs by the most salient
+/// *clean* separator — a vertical column gutter (no glyph crosses it) or a full-width horizontal
+/// band gap — emitting reading order naturally: a vertical cut reads left region then right; a
+/// horizontal cut reads top then bottom. A region with no clean separator is a leaf, where glyphs
+/// are finally clustered into lines ([`cluster_lines`]) and grouped into blocks ([`group_blocks`]).
+/// This resolves multi-column papers and a spanning title above columns; single-column pages have no
+/// interior gutter and fall straight through to one leaf.
+fn xy_cut(
+    glyphs: &[&Glyph],
+    opts: &ReconstructOpts,
+    body_h: f32,
+    glyph_w: f32,
+    depth: usize,
+    out: &mut Vec<Block>,
+) {
+    if glyphs.is_empty() {
+        return;
+    }
+    let vert = (depth < MAX_CUT_DEPTH)
+        .then(|| best_vertical_gutter(glyphs, opts, glyph_w))
+        .flatten();
+    let horiz = (depth < MAX_CUT_DEPTH)
+        .then(|| best_horizontal_band(glyphs, opts, body_h))
+        .flatten();
+
+    // Prefer the separator with the larger axis-normalized score; vertical wins ties (a clean
+    // column gutter is a stronger reading-order signal than an incidental band gap).
+    let take_vertical = match (&vert, &horiz) {
+        (Some(v), Some(h)) => v.1 >= h.1,
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        (None, None) => {
+            let lines = cluster_lines(glyphs, opts);
+            out.extend(group_blocks(&lines, body_h, opts));
+            return;
+        }
+    };
+
+    if take_vertical {
+        let (mid, _) = vert.unwrap();
+        let (left, right): (Vec<&Glyph>, Vec<&Glyph>) =
+            glyphs.iter().copied().partition(|g| g.x_center() < mid);
+        xy_cut(&left, opts, body_h, glyph_w, depth + 1, out);
+        xy_cut(&right, opts, body_h, glyph_w, depth + 1, out);
+    } else {
+        let (mid, _) = horiz.unwrap();
+        let (top, bottom): (Vec<&Glyph>, Vec<&Glyph>) =
+            glyphs.iter().copied().partition(|g| g.y_center() < mid);
+        xy_cut(&top, opts, body_h, glyph_w, depth + 1, out);
+        xy_cut(&bottom, opts, body_h, glyph_w, depth + 1, out);
+    }
+}
+
+/// Find the widest **interior vertical gutter** — an x-interval that no glyph's `[x0, x1]` overlaps —
+/// at least `column_gap_mult × glyph_w` wide. Returns `(split_x, score)` where `score` is the gutter
+/// width in glyph-width units (comparable to the horizontal band score). `None` if the region's
+/// glyphs cover x continuously (a single column): only a true column gutter, empty on *every* line,
+/// survives the merge.
+fn best_vertical_gutter(
+    glyphs: &[&Glyph],
+    opts: &ReconstructOpts,
+    glyph_w: f32,
+) -> Option<(f32, f32)> {
+    let min_w = opts.column_gap_mult * glyph_w;
+    let mut spans: Vec<(f32, f32)> = glyphs.iter().map(|g| (g.x0, g.x1)).collect();
+    spans.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    largest_interior_gap(&spans, min_w).map(|(mid, gap)| (mid, gap / glyph_w))
+}
+
+/// Find the widest **full-width horizontal band gap** — a y crossed by no glyph, separating an upper
+/// region from a lower one — at least `band_gap_mult × body_h` tall (clearly larger than a paragraph
+/// gap, so it fires only at major separators like a spanning title above columns). Returns
+/// `(split_y, score)` in body-height units. `None` when glyphs pack vertically with no major break
+/// (interleaved columns, or a single column whose gaps are mere line leading / paragraph spacing).
+fn best_horizontal_band(
+    glyphs: &[&Glyph],
+    opts: &ReconstructOpts,
+    body_h: f32,
+) -> Option<(f32, f32)> {
+    let min_h = opts.band_gap_mult * body_h;
+    let mut spans: Vec<(f32, f32)> = glyphs.iter().map(|g| (g.y0, g.y1)).collect();
+    spans.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    largest_interior_gap(&spans, min_h).map(|(mid, gap)| (mid, gap / body_h))
+}
+
+/// Over `[lo, hi]` spans sorted by `lo`, find the widest interior gap (region uncovered by any span)
+/// exceeding `min`. Returns `(gap_midpoint, gap_width)`, or `None` if coverage is continuous. Shared
+/// by both axes — a vertical gutter and a horizontal band are the same 1-D problem.
+fn largest_interior_gap(spans: &[(f32, f32)], min: f32) -> Option<(f32, f32)> {
+    let mut best: Option<(f32, f32)> = None;
+    let mut cover_end = spans.first()?.1;
+    for &(lo, hi) in &spans[1..] {
+        let gap = lo - cover_end;
+        if gap > min && best.is_none_or(|(_, w)| gap > w) {
+            best = Some((cover_end + gap * 0.5, gap));
+        }
+        cover_end = cover_end.max(hi);
+    }
+    best
 }
 
 /// A reconstructed text line: its glyph-derived text plus the geometry the paragraph/heading stage
@@ -107,15 +236,15 @@ struct Line {
 /// Stage 1+2 — cluster glyphs into baseline lines (top→bottom) and render each to text with
 /// x-gap-synthesized spaces. Glyphs are grouped by vertical-center proximity (relative to the median
 /// glyph height), then ordered left→right within a line.
-fn cluster_lines(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Line> {
+fn cluster_lines(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Vec<Line> {
     if glyphs.is_empty() {
         return Vec::new();
     }
-    let h_med = median(glyphs.iter().map(Glyph::height)).max(f32::EPSILON);
+    let h_med = median(glyphs.iter().map(|g| g.height())).max(f32::EPSILON);
     let split = opts.line_split_mult * h_med;
 
     // Sort by vertical center, then left edge, so same-baseline glyphs are adjacent.
-    let mut order: Vec<&Glyph> = glyphs.iter().collect();
+    let mut order: Vec<&Glyph> = glyphs.to_vec();
     order.sort_by(|a, b| {
         a.y_center()
             .partial_cmp(&b.y_center())
@@ -193,17 +322,18 @@ fn line_from_glyphs(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Option<Line> {
     })
 }
 
-/// Stages 3–5 — group lines into paragraphs (vertical gap / first-line indent), join hyphenation,
-/// and split out headings (font-size outliers) as their own blocks.
-fn group_blocks(lines: &[Line], opts: &ReconstructOpts) -> Vec<Block> {
+/// Stages 3–5 — group a single region's lines into paragraphs (vertical gap / first-line indent),
+/// join hyphenation, and split out headings (font-size outliers) as their own blocks. `body_h` is
+/// the **global** body line height (so heading detection is stable even when a region holds only a
+/// heading); the left margin is taken **locally** so a right column's indent is measured against its
+/// own edge, not the page's.
+fn group_blocks(lines: &[Line], body_h: f32, opts: &ReconstructOpts) -> Vec<Block> {
     if lines.is_empty() {
         return Vec::new();
     }
-    let body_h = median(lines.iter().map(|l| l.height)).max(f32::EPSILON);
     let left_margin = lines.iter().map(|l| l.x_left).fold(f32::INFINITY, f32::min);
-    let w_med = median(lines.iter().map(|l| l.height)).max(f32::EPSILON); // height ≈ font size proxy
     let para_gap = opts.para_gap_mult * body_h;
-    let indent = opts.indent_mult * w_med;
+    let indent = opts.indent_mult * body_h; // body height ≈ font size — the indent length scale
 
     let mut out: Vec<Block> = Vec::new();
     let mut para = String::new();
@@ -426,6 +556,43 @@ mod tests {
                 .all(|b| matches!(b, Block::Paragraph { .. })),
             "body lines are paragraphs: {blocks:?}"
         );
+    }
+
+    #[test]
+    fn two_columns_read_left_then_right() {
+        // Two vertically-stacked lines in each of two columns separated by a wide gutter (left
+        // spans x∈[0,~78], right starts at x=120 → ~42 gutter ≫ column threshold). Reading order
+        // must be the whole left column, then the whole right column — not interleaved by row.
+        let mut g = lay_line("left one", 0.0, 0.0, 10.0);
+        g.extend(lay_line("left two", 0.0, 12.0, 10.0));
+        g.extend(lay_line("right one", 120.0, 0.0, 10.0));
+        g.extend(lay_line("right two", 120.0, 12.0, 10.0));
+        let blocks = reconstruct(&g);
+        assert_eq!(blocks.len(), 2, "one paragraph per column: {blocks:?}");
+        assert_eq!(block_text(&blocks[0]), "left one left two");
+        assert_eq!(block_text(&blocks[1]), "right one right two");
+    }
+
+    #[test]
+    fn spanning_title_above_two_columns_reads_title_then_columns() {
+        // A full-width title (crosses the gutter, so no top-level vertical cut) with a large gap to
+        // two columns below. XY-cut peels the title band first, then splits the body into columns:
+        // reading order = title, left column, right column.
+        let mut g = lay_line("the full width title", 0.0, 0.0, 20.0);
+        g.extend(lay_line("left alpha", 0.0, 50.0, 10.0));
+        g.extend(lay_line("left beta", 0.0, 62.0, 10.0));
+        g.extend(lay_line("right alpha", 120.0, 50.0, 10.0));
+        g.extend(lay_line("right beta", 120.0, 62.0, 10.0));
+        let blocks = reconstruct(&g);
+        assert_eq!(blocks.len(), 3, "title + two columns: {blocks:?}");
+        assert!(
+            matches!(blocks[0], Block::Heading { .. }),
+            "spanning title is a heading: {:?}",
+            blocks[0]
+        );
+        assert_eq!(block_text(&blocks[0]), "the full width title");
+        assert_eq!(block_text(&blocks[1]), "left alpha left beta");
+        assert_eq!(block_text(&blocks[2]), "right alpha right beta");
     }
 
     #[test]

--- a/inkread-pdftext/src/lib.rs
+++ b/inkread-pdftext/src/lib.rs
@@ -61,7 +61,8 @@ impl Glyph {
 pub struct ReconstructOpts {
     /// New line when a glyph's vertical center jumps more than this × the median glyph height.
     pub line_split_mult: f32,
-    /// Insert a space when the horizontal gap between adjacent glyphs exceeds this × median width.
+    /// Insert a space when the horizontal gap between adjacent glyphs exceeds this × the line's
+    /// median glyph **height** (font size) — a space is ~0.25 em (see [`line_from_glyphs`]).
     pub word_gap_mult: f32,
     /// New paragraph when the vertical gap between lines exceeds this × the median line height.
     pub para_gap_mult: f32,
@@ -83,7 +84,7 @@ impl Default for ReconstructOpts {
     fn default() -> Self {
         Self {
             line_split_mult: 0.6,
-            word_gap_mult: 0.3,
+            word_gap_mult: 0.25,
             para_gap_mult: 0.65,
             indent_mult: 1.5,
             heading_ratio: 1.3,
@@ -102,6 +103,16 @@ pub fn reconstruct(glyphs: &[Glyph]) -> Vec<Block> {
 /// Reconstruct with explicit [`ReconstructOpts`]. Never panics; an empty/degenerate page → `[]`.
 #[must_use]
 pub fn reconstruct_with(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Block> {
+    // Keep explicit space glyphs (PDFs emit them as zero-width boxes and they are sometimes the only
+    // word-boundary signal — letters can butt together with no gap), dropping only non-finite boxes.
+    // The ordering hazard they pose (a zero-width space shares an x0 with the next letter and, at a
+    // slightly different baseline, can be tie-broken *after* it) is handled where lines are ordered:
+    // the x-sort tie-breaks on the right edge, and the pen tracks a running max. Median metrics below
+    // ignore these as a minority (spaces are < half of glyphs), so zero heights don't skew them.
+    let glyphs: Vec<&Glyph> = glyphs
+        .iter()
+        .filter(|g| g.x0.is_finite() && g.y0.is_finite() && g.x1.is_finite() && g.y1.is_finite())
+        .collect();
     if glyphs.is_empty() {
         return Vec::new();
     }
@@ -110,11 +121,10 @@ pub fn reconstruct_with(glyphs: &[Glyph], opts: &ReconstructOpts) -> Vec<Block> 
     // held fixed across the recursive segmentation below. Segmentation must run on glyphs *before*
     // line clustering — otherwise glyphs sharing a baseline across columns would merge into one
     // full-width line and erase the gutter.
-    let body_h = median(glyphs.iter().map(Glyph::height)).max(f32::EPSILON);
-    let glyph_w = median(glyphs.iter().map(Glyph::width)).max(f32::EPSILON);
-    let refs: Vec<&Glyph> = glyphs.iter().collect();
+    let body_h = median(glyphs.iter().map(|g| g.height())).max(f32::EPSILON);
+    let glyph_w = median(glyphs.iter().map(|g| g.width())).max(f32::EPSILON);
     let mut out = Vec::new();
-    xy_cut(&refs, opts, body_h, glyph_w, 0, &mut out);
+    xy_cut(&glyphs, opts, body_h, glyph_w, 0, &mut out);
     out
 }
 
@@ -274,7 +284,15 @@ fn cluster_lines(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Vec<Line> {
     groups
         .into_iter()
         .filter_map(|mut g| {
-            g.sort_by(|a, b| a.x0.partial_cmp(&b.x0).unwrap_or(std::cmp::Ordering::Equal));
+            // Order left→right by glyph **center**, not left edge: a zero-width space sits at the
+            // word gap, and its center falls cleanly between the neighbouring letters' centers —
+            // whereas its left edge ties (to sub-pixel noise) with the next letter's, which would
+            // sort it mid-word and split the word.
+            g.sort_by(|a, b| {
+                a.x_center()
+                    .partial_cmp(&b.x_center())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             line_from_glyphs(&g, opts)
         })
         .collect()
@@ -283,13 +301,19 @@ fn cluster_lines(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Vec<Line> {
 /// Build a [`Line`] from one cluster's left-ordered glyphs, synthesizing inter-word spaces from
 /// horizontal gaps. Returns `None` for an all-whitespace line (contributes no block content).
 fn line_from_glyphs(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Option<Line> {
-    let w_med = median(glyphs.iter().map(|g| g.width())).max(f32::EPSILON);
-    let word_gap = opts.word_gap_mult * w_med;
+    // The word gap is scaled by the line's **font size** (median glyph *height*), not glyph width:
+    // a space is ~0.25 em regardless of which letters border it, and a width-median is dragged down
+    // by narrow glyphs (i, l, t, f, .) on text-heavy lines, over-splitting words. Height is uniform
+    // across a line's font and aspect-correct in point space.
+    let h_med = median(glyphs.iter().map(|g| g.height())).max(f32::EPSILON);
+    let word_gap = opts.word_gap_mult * h_med;
 
     let mut text = String::new();
-    let mut prev_x1: Option<f32> = None;
+    // Running max of right edges seen so far — a glyph that sits behind a wider predecessor (kerning
+    // overlap, or a stray narrow box) can't regress the pen and fabricate a gap before the next one.
+    let mut pen_x1: Option<f32> = None;
     for g in glyphs {
-        if let Some(px1) = prev_x1 {
+        if let Some(px1) = pen_x1 {
             if g.x0 - px1 > word_gap {
                 text.push(' ');
             }
@@ -299,7 +323,7 @@ fn line_from_glyphs(glyphs: &[&Glyph], opts: &ReconstructOpts) -> Option<Line> {
         } else {
             text.push(g.ch);
         }
-        prev_x1 = Some(g.x1);
+        pen_x1 = Some(pen_x1.map_or(g.x1, |p| p.max(g.x1)));
     }
 
     let text = collapse_ws(&text);

--- a/reader-core/Cargo.toml
+++ b/reader-core/Cargo.toml
@@ -26,6 +26,9 @@ inkread-ink = { workspace = true }
 # EPUB backend: parsing + reflow layout + glyph rasterization (RR2-FR5). Pure Rust; the EpubBackend
 # adapter (document/reflow) maps it to the Document trait.
 inkread-epub = { workspace = true }
+# PDF reflow reconstruction (ADR-INKREAD-0011): pdfium glyph geometry -> reflowable Block model, fed
+# through inkread-epub's layout via the shared ReflowView. Pure Rust; host-testable.
+inkread-pdftext = { workspace = true }
 pdfium-render = { workspace = true }
 tiny-skia = { workspace = true }
 rusqlite = { workspace = true }

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -91,6 +91,18 @@ fn bind_pdfium() -> CoreResult<Box<dyn PdfiumLibraryBindings>> {
     })
 }
 
+/// Whether a pdfium font weight counts as **bold** (≥ 600, i.e. semibold and up) — used to flag
+/// body-sized bold section headings during reflow reconstruction (ADR-INKREAD-0011).
+fn weight_is_bold(w: PdfFontWeight) -> bool {
+    matches!(
+        w,
+        PdfFontWeight::Weight600
+            | PdfFontWeight::Weight700Bold
+            | PdfFontWeight::Weight800
+            | PdfFontWeight::Weight900
+    ) || matches!(w, PdfFontWeight::Custom(n) if n >= 600)
+}
+
 /// Map a pdfium load error to a typed [`CoreError`] (DRM vs corrupt vs other — RR7-FR5).
 fn map_load_error(e: PdfiumError) -> CoreError {
     match e {
@@ -181,34 +193,49 @@ impl PdfBackend {
         self.document.pages().len() as usize
     }
 
-    /// Map a source page's [`CharBox`]es into reconstruction [`Glyph`]s in **aspect-correct point
-    /// space** (un-normalizing by the page size), y-down — so reconstruction's per-axis thresholds
-    /// (a width-based column gutter, a height-based word gap) are in one physical scale rather than
-    /// x and y normalized independently (which distorts gaps). See `inkread_pdftext`'s contract.
+    /// Extract a source page's glyphs for reconstruction directly from pdfium, in **aspect-correct
+    /// point space**, y-down, carrying the per-char **bold** flag. Point space (not the normalized
+    /// `[0,1]` `page_chars` returns) keeps reconstruction's per-axis thresholds in one physical scale;
+    /// bold lets it pick out body-sized bold section headings. See `inkread_pdftext`'s contract.
     fn glyphs_for_page(&self, index: usize) -> Vec<Glyph> {
-        let (pw, ph) = i32::try_from(index)
+        let Some(page) = i32::try_from(index)
             .ok()
             .and_then(|i| self.document.pages().get(i).ok())
-            .map(|p| (p.width().value, p.height().value))
-            .unwrap_or((1.0, 1.0));
-        self.page_chars(index)
-            .into_iter()
-            .map(|c| Glyph {
-                ch: c.ch,
-                x0: c.rect.x0 * pw,
-                y0: c.rect.y0 * ph,
-                x1: c.rect.x1 * pw,
-                y1: c.rect.y1 * ph,
-            })
-            .collect()
+        else {
+            return Vec::new();
+        };
+        let ph = page.height().value;
+        let Ok(text) = page.text() else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for ch in text.chars().iter() {
+            let Some(c) = ch.unicode_char() else { continue };
+            let Ok(b) = ch.loose_bounds() else { continue };
+            // pdfium origin is bottom-left; flip to y-down (matches page_chars).
+            let (x0, x1) = (b.left().value, b.right().value);
+            let (y_top, y_bottom) = (ph - b.top().value, ph - b.bottom().value);
+            let bold = ch.font_is_bold_reenforced() || ch.font_weight().is_some_and(weight_is_bold);
+            out.push(Glyph {
+                ch: c,
+                x0: x0.min(x1),
+                y0: y_top.min(y_bottom),
+                x1: x0.max(x1),
+                y1: y_top.max(y_bottom),
+                bold,
+            });
+        }
+        out
     }
 
-    /// Reconstruct every source page into a reflowable [`Block`] unit (ADR-0011 page-by-page). Text
+    /// Reconstruct every source page into a reflowable [`Block`] unit (ADR-0011 page-by-page). Runs
+    /// the multi-page path so recurring running headers/footers and page numbers are stripped. Text
     /// only — bounded by the document's text size, like the EPUB backend holding all chapters.
     fn extract_units(&self) -> Vec<Vec<Block>> {
-        (0..self.source_page_count())
-            .map(|i| inkread_pdftext::reconstruct(&self.glyphs_for_page(i)))
-            .collect()
+        let pages: Vec<Vec<Glyph>> = (0..self.source_page_count())
+            .map(|i| self.glyphs_for_page(i))
+            .collect();
+        inkread_pdftext::reconstruct_pages(&pages)
     }
 
     /// Whether the PDF carries a usable text layer (sampling the first pages — a cover/blank first

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -14,10 +14,14 @@
 //! a vendored binary) → the system library → else [`CoreError::BackendUnavailable`]. On
 //! Android the loader finds `libpdfium.so` in `jniLibs/` via the system path.
 
+use std::cell::{Cell, RefCell};
 use std::sync::{Mutex, OnceLock};
 
+use inkread_epub::Block;
+use inkread_pdftext::Glyph;
 use pdfium_render::prelude::*;
 
+use crate::document::reflow_view::ReflowView;
 use crate::document::text_select::{self, CharBox, NormRect, TextSelection};
 use crate::document::{
     Document, DocumentMetadata, ExportMode, FitMode, LinkTarget, PageInk, PageLink, TocEntry,
@@ -143,8 +147,18 @@ fn chaikin(points: &[(f32, f32)], iterations: u8) -> Vec<(f32, f32)> {
 }
 
 /// A loaded PDF, rendered directly into the shell's buffer (RR5, Amendment 4).
+///
+/// When **reflow mode** is on (ADR-INKREAD-0011), rendering, page count, selection, search, and the
+/// typesetting setters are served by the [`ReflowView`] over the document's reconstructed text
+/// instead of the fixed pdfium page; toggling back restores the fixed-layout path.
 pub struct PdfBackend {
     document: PdfDocument<'static>,
+    /// Reflow view over the reconstructed text, `Some` while reflow mode is on. Interior mutability
+    /// so the `&self` render/setter paths can build/repaginate it.
+    reflow: RefCell<Option<ReflowView>>,
+    /// The last viewport (panel) size rendered at — the initial pagination guess when reflow is
+    /// enabled, so the position-preserving jump lands correctly (the first render then confirms it).
+    last_viewport: Cell<(u32, u32)>,
 }
 
 impl PdfBackend {
@@ -155,7 +169,50 @@ impl PdfBackend {
         let document = pdfium
             .load_pdf_from_byte_vec(bytes, None)
             .map_err(map_load_error)?;
-        Ok(Self { document })
+        Ok(Self {
+            document,
+            reflow: RefCell::new(None),
+            last_viewport: Cell::new((0, 0)),
+        })
+    }
+
+    /// The number of source (fixed-layout) pages in the document.
+    fn source_page_count(&self) -> usize {
+        self.document.pages().len() as usize
+    }
+
+    /// Map a source page's normalized [`CharBox`]es into reconstruction [`Glyph`]s (same normalized
+    /// `[0,1]`, y-down geometry — see `inkread_pdftext`'s coordinate contract).
+    fn glyphs_for_page(&self, index: usize) -> Vec<Glyph> {
+        self.page_chars(index)
+            .into_iter()
+            .map(|c| Glyph {
+                ch: c.ch,
+                x0: c.rect.x0,
+                y0: c.rect.y0,
+                x1: c.rect.x1,
+                y1: c.rect.y1,
+            })
+            .collect()
+    }
+
+    /// Reconstruct every source page into a reflowable [`Block`] unit (ADR-0011 page-by-page). Text
+    /// only — bounded by the document's text size, like the EPUB backend holding all chapters.
+    fn extract_units(&self) -> Vec<Vec<Block>> {
+        (0..self.source_page_count())
+            .map(|i| inkread_pdftext::reconstruct(&self.glyphs_for_page(i)))
+            .collect()
+    }
+
+    /// Whether the PDF carries a usable text layer (sampling the first pages — a cover/blank first
+    /// page is common). A pure scan has none and cannot be reflowed without OCR (out of scope).
+    fn has_text_layer(&self) -> bool {
+        (0..self.source_page_count().min(8)).any(|i| !self.page_chars(i).is_empty())
+    }
+
+    /// Borrow the reflow view if reflow mode is on.
+    fn reflow_on(&self) -> bool {
+        self.reflow.borrow().is_some()
     }
 
     /// Render page `index` into `buf` using a [`PdfRenderConfig`] built from the buffer's
@@ -284,7 +341,10 @@ impl PdfBackend {
 
 impl Document for PdfBackend {
     fn page_count(&self) -> usize {
-        self.document.pages().len() as usize
+        match &*self.reflow.borrow() {
+            Some(v) => v.page_count(),
+            None => self.source_page_count(),
+        }
     }
 
     fn metadata(&self) -> DocumentMetadata {
@@ -375,6 +435,10 @@ impl Document for PdfBackend {
     }
 
     fn render_page(&self, index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+        self.last_viewport.set((buf.width(), buf.height()));
+        if let Some(v) = &*self.reflow.borrow() {
+            return v.render(index, buf);
+        }
         // Full-page render: scale the whole page to the buffer. Amendment 3: reverse byte
         // order so pdfium emits RGBA into our RGBA buffer.
         self.render_with_config(index, buf, |w, h| {
@@ -393,6 +457,11 @@ impl Document for PdfBackend {
         pan_x: f32,
         pan_y: f32,
     ) -> CoreResult<()> {
+        self.last_viewport.set((buf.width(), buf.height()));
+        // Reflowed text already fills the viewport — fit modes don't apply.
+        if let Some(v) = &*self.reflow.borrow() {
+            return v.render(index, buf);
+        }
         buf.fill_white();
         let bw = i32::try_from(buf.width()).unwrap_or(0);
         let bh = i32::try_from(buf.height()).unwrap_or(0);
@@ -430,6 +499,10 @@ impl Document for PdfBackend {
     }
 
     fn content_bbox(&self, index: usize) -> Option<NormRect> {
+        // Reflowed text fills the viewport with no white margins — nothing to crop.
+        if self.reflow_on() {
+            return None;
+        }
         let page = i32::try_from(index)
             .ok()
             .and_then(|i| self.document.pages().get(i).ok())?;
@@ -488,6 +561,11 @@ impl Document for PdfBackend {
         pan_x: f32,
         pan_y: f32,
     ) -> CoreResult<()> {
+        self.last_viewport.set((buf.width(), buf.height()));
+        // Reflowed text already fills the viewport — there is no crop region to apply.
+        if let Some(v) = &*self.reflow.borrow() {
+            return v.render(index, buf);
+        }
         buf.fill_white();
         let bw = i32::try_from(buf.width()).unwrap_or(0);
         let bh = i32::try_from(buf.height()).unwrap_or(0);
@@ -529,6 +607,11 @@ impl Document for PdfBackend {
         offset_x: i32,
         offset_y: i32,
     ) -> CoreResult<()> {
+        self.last_viewport.set((buf.width(), buf.height()));
+        // Reflow has no fixed page to magnify; the reader uses font size instead of pinch-zoom.
+        if let Some(v) = &*self.reflow.borrow() {
+            return v.render(index, buf);
+        }
         let z = if zoom.is_finite() && zoom > 0.0 {
             zoom
         } else {
@@ -626,15 +709,78 @@ impl Document for PdfBackend {
     }
 
     fn word_at(&self, page: usize, x: f32, y: f32) -> Option<TextSelection> {
-        text_select::word_at(&self.page_chars(page), x, y)
+        match &*self.reflow.borrow() {
+            Some(v) => text_select::word_at(&v.page_chars(page), x, y),
+            None => text_select::word_at(&self.page_chars(page), x, y),
+        }
     }
 
     fn text_in_rect(&self, page: usize, rect: NormRect) -> TextSelection {
-        text_select::text_in_rect(&self.page_chars(page), rect)
+        match &*self.reflow.borrow() {
+            Some(v) => text_select::text_in_rect(&v.page_chars(page), rect),
+            None => text_select::text_in_rect(&self.page_chars(page), rect),
+        }
     }
 
     fn search_page(&self, page: usize, query: &str) -> Vec<crate::document::SearchMatch> {
-        text_select::find_matches(&self.page_chars(page), query)
+        match &*self.reflow.borrow() {
+            Some(v) => text_select::find_matches(&v.page_chars(page), query),
+            None => text_select::find_matches(&self.page_chars(page), query),
+        }
+    }
+
+    fn set_text_scale(&self, scale: f32, current_page: usize) -> Option<usize> {
+        self.reflow
+            .borrow()
+            .as_ref()
+            .map(|v| v.set_scale(scale, current_page))
+    }
+
+    fn set_line_spacing(&self, mult: f32, current_page: usize) -> Option<usize> {
+        self.reflow
+            .borrow()
+            .as_ref()
+            .map(|v| v.set_line_spacing(mult, current_page))
+    }
+
+    fn set_alignment(&self, align_code: i32, current_page: usize) -> Option<usize> {
+        self.reflow
+            .borrow()
+            .as_ref()
+            .map(|v| v.set_alignment(align_code, current_page))
+    }
+
+    fn supports_reflow(&self) -> bool {
+        self.has_text_layer()
+    }
+
+    fn set_reflow(&self, on: bool, current_page: usize) -> Option<usize> {
+        if on {
+            // Already on → no-op jump. No text layer → can't reflow (scanned PDF needs OCR).
+            if self.reflow_on() {
+                return Some(current_page);
+            }
+            if !self.has_text_layer() {
+                return None;
+            }
+            let units = self.extract_units();
+            let (w, h) = self.last_viewport.get();
+            let view = ReflowView::new(units, w, h);
+            // `current_page` is a source page (fixed mode) → land on its first reflowed page.
+            let target = view.unit_start_page(current_page);
+            *self.reflow.borrow_mut() = Some(view);
+            Some(target)
+        } else {
+            // Map the current reflowed page back to its source page before tearing the view down.
+            let target = {
+                self.reflow
+                    .borrow()
+                    .as_ref()
+                    .map(|v| v.unit_of(current_page))
+            };
+            *self.reflow.borrow_mut() = None;
+            Some(target.unwrap_or(current_page))
+        }
     }
 }
 

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -181,17 +181,24 @@ impl PdfBackend {
         self.document.pages().len() as usize
     }
 
-    /// Map a source page's normalized [`CharBox`]es into reconstruction [`Glyph`]s (same normalized
-    /// `[0,1]`, y-down geometry — see `inkread_pdftext`'s coordinate contract).
+    /// Map a source page's [`CharBox`]es into reconstruction [`Glyph`]s in **aspect-correct point
+    /// space** (un-normalizing by the page size), y-down — so reconstruction's per-axis thresholds
+    /// (a width-based column gutter, a height-based word gap) are in one physical scale rather than
+    /// x and y normalized independently (which distorts gaps). See `inkread_pdftext`'s contract.
     fn glyphs_for_page(&self, index: usize) -> Vec<Glyph> {
+        let (pw, ph) = i32::try_from(index)
+            .ok()
+            .and_then(|i| self.document.pages().get(i).ok())
+            .map(|p| (p.width().value, p.height().value))
+            .unwrap_or((1.0, 1.0));
         self.page_chars(index)
             .into_iter()
             .map(|c| Glyph {
                 ch: c.ch,
-                x0: c.rect.x0,
-                y0: c.rect.y0,
-                x1: c.rect.x1,
-                y1: c.rect.y1,
+                x0: c.rect.x0 * pw,
+                y0: c.rect.y0 * ph,
+                x1: c.rect.x1 * pw,
+                y1: c.rect.y1 * ph,
             })
             .collect()
     }

--- a/reader-core/src/document/fixed/pdf_tests.rs
+++ b/reader-core/src/document/fixed/pdf_tests.rs
@@ -559,3 +559,145 @@ fn content_bbox_is_tighter_than_full_page_and_crops() {
     );
     assert!(pb.bytes().chunks_exact(4).all(|p| p[3] == 0xFF), "opaque");
 }
+
+// ADR-INKREAD-0011 — PDF reflow end-to-end through the PdfBackend reflow mode.
+#[test]
+fn pdf_reflow_toggles_and_reflows_text() {
+    let _s = pdfium_serial();
+    if !host_pdfium_available() {
+        eprintln!("SKIP pdf_reflow_toggles_and_reflows_text: host libpdfium UNVERIFIED");
+        return;
+    }
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/minimal.pdf"
+    ))
+    .expect("fixture present");
+    let doc = PdfBackend::open(bytes).expect("open fixture");
+
+    // The fixture draws real text ("inkread M0") → it carries a reflow-able text layer.
+    assert!(doc.supports_reflow(), "minimal.pdf has a text layer");
+
+    let (w, h) = (300u32, 400u32);
+    let mut warm = vec![0u8; (w * h * 4) as usize];
+    // A fixed render first records the viewport the reflow pagination is built against.
+    doc.render_page(0, &mut PixelBuffer::from_rgba(&mut warm, w, h).unwrap())
+        .expect("fixed render");
+
+    // Fixed-layout: the typesetting setters are inert (RR4 — PDF returns None).
+    assert!(doc.set_text_scale(1.5, 0).is_none(), "no reflow while off");
+    let source_pages = doc.page_count();
+
+    // Enable reflow → lands on the reflowed page for source page 0.
+    let target = doc
+        .set_reflow(true, 0)
+        .expect("reflow enables with a text layer");
+    assert!(target < doc.page_count());
+
+    // The reflowed page renders the reconstructed text via the EPUB layout engine.
+    let mut rp = vec![0u8; (w * h * 4) as usize];
+    let mut rpb = PixelBuffer::from_rgba(&mut rp, w, h).unwrap();
+    doc.render_page(target, &mut rpb).expect("reflow render");
+    let inked = rpb.bytes().chunks_exact(4).filter(|p| p[0] < 200).count();
+    assert!(inked > 20, "reflowed page shows text: {inked} inked px");
+
+    // With reflow on, the typesetting setters are live and preserve position.
+    let p = doc
+        .set_text_scale(1.5, target)
+        .expect("reflow honors font size");
+    let p = doc
+        .set_line_spacing(1.8, p)
+        .expect("reflow honors line spacing");
+    let p = doc.set_alignment(1, p).expect("reflow honors alignment");
+
+    // The reflowed text is searchable through the shared text path.
+    assert!(
+        !doc.search_page(p, "inkread").is_empty(),
+        "search finds reflowed text"
+    );
+
+    // Disable → maps back to the source page and restores the fixed page count.
+    let back = doc.set_reflow(false, p).expect("reflow disables");
+    assert_eq!(back, 0, "reflowed page maps back to source page 0");
+    assert_eq!(doc.page_count(), source_pages, "fixed page count restored");
+    assert!(doc.set_text_scale(1.0, 0).is_none(), "setters inert again");
+}
+
+/// Visual gate (ADR-INKREAD-0011): render the first reflowed pages of a real text PDF to BMPs for
+/// human inspection — the black-screencap Supernote can't self-verify, so we eyeball on the host.
+/// Run on demand: `INKREAD_REFLOW_PDF=/path/book.pdf cargo test -p reader-core
+/// pdf_reflow_visual_dump -- --ignored --nocapture` → writes `target/reflow-bmp/reflow-NNN.bmp`.
+#[test]
+#[ignore = "visual gate: needs INKREAD_REFLOW_PDF=<text pdf>; run with --ignored --nocapture"]
+fn pdf_reflow_visual_dump() {
+    let _s = pdfium_serial();
+    let Ok(path) = std::env::var("INKREAD_REFLOW_PDF") else {
+        eprintln!("SKIP pdf_reflow_visual_dump: set INKREAD_REFLOW_PDF to a text PDF path");
+        return;
+    };
+    if !host_pdfium_available() {
+        eprintln!("SKIP pdf_reflow_visual_dump: host libpdfium UNVERIFIED");
+        return;
+    }
+    let bytes = std::fs::read(&path).expect("pdf readable");
+    let doc = PdfBackend::open(bytes).expect("open pdf");
+    assert!(doc.supports_reflow(), "no extractable text layer in {path}");
+
+    let (w, h) = (1404u32, 1872u32); // a Supernote-class portrait panel
+    let mut warm = vec![0u8; (w * h * 4) as usize];
+    doc.render_page(0, &mut PixelBuffer::from_rgba(&mut warm, w, h).unwrap())
+        .ok(); // records the viewport for pagination
+    let start = doc.set_reflow(true, 0).expect("reflow enables");
+    let pages = doc.page_count();
+
+    let out_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../target/reflow-bmp");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    for i in start..(start + 6).min(pages) {
+        let mut px = vec![0u8; (w * h * 4) as usize];
+        doc.render_page(i, &mut PixelBuffer::from_rgba(&mut px, w, h).unwrap())
+            .expect("render reflow page");
+        let path = out_dir.join(format!("reflow-{i:03}.bmp"));
+        write_bmp(&path, &px, w, h);
+        eprintln!("wrote {}", path.display());
+    }
+}
+
+/// Write an RGBA buffer as a 24-bit BMP (bottom-up, BGR) — dependency-free, Preview-openable, and
+/// `sips`-convertible to PNG. Used only by the visual gate.
+#[cfg(test)]
+fn write_bmp(path: &std::path::Path, rgba: &[u8], w: u32, h: u32) {
+    use std::io::Write;
+    let row_bytes = (w * 3).div_ceil(4) * 4; // each row padded to a 4-byte boundary
+    let pad = row_bytes - w * 3;
+    let pixels = row_bytes * h;
+    let file_size = 54 + pixels;
+    let mut out = Vec::with_capacity(file_size as usize);
+    out.extend_from_slice(b"BM");
+    out.extend_from_slice(&file_size.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes()); // reserved
+    out.extend_from_slice(&54u32.to_le_bytes()); // pixel data offset
+    out.extend_from_slice(&40u32.to_le_bytes()); // DIB header size
+    out.extend_from_slice(&(w as i32).to_le_bytes());
+    out.extend_from_slice(&(h as i32).to_le_bytes()); // positive → bottom-up
+    out.extend_from_slice(&1u16.to_le_bytes()); // planes
+    out.extend_from_slice(&24u16.to_le_bytes()); // bpp
+    out.extend_from_slice(&0u32.to_le_bytes()); // no compression
+    out.extend_from_slice(&pixels.to_le_bytes());
+    out.extend_from_slice(&2835i32.to_le_bytes()); // x ppm
+    out.extend_from_slice(&2835i32.to_le_bytes()); // y ppm
+    out.extend_from_slice(&0u32.to_le_bytes()); // palette colors
+    out.extend_from_slice(&0u32.to_le_bytes()); // important colors
+    for y in (0..h).rev() {
+        let row = (y * w * 4) as usize;
+        for x in 0..w as usize {
+            let o = row + x * 4;
+            out.push(rgba[o + 2]); // B
+            out.push(rgba[o + 1]); // G
+            out.push(rgba[o]); // R
+        }
+        out.extend(std::iter::repeat_n(0u8, pad as usize));
+    }
+    std::fs::File::create(path)
+        .and_then(|mut f| f.write_all(&out))
+        .expect("write bmp");
+}

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod fixed;
 pub mod reflow;
+pub(crate) mod reflow_view;
 pub mod text_select;
 
 pub use text_select::{CharBox, NormRect, SearchMatch, TextSelection};
@@ -346,6 +347,24 @@ pub trait Document {
     /// preserving the chapter (RR4 — KOReader's "Alignment"). Returns the new page, or `None` for a
     /// fixed-layout format (PDF). Default: unsupported.
     fn set_alignment(&self, _align_code: i32, _current_page: usize) -> Option<usize> {
+        None
+    }
+
+    /// Whether this document can be **reflowed** — true for a fixed-layout PDF that carries a text
+    /// layer (ADR-INKREAD-0011), false for one without (a pure scan: needs OCR, out of scope) and
+    /// false for already-reflowable formats (EPUB is always reflowed; the toggle is meaningless).
+    /// The shell uses this to enable/disable the Reflow control. Default: not reflow-able.
+    fn supports_reflow(&self) -> bool {
+        false
+    }
+
+    /// Toggle **reflow mode** on a fixed-layout PDF (ADR-INKREAD-0011): when `on`, the page's text is
+    /// reconstructed and laid out like a reflowable book so the font-size/line-spacing/alignment
+    /// controls take effect; when off, the original fixed page is shown. `current_page` is the page
+    /// the reader is on before the toggle; the backend returns `Some(new_page)` to jump to so the
+    /// reading position is preserved across the (changing) page count, or `None` if reflow is
+    /// unavailable (no text layer) or the format doesn't support the toggle. Default: unsupported.
+    fn set_reflow(&self, _on: bool, _current_page: usize) -> Option<usize> {
         None
     }
 

--- a/reader-core/src/document/reflow_view.rs
+++ b/reader-core/src/document/reflow_view.rs
@@ -258,3 +258,40 @@ fn layout_all(
         unit_start,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use inkread_epub::{Inline, TextRun};
+
+    // A heading flowed through the whole reflow pipeline (layout → render → page_chars) keeps its
+    // words intact across font sizes — guards the device "regressio n" / "valu e" regression at the
+    // integration level (the unit-level cause is covered in inkread-pdftext).
+    #[test]
+    fn heading_word_not_split_across_scales() {
+        let unit = vec![Block::Heading {
+            level: 2,
+            content: vec![Inline::Run(TextRun {
+                text: "Minimizing loss with logistic regression".to_string(),
+                bold: true,
+                italic: false,
+                href: None,
+            })],
+        }];
+        let view = ReflowView::new(vec![unit], 1404, 1872);
+        for scale in [1.0_f32, 1.5, 2.0] {
+            view.set_scale(scale, 0);
+            let mut bytes = vec![0u8; 1404 * 1872 * 4];
+            {
+                let mut buf = PixelBuffer::from_rgba(&mut bytes, 1404, 1872).unwrap();
+                view.render(0, &mut buf).unwrap();
+            }
+            let text: String = view.page_chars(0).iter().map(|c| c.ch).collect();
+            // The word must never be broken mid-word (no "regressio n").
+            assert!(
+                !text.contains("regressio n"),
+                "scale {scale} split the heading word: {text:?}"
+            );
+        }
+    }
+}

--- a/reader-core/src/document/reflow_view.rs
+++ b/reader-core/src/document/reflow_view.rs
@@ -1,0 +1,260 @@
+//! `ReflowView` — the reusable "reflowable units → layout cache → render / page-chars / repaginate"
+//! engine that backs **PDF reflow** (ADR-INKREAD-0011, approach b).
+//!
+//! It takes a sequence of reflowable **units** (each a `Vec<Block>` — for PDF, one per *source*
+//! page; ADR-0011 Decision 2 page-by-page) and reuses the existing `inkread-epub` layout/render
+//! pipeline verbatim: `paginate` → `render_page` → `page_glyphs`. The result is that PDF reflow gets
+//! font-size, line-spacing, alignment, selection, and search for free, with no new layout code.
+//!
+//! This mirrors the cache/repaginate shape of [`crate::document::reflow::EpubBackend`] but is a
+//! standalone helper so the working EPUB backend is left untouched (approach b); a future refactor
+//! could fold EPUB onto it. Each unit starts a new viewport page (book convention), which also gives
+//! a stable unit → page mapping for reading-position preservation.
+
+use std::cell::{Cell, RefCell};
+
+use inkread_epub::layout::{paginate, Align, LayoutOpts, Page};
+use inkread_epub::render::{page_glyphs, render_page as raster_page, AbFont, GrayCanvas};
+use inkread_epub::Block;
+
+use crate::document::text_select::{CharBox, NormRect};
+use crate::error::{CoreError, CoreResult};
+use crate::render::PixelBuffer;
+
+/// Base body font size in device pixels at scale `1.0` — matches the EPUB backend so a PDF and an
+/// EPUB read at the same nominal size (RR2-FR5 font-size control).
+const BASE_FONT_PX: f32 = 38.0;
+
+/// Clamp for the user text scale (font size). `1.0` = [`BASE_FONT_PX`].
+const MIN_SCALE: f32 = 0.6;
+const MAX_SCALE: f32 = 2.5;
+
+/// A pagination of all units for one (viewport, typography) — recomputed on a metrics change.
+struct Laid {
+    opts: LayoutOpts,
+    /// All viewport pages across all units, concatenated (a single global page index).
+    pages: Vec<Page>,
+    /// `unit_start[i]` = the global viewport page index where unit `i` begins.
+    unit_start: Vec<usize>,
+}
+
+/// A reflowed view over reading-order [`Block`] units, with a cached pagination.
+pub(crate) struct ReflowView {
+    /// Reading-order units (PDF source pages) as content blocks.
+    units: Vec<Vec<Block>>,
+    /// The reading face (embedded default — shared with the EPUB path).
+    font: AbFont,
+    /// User text scale (font size); `1.0` = [`BASE_FONT_PX`].
+    scale: Cell<f32>,
+    /// Line-spacing multiple (RR4 — default 1.4).
+    line_spacing: Cell<f32>,
+    /// Text alignment (RR4 — default Left).
+    align: Cell<Align>,
+    /// The current pagination; recomputed when the viewport or typography changes.
+    laid: RefCell<Laid>,
+}
+
+impl ReflowView {
+    /// Build a view over `units`, paginated for the initial `(w, h)` viewport at the default
+    /// typography. `w`/`h` may be a best-effort guess (the last render size); the first render
+    /// repaginates to the true buffer via [`Self::render`].
+    pub(crate) fn new(units: Vec<Vec<Block>>, w: u32, h: u32) -> Self {
+        let font = AbFont::default_font();
+        let laid = layout_all(
+            &units,
+            &font,
+            w.max(1),
+            h.max(1),
+            BASE_FONT_PX,
+            1.4,
+            Align::Left,
+        );
+        Self {
+            units,
+            font,
+            scale: Cell::new(1.0),
+            line_spacing: Cell::new(1.4),
+            align: Cell::new(Align::Left),
+            laid: RefCell::new(laid),
+        }
+    }
+
+    /// Total reflowed (viewport) page count for the current layout.
+    pub(crate) fn page_count(&self) -> usize {
+        self.laid.borrow().pages.len()
+    }
+
+    /// The global viewport page where reading-order `unit` begins (clamped to a valid page).
+    pub(crate) fn unit_start_page(&self, unit: usize) -> usize {
+        let laid = self.laid.borrow();
+        laid.unit_start.get(unit).copied().unwrap_or(0)
+    }
+
+    /// The unit (PDF source page) that global viewport `page` falls in.
+    pub(crate) fn unit_of(&self, page: usize) -> usize {
+        let laid = self.laid.borrow();
+        laid.unit_start
+            .iter()
+            .rposition(|&start| start <= page)
+            .unwrap_or(0)
+    }
+
+    /// The effective body font size for the current user scale.
+    fn font_px(&self) -> f32 {
+        BASE_FONT_PX * self.scale.get()
+    }
+
+    /// Repaginate if the requested buffer dimensions or the effective font size differ from the
+    /// cached layout (mirrors the EPUB backend's lazy repagination).
+    fn ensure_laid(&self, w: u32, h: u32) {
+        let font_px = self.font_px();
+        let needs = {
+            let laid = self.laid.borrow();
+            laid.opts.page_w as u32 != w
+                || laid.opts.page_h as u32 != h
+                || (laid.opts.font_px - font_px).abs() > 0.01
+        };
+        if needs {
+            let fresh = layout_all(
+                &self.units,
+                &self.font,
+                w,
+                h,
+                font_px,
+                self.line_spacing.get(),
+                self.align.get(),
+            );
+            *self.laid.borrow_mut() = fresh;
+        }
+    }
+
+    /// Repaginate at the current viewport/typography, anchoring to the unit `current_page` is in,
+    /// and return that unit's new start page so the reader stays put across the reflow.
+    fn repaginate_keeping_unit(&self, current_page: usize) -> usize {
+        let unit = self.unit_of(current_page);
+        let (w, h) = {
+            let laid = self.laid.borrow();
+            (laid.opts.page_w as u32, laid.opts.page_h as u32)
+        };
+        let fresh = layout_all(
+            &self.units,
+            &self.font,
+            w,
+            h,
+            self.font_px(),
+            self.line_spacing.get(),
+            self.align.get(),
+        );
+        let target = fresh.unit_start.get(unit).copied().unwrap_or(0);
+        *self.laid.borrow_mut() = fresh;
+        target
+    }
+
+    /// Render viewport page `index` into `buf` (white background, 8-bit gray expanded to RGBA) —
+    /// the same rasterization the EPUB backend uses. Repaginates lazily to the buffer first.
+    pub(crate) fn render(&self, index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+        self.ensure_laid(buf.width(), buf.height());
+        let laid = self.laid.borrow();
+        let page = laid.pages.get(index).ok_or(CoreError::PageOutOfRange {
+            requested: index,
+            available: laid.pages.len(),
+        })?;
+        buf.fill_white();
+        let mut canvas = GrayCanvas::new(buf.width(), buf.height());
+        raster_page(page, &laid.opts, &self.font, &mut canvas);
+        let dst = buf.bytes_mut();
+        for (i, &g) in canvas.pixels.iter().enumerate() {
+            let o = i * 4;
+            dst[o] = g;
+            dst[o + 1] = g;
+            dst[o + 2] = g;
+            dst[o + 3] = 0xFF;
+        }
+        Ok(())
+    }
+
+    /// The viewport page's glyphs as normalized [`CharBox`]es — the input to the shared selection +
+    /// search logic (mirrors the EPUB backend's `page_chars`). Out-of-range → empty (RR21-FR3).
+    pub(crate) fn page_chars(&self, index: usize) -> Vec<CharBox> {
+        let laid = self.laid.borrow();
+        let Some(page) = laid.pages.get(index) else {
+            return Vec::new();
+        };
+        let pw = laid.opts.page_w.max(1.0);
+        let ph = laid.opts.page_h.max(1.0);
+        page_glyphs(page, &laid.opts, &self.font)
+            .into_iter()
+            .map(|g| CharBox {
+                ch: g.ch,
+                rect: NormRect {
+                    x0: (g.x0 / pw).clamp(0.0, 1.0),
+                    y0: (g.y0 / ph).clamp(0.0, 1.0),
+                    x1: (g.x1 / pw).clamp(0.0, 1.0),
+                    y1: (g.y1 / ph).clamp(0.0, 1.0),
+                },
+            })
+            .collect()
+    }
+
+    /// Set the text scale (font size) and repaginate, returning the preserved-position page.
+    pub(crate) fn set_scale(&self, scale: f32, current_page: usize) -> usize {
+        let scale = if scale.is_finite() {
+            scale.clamp(MIN_SCALE, MAX_SCALE)
+        } else {
+            1.0
+        };
+        self.scale.set(scale);
+        self.repaginate_keeping_unit(current_page)
+    }
+
+    /// Set the line-spacing multiplier and repaginate, returning the preserved-position page.
+    pub(crate) fn set_line_spacing(&self, mult: f32, current_page: usize) -> usize {
+        let mult = if mult.is_finite() {
+            mult.clamp(1.0, 2.5)
+        } else {
+            1.4
+        };
+        self.line_spacing.set(mult);
+        self.repaginate_keeping_unit(current_page)
+    }
+
+    /// Set the alignment and repaginate, returning the preserved-position page.
+    pub(crate) fn set_alignment(&self, align_code: i32, current_page: usize) -> usize {
+        self.align.set(Align::from_code(align_code));
+        self.repaginate_keeping_unit(current_page)
+    }
+}
+
+/// Paginate every unit for `(w, h, font_px, line_spacing, align)`; each unit starts a page. Mirrors
+/// the EPUB backend's `layout_all` (chapters → here, units).
+fn layout_all(
+    units: &[Vec<Block>],
+    font: &AbFont,
+    w: u32,
+    h: u32,
+    font_px: f32,
+    line_spacing: f32,
+    align: Align,
+) -> Laid {
+    let mut opts = LayoutOpts::new(w as f32, h as f32, font_px);
+    opts.line_spacing = line_spacing;
+    opts.align = align;
+    let mut pages = Vec::new();
+    let mut unit_start = Vec::with_capacity(units.len());
+    for blocks in units {
+        unit_start.push(pages.len());
+        let mut ps = paginate(blocks, &opts, font);
+        if ps.is_empty() {
+            ps.push(Page::default()); // keep a 1:1 unit→start mapping even for an empty page
+        }
+        pages.append(&mut ps);
+    }
+    if pages.is_empty() {
+        pages.push(Page::default());
+    }
+    Laid {
+        opts,
+        pages,
+        unit_start,
+    }
+}

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -651,6 +651,43 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetAlignmen
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSupportsReflow(handle) : boolean — whether the open document can be reflowed (a text-layer
+// PDF). The shell uses this to enable/disable the Reflow control (ADR-INKREAD-0011).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSupportsReflow<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) -> jboolean {
+    env.with_env(|env| -> jni::errors::Result<jboolean> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        Ok(session.supports_reflow())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// nativeSetReflow(handle, on) : int — toggle reflow mode on a text-layer PDF (ADR-INKREAD-0011):
+// reconstruct the page text and flow it like a book so font/spacing/alignment take effect; off
+// restores the fixed page. Returns the new current page index (page count changes across the
+// toggle), or -1 if reflow is unavailable (no text layer / unsupported). Re-render afterward.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetReflow<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    on: jboolean,
+) -> jint {
+    env.with_env(|env| -> jni::errors::Result<jint> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        if session.set_reflow(on) {
+            Ok(session.current_page() as jint)
+        } else {
+            Ok(-1)
+        }
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkBeginStroke<'local>(
     mut env: EnvUnowned<'local>,

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -557,6 +557,30 @@ impl ReaderSession {
         }
     }
 
+    /// Whether the open document can be **reflowed** (ADR-INKREAD-0011) — a text-layer PDF. The
+    /// shell uses this to enable/disable the Reflow control (disabled for scanned PDFs / EPUB).
+    #[must_use]
+    pub fn supports_reflow(&self) -> bool {
+        self.document.supports_reflow()
+    }
+
+    /// Toggle **reflow mode** on the open PDF (ADR-INKREAD-0011): reconstructs the text and flows it
+    /// like a book so the font-size/line-spacing/alignment controls take effect; toggling off
+    /// restores the fixed page. Preserves the reading position across the changing page count and
+    /// invalidates the (now stale-keyed) crop cache. Returns `true` if the toggle applied, `false`
+    /// if reflow is unavailable (no text layer / unsupported format). Re-render after.
+    pub fn set_reflow(&mut self, on: bool) -> bool {
+        match self.document.set_reflow(on, self.page) {
+            Some(new_page) => {
+                self.page = new_page.min(self.page_count().saturating_sub(1));
+                *self.crop_cache.borrow_mut() = None; // page indices change meaning across the toggle
+                self.load_ink_for_current_page();
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Apply a navigation gesture: move the position (clamped at the document ends), then
     /// delegate to the policy's `on_page_turn` for the refresh stream (Amendment 6).
     ///


### PR DESCRIPTION
Makes the Font/Page typesetting controls work on **text-layer PDFs** by reconstructing the PDF's own text and flowing it through the existing `inkread-epub` layout engine. Design: **ADR-INKREAD-0011** (gitignored `spec/adr/`); backlog item 2.4. Device-verified on a Supernote Nomad.

## Architecture
A reflowed PDF is an EPUB-style `Block` flow reconstructed from pdfium glyph geometry, so pagination, font-size, line-spacing, alignment, selection, and search are all **reused, not rebuilt**.

- **New crate `inkread-pdftext`** — pure `&[Glyph] → Vec<Block>` reconstruction (host-testable; no pdfium/Android). Stages: XY-cut column/band segmentation → baseline line clustering → word spacing → paragraph grouping → hyphen-join → heading classification. `reconstruct_pages()` strips recurring running headers/footers + page numbers across pages.
- **`reader-core`** — `ReflowView` reuses the EPUB layout/render/pagination cache; `PdfBackend` gains a reflow **mode** behind `Document::set_reflow`/`supports_reflow` (approach b: `EpubBackend` untouched). Page-by-page, streaming.
- **Shell** — JNI `nativeSetReflow`/`nativeSupportsReflow`; a Reflow Off/On toggle on the Adjust sheet **Page** tab (shown only for text-layer PDFs; session-scoped, defaults off).

## What works
- Text PDFs reflow to the viewport; Font Size / Line Spacing / Alignment drive them; toggle off restores the fixed page.
- 2-column papers de-interleave into correct reading order; spanning titles read before columns.
- Headers/footers + page numbers stripped; bold section headings detected; selection + search work on reflowed text.
- Scanned (no-text-layer) PDFs hide the toggle.

## Testing
- 17 `inkread-pdftext` + 188 `reader-core` host tests pass; clippy/fmt clean; host builds without an Android SDK (RR1-AC3).
- **Host visual gate** on a real arXiv paper caught 3 reconstruction bugs (point-space coords, explicit-space handling, x-center glyph ordering).
- **On-device testing** caught a device-only bug: the device's pdfium emits a CR/LF glyph backed up over the last letter, injecting mid-word spaces ("valu e"); fixed by dropping control glyphs. Verified clean on device (no crashes in logcat).

## Known v1 limitations (deferred, documented in ADR)
- Rotated/vertical text (e.g. the arXiv left-margin watermark) mangles into per-letter junk — needs glyph-angle plumbing.
- Section numbers occasionally render on their own line.

Out of scope (separate engines): OCR for scanned PDFs, continuous-scroll view, deskew.