### PR TITLE
feat(digest): save a lasso text selection into the Supernote Digest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,14 @@
          Granted via Settings → All files access (Android 11+); sideloaded-app scope. -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
+    <!-- Supernote Digest ("Knowledge") write-through (ADR-INKREAD-0010): a lasso selection can be
+         saved into the firmware Digest app via its exported ContentProvider
+         (content://com.ratta.supernote.knowledge.provider). Both permissions are protectionLevel
+         "normal", so they are auto-granted to this sideloaded app at install — no platform signature
+         or system UID required. Vendor specifics stay in DigestController (IR-7). -->
+    <uses-permission android:name="com.ratta.supernote.knowledge.permission.READ_KNOWLEDGE" />
+    <uses-permission android:name="com.ratta.supernote.knowledge.permission.WRITE_KNOWLEDGE" />
+
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/dev/jraghavan/inkread/DigestController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DigestController.kt
@@ -1,0 +1,163 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.content.ContentUris
+import android.content.ContentValues
+import android.net.Uri
+import android.util.Log
+import android.widget.Toast
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Saves a lasso selection into the **Supernote Digest** (ADR-INKREAD-0010). The firmware calls this
+ * feature "Knowledge": an exported `ContentProvider`
+ * (`content://com.ratta.supernote.knowledge.provider`) backs the Digest app, gated by two
+ * protectionLevel-`normal` permissions (declared in the manifest) that are auto-granted to this
+ * sideloaded app at install. We mirror the native document reader's `insertDigest` map exactly so
+ * the entry shows up — and opens at the right page — in the stock Digest app.
+ *
+ * This is the single place that names the vendor (IR-7): the rest of inkread speaks lasso bounds and
+ * page numbers, never `com.ratta.*`.
+ *
+ * **v1 scope (page-level).** `content` is the PDF text under the selection; `source_page` makes the
+ * Digest entry jump back to the page. The precise in-page highlight needs mupdf-compatible character
+ * offsets (`startPosition`/`endPosition`) which pdfium can't reproduce 1:1 yet, so the location is
+ * emitted page-only (`start=end=0`) for now — see the location note below.
+ */
+class DigestController(private val host: Host) {
+
+    /** What digest-write needs from the reader shell. */
+    interface Host {
+        /** Context for toasts / `runOnUiThread`. */
+        val activity: Activity
+
+        /** The open document handle (`0` = none). */
+        val docHandle: Long
+
+        /** Filesystem path of the open document (the private copy), or null if none. */
+        val currentDocPath: String?
+
+        /** Run [block] on the single engine thread (serializes native access). */
+        fun engineExecute(block: () -> Unit)
+    }
+
+    private val activity: Activity get() = host.activity
+
+    /**
+     * Save the lasso selection on [page] (bounds in normalized doc coords `[nx0,ny0,nx1,ny1]`) to the
+     * Digest. Extracts the PDF text under the selection on the engine thread (native), then inserts
+     * via the Knowledge provider. No-ops with a toast when there's nothing to save.
+     */
+    fun addDigest(page: Int, boundsNorm: FloatArray) {
+        val path = host.currentDocPath
+        if (path == null || host.docHandle == 0L || boundsNorm.size != 4) {
+            toast("Nothing to add to Digest")
+            return
+        }
+        host.engineExecute {
+            val text = try {
+                WireCodec.decodeSelection(
+                    NativeBridge.nativeTextInRect(
+                        host.docHandle, page, boundsNorm[0], boundsNorm[1], boundsNorm[2], boundsNorm[3],
+                    ),
+                ).text.trim()
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "textInRect failed: ${e.message}"); ""
+            }
+            if (text.isEmpty()) {
+                toast("No selectable text under the selection")
+                return@engineExecute
+            }
+            val ok = insertDigest(path, page, text)
+            toast(if (ok) "Added to Digest" else "Couldn't add to Digest")
+        }
+    }
+
+    /**
+     * Save already-selected text on [page] to the Digest. Used by the printed-text lasso path, which
+     * has resolved the selection itself — so no native extraction is needed, just the insert.
+     */
+    fun addDigestText(page: Int, content: String) {
+        val path = host.currentDocPath
+        val text = content.trim()
+        if (path == null || host.docHandle == 0L || text.isEmpty()) {
+            toast("Nothing to add to Digest")
+            return
+        }
+        host.engineExecute {
+            val ok = insertDigest(path, page, text)
+            toast(if (ok) "Added to Digest" else "Couldn't add to Digest")
+        }
+    }
+
+    /**
+     * Insert one Digest row, mirroring the native document reader's `KnowledgeDatabaseManager`:
+     * `content`, `source_type=1` (document), `source_path`, `source_page`, and a `metadata` JSON that
+     * nests `document_location_data` + `source_size`. `creation_time`/`last_modified_time` are left
+     * for the provider to fill, exactly as the firmware does.
+     */
+    private fun insertDigest(srcPath: String, page: Int, content: String): Boolean {
+        val values = ContentValues().apply {
+            put(COL_CONTENT, content)
+            put(COL_SOURCE_TYPE, SOURCE_TYPE_DOCUMENT)
+            put(COL_SOURCE_PATH, srcPath)
+            put(COL_SOURCE_PAGE, page.toString())
+            put(COL_METADATA, buildMetadata(srcPath, page))
+        }
+        return try {
+            val uri = activity.contentResolver.insert(Uri.parse(INSERT_URI), values)
+            val id = uri?.let { ContentUris.parseId(it) } ?: -1L
+            Log.i(TAG, "DIAG digest insert → id=$id page=$page len=${content.length}")
+            id > 0
+        } catch (e: SecurityException) {
+            // WRITE_KNOWLEDGE missing (provider absent on a non-Supernote device, or perm denied).
+            Log.e(TAG, "digest insert denied: ${e.message}"); false
+        } catch (e: RuntimeException) {
+            Log.e(TAG, "digest insert failed: ${e.message}"); false
+        }
+    }
+
+    /**
+     * `metadata` JSON. `document_location_data` is itself a JSON string — a `[{chapter,page,
+     * startPosition,endPosition}]` array (mupdf coordinate model). v1 emits page-only
+     * (`start=end=0`): the entry opens at [page] but doesn't restore a precise highlight span until
+     * we calibrate pdfium offsets against a real mupdf sample. `source_size` is the PDF byte size.
+     */
+    private fun buildMetadata(srcPath: String, page: Int): String {
+        val location = JSONArray().put(
+            JSONObject()
+                .put("chapter", 0)
+                .put("page", page)
+                .put("startPosition", 0)
+                .put("endPosition", 0),
+        )
+        val size = runCatching { File(srcPath).length() }.getOrDefault(0L)
+        return JSONObject()
+            .put(KEY_DOCUMENT_LOCATION_DATA, location.toString())
+            .put(KEY_SOURCE_SIZE, size)
+            .toString()
+    }
+
+    private fun toast(msg: String) =
+        activity.runOnUiThread { Toast.makeText(activity, msg, Toast.LENGTH_SHORT).show() }
+
+    private companion object {
+        const val TAG = "DigestController"
+
+        // --- Supernote "Knowledge" provider contract (the only vendor-named surface; IR-7). ---
+        const val INSERT_URI = "content://com.ratta.supernote.knowledge.provider/knowledge/insert"
+
+        const val SOURCE_TYPE_DOCUMENT = 1 // 1=DOCUMENT(PDF), 2=NOTE, 3=PASTEBOARD, 4=SELF_ADD
+
+        const val COL_CONTENT = "content"
+        const val COL_SOURCE_TYPE = "source_type"
+        const val COL_SOURCE_PATH = "source_path"
+        const val COL_SOURCE_PAGE = "source_page"
+        const val COL_METADATA = "metadata"
+
+        const val KEY_DOCUMENT_LOCATION_DATA = "document_location_data"
+        const val KEY_SOURCE_SIZE = "source_size"
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -126,6 +126,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun engineExecute(block: () -> Unit) { engine.execute(block) }
     })
 
+    // ---- Supernote Digest write-through (ADR-INKREAD-0010) — saves a lasso selection into the
+    //      firmware Digest app via its "Knowledge" provider; owns the vendor surface (IR-7). ----
+    private val digest = DigestController(object : DigestController.Host {
+        override val activity get() = this@ReaderActivity
+        override val docHandle get() = this@ReaderActivity.docHandle
+        override val currentDocPath get() = this@ReaderActivity.currentDocPath
+        override fun engineExecute(block: () -> Unit) { engine.execute(block) }
+    })
+
     // ---- tool model (ADR-INKREAD-0010) ----
     /** The active annotation tool. [Tool.PEN] inks via firmware; the rest capture the stylus. */
     @Volatile private var tool: Tool = Tool.PEN
@@ -1968,7 +1977,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val snippet = sel.text.trim().replace(Regex("\\s+"), " ")
         // Define is a per-word action — it makes no sense for a multi-line selection, so a multi-line
         // catch (more than one line box) offers only Copy + Highlight.
-        val items = if (sel.boxes.size > 1) arrayOf("Copy", "Highlight") else arrayOf("Define", "Copy", "Highlight")
+        val items = if (sel.boxes.size > 1) arrayOf("Copy", "Highlight", "Add to Digest")
+        else arrayOf("Define", "Copy", "Highlight", "Add to Digest")
         AlertDialog.Builder(this, R.style.InkDialog)
             .setTitle(if (snippet.length > 42) snippet.take(42) + "…" else snippet)
             .setItems(items) { _, which ->
@@ -1976,6 +1986,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                     "Define" -> dict.defineSelectionText(snippet)
                     "Copy" -> copyTextToClipboard(snippet)
                     "Highlight" -> engine.execute { highlightTextBoxes(sel) }
+                    "Add to Digest" -> digest.addDigestText(currentPage, sel.text)
                 }
             }
             // Any dismissal (action chosen or cancelled) clears the box overlay; a Highlight redraws
@@ -2086,6 +2097,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 val newIds = try { NativeBridge.nativeInkPaste(docHandle, PASTE_OFFSET, PASTE_OFFSET) } catch (e: RuntimeException) { IntArray(0) }
                 if (newIds.isNotEmpty()) setSelection(newIds) else runOnUiThread { showSelectionToolbar() }
             }
+            // Save the PDF text under the selection into the Supernote Digest; keep the selection up.
+            SelAction.DIGEST -> if (ids.isNotEmpty()) digest.addDigest(currentPage, selectionBounds.copyOf())
         }
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/SelectionToolbar.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SelectionToolbar.kt
@@ -19,6 +19,7 @@ enum class SelAction(val label: String, val iconRes: Int) {
     COPY("Copy", R.drawable.ic_sel_copy),
     PASTE("Paste", R.drawable.ic_sel_paste),
     SELECT_ALL("Select all", R.drawable.ic_sel_all),
+    DIGEST("Add to Digest", R.drawable.ic_sel_digest),
     DONE("Done", R.drawable.ic_sel_done),
 }
 

--- a/app/src/main/res/drawable/ic_sel_digest.xml
+++ b/app/src/main/res/drawable/ic_sel_digest.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@android:color/black" android:pathData="M17,11v6.97l-5,-2.14l-5,2.14V5h7V3H7c-1.1,0 -2,0.9 -2,2v16l7,-3l7,3V11H17zM21,7h-2v2h-2V7h-2V5h2V3h2v2h2V7z"/>
+</vector>


### PR DESCRIPTION
## What

Adds an **Add to Digest** action: lasso-select text in a PDF and save the excerpt straight into the firmware **Digest** app.

## How

Supernote's Digest is internally the **"Knowledge"** store, backed by an exported `ContentProvider` (`content://com.ratta.supernote.knowledge.provider`). Its `READ_KNOWLEDGE`/`WRITE_KNOWLEDGE` permissions are protectionLevel **`normal`**, so they are auto-granted to this sideloaded app at install — no platform signature or system UID needed.

- **`DigestController`** owns the entire vendor-named provider contract (IR-7); the rest of the app only speaks page numbers and selection text.
- Wired onto the **printed-text lasso menu** (`Define · Copy · Highlight · Add to Digest`) and the ink-stroke selection toolbar.
- The insert mirrors the native document reader's `insertDigest` map exactly: `source_type=1`, `source_path`, `source_page`, and a `metadata` JSON nesting `document_location_data` + `source_size`.

## Scope

v1 is **page-level**: the Digest entry opens the source PDF at the right page. Precise in-page highlight restoration needs mupdf-compatible character offsets (the firmware indexes its own text walk directly), which pdfium can't reproduce 1:1 — deferred as optional polish.

## Verification

Built and installed on a Manta (`./buildApk.sh --install`). Both KNOWLEDGE permissions show `granted=true` for the sideloaded app. A live lasso → Add to Digest produced `DigestController: DIAG digest insert → id=9 page=59 len=226`, and the excerpt appears in the native Digest app.

## Files

- `AndroidManifest.xml` — `READ_KNOWLEDGE` + `WRITE_KNOWLEDGE`
- `DigestController.kt` *(new)* — the writer
- `ic_sel_digest.xml` *(new)* — toolbar icon
- `SelectionToolbar.kt`, `ReaderActivity.kt` — action wiring