### PR TITLE
Review hardening: deferred ink flush, batched JNI, import/export/dict bounds, cancelable search

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
@@ -10,6 +10,7 @@ import android.content.Context
 object AppSettings {
     private const val PREFS = "settings"
     private const val KEY_OVERWRITE_ON_EXPORT = "overwrite_on_export"
+    private const val KEY_ONLINE_LOOKUP = "online_lookup"
 
     private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -22,4 +23,14 @@ object AppSettings {
 
     fun setOverwriteOnExport(c: Context, value: Boolean) =
         prefs(c).edit().putBoolean(KEY_OVERWRITE_ON_EXPORT, value).apply()
+
+    /**
+     * When true, a dictionary miss falls back to an online (Wiktionary) lookup, waking the radio.
+     * Off by default — inkread is offline-first, and a definitive opt-in keeps looked-up words from
+     * leaving the device without the reader's say-so (the review's privacy/power note).
+     */
+    fun onlineLookup(c: Context): Boolean = prefs(c).getBoolean(KEY_ONLINE_LOOKUP, false)
+
+    fun setOnlineLookup(c: Context, value: Boolean) =
+        prefs(c).edit().putBoolean(KEY_ONLINE_LOOKUP, value).apply()
 }

--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -8,6 +8,8 @@ import android.provider.OpenableColumns
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
 
 /**
  * A minimal on-device book library (RR17) for the shell: imported PDFs live under
@@ -40,12 +42,31 @@ object Books {
         val ext = if (raw.substringAfterLast('.', "").equals("epub", ignoreCase = true)) "epub" else "pdf"
         val dest = File(dir(context), "${sanitize(raw)}.$ext")
         return try {
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                dest.outputStream().use { out -> input.copyTo(out) }
+            val ok = context.contentResolver.openInputStream(uri)?.use { input ->
+                dest.outputStream().use { out -> copyCapped(input, out, MAX_IMPORT_BYTES) }
             } ?: return null
+            // Over the cap: the core would reject this at open anyway (2 GiB), so don't keep a
+            // huge/partial copy wasting storage. Match the native limit, fail before fully writing.
+            if (!ok) { dest.delete(); return null }
             dest
         } catch (e: Exception) {
+            dest.delete() // never leave a partial copy behind on an IO failure
             null
+        }
+    }
+
+    /** Stream [input] → [out], aborting once more than [max] bytes have been read (mirrors the native
+     *  open cap so a file the core would refuse never gets fully written). Returns false if the source
+     *  exceeded the cap, true otherwise. */
+    private fun copyCapped(input: InputStream, out: OutputStream, max: Long): Boolean {
+        val buf = ByteArray(64 * 1024)
+        var total = 0L
+        while (true) {
+            val n = input.read(buf)
+            if (n < 0) return true
+            total += n
+            if (total > max) return false
+            out.write(buf, 0, n)
         }
     }
 
@@ -128,6 +149,9 @@ object Books {
 
     private const val THUMB_W = 360
     private const val RECENTS_MAX = 12
+    // Cap a SAF import at the native open limit (2 GiB) so an oversized/unbounded source stream is
+    // rejected before it's fully copied into app storage, not after (the review's import-cap note).
+    private const val MAX_IMPORT_BYTES = 2L shl 30
 
     private fun queryName(context: Context, uri: Uri): String? =
         context.contentResolver

--- a/app/src/main/java/dev/jraghavan/inkread/DictController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DictController.kt
@@ -104,7 +104,7 @@ class DictController(private val host: Host) {
         } catch (e: RuntimeException) {
             WordDefinition(false, "", "", emptyList(), emptyList())
         }
-        if (!def.found) {
+        if (!def.found && AppSettings.onlineLookup(activity)) {
             onlineLookup(word)?.let { online ->
                 try {
                     NativeBridge.nativeDictPut(dictHandle, online.lang, online.headword, online.senses.joinToString("\n"))

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -66,15 +66,29 @@ class HomeActivity : Activity() {
         return s
     }
 
+    /** Signature of the shelf state the current view was built from — lets onResume skip a full
+     *  rebuild (and the e-ink full refresh it triggers) when nothing the home screen shows changed,
+     *  e.g. returning from Settings rather than the reader. */
+    private var shelfSig: String? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(buildView())
+        shelfSig = shelfSignature()
     }
 
     override fun onResume() {
         super.onResume()
-        setContentView(buildView()) // refresh covers + progress after returning from the reader
+        val sig = shelfSignature()
+        if (sig != shelfSig) {
+            setContentView(buildView()) // refresh covers + progress after returning from the reader
+            shelfSig = sig
+        }
     }
+
+    /** A stable digest of what the shelf renders — recents order + per-book read progress. */
+    private fun shelfSignature(): String =
+        Books.recents(this).joinToString("|") { "${it.id}@${Books.progress(this, it.id)}" }
 
     private fun buildView(): View {
         val w = resources.displayMetrics.widthPixels

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -207,8 +207,17 @@ object NativeBridge {
     /** Add a sample to the in-progress stroke (ink) or erase at the point (eraser). NaN tilt = absent. */
     external fun nativeInkAddPoint(handle: Long, x: Float, y: Float, pressure: Float, tiltX: Float, tiltY: Float, timestampMs: Int)
 
+    /** Batched [nativeInkAddPoint]: [xy] is packed `[x0,y0,x1,y1,…]` (pressure 1, no tilt/timestamp).
+     *  One JNI crossing per stroke instead of per point — cheaper on the annotation hot path. */
+    external fun nativeInkAddPoints(handle: Long, xy: FloatArray)
+
     /** Commit the in-progress stroke / eraser gesture; autosaves the page only if it changed. */
     external fun nativeInkEndStroke(handle: Long)
+
+    /** Opt into deferred-autosave mode: edits mark the page dirty instead of fsyncing on every
+     *  stroke-end, and the shell flushes via [nativeInkSave] on a trailing-edge debounce. Off by
+     *  default (save-on-stroke-end durability). A power/flash-wear knob. */
+    external fun nativeInkSetDeferredAutosave(handle: Long, deferred: Boolean)
 
     /** Strokes on [page] in the draw-wire (decode with [WireCodec.decodeStrokes]) — for baking. */
     external fun nativeInkStrokesForDraw(handle: Long, page: Int): ByteArray

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -187,6 +187,21 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     /** Safety net for a swallowed stylus ACTION_UP: commit the stroke after a brief pen pause. */
     private val strokeFinalize = Runnable { finalizeStroke() }
 
+    /** Trailing-edge flush of deferred ink (RR20): coalesces the per-stroke fsync into one write a
+     *  short while after the pen goes idle. onPause/teardown flush immediately and cancel this. */
+    private val inkFlush = Runnable {
+        val h = docHandle
+        if (h != 0L) engine.execute {
+            try { NativeBridge.nativeInkSave(h) } catch (e: RuntimeException) { Log.e(TAG, "ink flush failed: ${e.message}") }
+        }
+    }
+
+    /** (Re)arm the trailing-edge ink flush after an edit; resets the timer on each new stroke. */
+    private fun scheduleInkFlush() {
+        mainHandler.removeCallbacks(inkFlush)
+        mainHandler.postDelayed(inkFlush, INK_FLUSH_MS)
+    }
+
     // ---- stylus long-press → instant word lookup (natural "hold a word to define it") ----
     private var lpDownX = 0f
     private var lpDownY = 0f
@@ -467,6 +482,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         if (::colorPalette.isInitialized) colorPalette.dismiss()
         mainHandler.removeCallbacks(fingerLongPress) // drop any pending finger gesture on leaving
         mainHandler.removeCallbacks(longPress)
+        mainHandler.removeCallbacks(inkFlush) // the explicit flush below supersedes the debounce
         ink.teardown() // release the firmware ink claim + clear the overlay
         // Persist the reading position + flush ink when backgrounded (RR27/RR20) — engine thread.
         engine.execute {
@@ -636,6 +652,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             try {
                 NativeBridge.nativeAttachInkStore(docHandle, path)
                 diag { "DIAG ink store attached for $path" }
+                // Defer the per-stroke fsync: edits mark the page dirty and we flush on a trailing
+                // debounce (scheduleInkFlush) + on pause/teardown, instead of fsyncing the sidecar
+                // on every stroke-end — saves flash wear + energy on long note sessions. The core
+                // still flushes on page-change/export, so nothing is lost on navigation.
+                NativeBridge.nativeInkSetDeferredAutosave(docHandle, true)
             } catch (e: RuntimeException) {
                 Log.e(TAG, "attach ink store failed: ${e.message}")
             }
@@ -865,6 +886,16 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         engine.execute { commitStroke(raw) }
     }
 
+    /** Map packed view-space `[x,y,…]` to packed page-normalized `[x,y,…]` for [NativeBridge.nativeInkAddPoints]. */
+    private fun toNormPoints(view: FloatArray): FloatArray {
+        val out = FloatArray(view.size)
+        var i = 0
+        while (i + 1 < view.size) {
+            out[i] = vToNx(view[i]); out[i + 1] = vToNy(view[i + 1]); i += 2
+        }
+        return out
+    }
+
     /** Feed the captured pen stroke to the core (begin→points→end → autosave). Engine thread. */
     private fun commitStroke(raw: FloatArray) {
         val w = viewW; val h = viewH
@@ -876,12 +907,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val color = if (isHl) highlightColor() else penColor()
         try {
             NativeBridge.nativeInkBeginStroke(docHandle, coreTool, color, widthNorm, System.currentTimeMillis())
-            var i = 0
-            while (i + 1 < raw.size) {
-                NativeBridge.nativeInkAddPoint(docHandle, vToNx(raw[i]), vToNy(raw[i + 1]), 1.0f, Float.NaN, Float.NaN, 0)
-                i += 2
-            }
+            NativeBridge.nativeInkAddPoints(docHandle, toNormPoints(raw))
             NativeBridge.nativeInkEndStroke(docHandle)
+            scheduleInkFlush() // deferred autosave: persist on a trailing debounce, not this fsync
             diag { "DIAG commitStroke OK ${raw.size / 2} pts tool=$tool → core page $currentPage" }
         } catch (e: RuntimeException) {
             Log.e(TAG, "ink commit failed: ${e.message}")
@@ -1754,12 +1782,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val radiusNorm = lenToNorm(ERASE_RADIUS_PX)
         try {
             NativeBridge.nativeInkBeginStroke(docHandle, CORE_TOOL_ERASER, INK_COLOR_BLACK, radiusNorm, System.currentTimeMillis())
-            var i = 0
-            while (i + 1 < viewPts.size) {
-                NativeBridge.nativeInkAddPoint(docHandle, vToNx(viewPts[i]), vToNy(viewPts[i + 1]), 1.0f, Float.NaN, Float.NaN, 0)
-                i += 2
-            }
+            NativeBridge.nativeInkAddPoints(docHandle, toNormPoints(viewPts))
             NativeBridge.nativeInkEndStroke(docHandle)
+            scheduleInkFlush() // deferred autosave: persist on a trailing debounce, not this fsync
         } catch (e: RuntimeException) {
             Log.e(TAG, "erase failed: ${e.message}"); return
         }
@@ -2020,6 +2045,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 NativeBridge.nativeInkAddPoint(docHandle, b.x1, midY, 1.0f, Float.NaN, Float.NaN, 0)
                 NativeBridge.nativeInkEndStroke(docHandle)
             }
+            scheduleInkFlush() // deferred autosave: persist the baked bands on the trailing debounce
             diag { "DIAG highlighted ${sel.boxes.size} text boxes" }
         } catch (e: RuntimeException) {
             Log.e(TAG, "text highlight failed: ${e.message}")
@@ -2104,13 +2130,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     /** Undo the last ink edit (from the tool pill). Global — refreshes any active selection too. */
     private fun inkUndo() = engine.execute {
-        try { NativeBridge.nativeInkUndo(docHandle) } catch (e: RuntimeException) {}
+        try { NativeBridge.nativeInkUndo(docHandle); scheduleInkFlush() } catch (e: RuntimeException) {}
         refreshSelectionAfterHistory()
     }
 
     /** Redo the last undone ink edit (from the tool pill). */
     private fun inkRedo() = engine.execute {
-        try { NativeBridge.nativeInkRedo(docHandle) } catch (e: RuntimeException) {}
+        try { NativeBridge.nativeInkRedo(docHandle); scheduleInkFlush() } catch (e: RuntimeException) {}
         refreshSelectionAfterHistory()
     }
 
@@ -2709,6 +2735,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val LINE_SPACINGS = floatArrayOf(1.2f, 1.4f, 1.7f) // Small / Medium / Large (RR4).
         const val HIGHLIGHT_WIDTH_PX = 30f // wide marker band (vs INK_STROKE_WIDTH for the pen).
         const val STROKE_PAUSE_MS = 600L // commit a stroke after this pen-pause (swallowed-UP net).
+        const val INK_FLUSH_MS = 1500L // trailing-edge delay before the deferred ink autosave fsyncs.
         const val LONG_PRESS_MS = 500L // hold the pen this long (≈still) on a word → look it up.
         const val LONG_PRESS_SLOP_PX = 16f // movement beyond this cancels the long-press (it's a stroke).
         const val INK_STROKE_WIDTH = 6f // baked-ink line width (px) tuned to match the firmware pen.

--- a/app/src/main/java/dev/jraghavan/inkread/SearchController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SearchController.kt
@@ -57,6 +57,9 @@ class SearchController(private val host: Host) {
     @Volatile private var query = ""
     @Volatile private var boxes: List<SelBox> = emptyList()
     @Volatile private var boxesPage = -1
+    /** Set on the UI thread (Cancel) and polled by the engine-thread scan each page so a long
+     *  full-document search can be aborted instead of pinning the SoC to the last page. */
+    @Volatile private var searchCancelled = false
 
     /** The active hit's highlight boxes if it lives on [page], else empty. Read on the engine thread
      *  by the render path; the shell draws these over the page. */
@@ -108,14 +111,24 @@ class SearchController(private val host: Host) {
         if (q.isEmpty()) { clear(); return }
         val handle = host.docHandle
         if (handle == 0L) return
-        Toast.makeText(host.activity, "Searching…", Toast.LENGTH_SHORT).show()
+        searchCancelled = false
+        // The scan blocks the engine thread, but the UI thread is free — so a cancelable progress
+        // dialog lets the user abort a long full-document scan (the Cancel flips the volatile flag
+        // the loop polls each page). Non-cancelable via back so the only exit is an explicit choice.
+        val progress = AlertDialog.Builder(host.activity)
+            .setTitle("Searching…")
+            .setMessage("Scanning the document for “$q”.")
+            .setNegativeButton("Cancel") { _, _ -> searchCancelled = true }
+            .setCancelable(false)
+            .create()
+        progress.show()
         host.engineExecute {
-            if (host.docHandle != handle) return@engineExecute
             val total = host.pageCount.coerceAtLeast(1)
             val found = ArrayList<SearchHit>()
             var page = 0
-            while (page < total && found.size < MAX_SEARCH_HITS) {
-                if (host.docHandle != handle) return@engineExecute
+            var aborted = host.docHandle != handle
+            while (!aborted && page < total && found.size < MAX_SEARCH_HITS) {
+                if (host.docHandle != handle || searchCancelled) { aborted = true; break }
                 val matches = try {
                     WireCodec.decodeSearch(NativeBridge.nativeSearchPage(handle, page, q))
                 } catch (e: RuntimeException) {
@@ -127,16 +140,16 @@ class SearchController(private val host: Host) {
                 }
                 page++
             }
-            query = q
-            hits = found
-            index = -1
+            // Only commit results for a completed scan; an aborted one leaves the prior query intact.
+            if (!aborted) { query = q; hits = found; index = -1 }
             host.activity.runOnUiThread {
-                if (found.isEmpty()) {
-                    Toast.makeText(host.activity, "No matches for \"$q\"", Toast.LENGTH_SHORT).show()
-                } else {
+                try { progress.dismiss() } catch (e: Exception) {}
+                when {
+                    aborted -> Toast.makeText(host.activity, "Search cancelled", Toast.LENGTH_SHORT).show()
+                    found.isEmpty() -> Toast.makeText(host.activity, "No matches for \"$q\"", Toast.LENGTH_SHORT).show()
                     // Open the results list and let the reader pick which hit to jump to — don't
                     // teleport to the first match (the list is the point of a search).
-                    showResults()
+                    else -> showResults()
                 }
             }
         }

--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -75,6 +75,22 @@ class SettingsActivity : Activity() {
             ) { onExportOverwriteTapped() },
         )
 
+        // ── Dictionary ─────────────────────────────────────────────────────────────
+        column.addView(spacer(dp(34)))
+        column.addView(eyebrow("Dictionary"))
+        column.addView(spacer(dp(12)))
+        column.addView(
+            toggleRow(
+                title = "Look up missing words online",
+                desc = "When the on-device dictionary has no entry, fetch a definition from " +
+                    "Wiktionary. This uses the network and sends the word off your device. Off by " +
+                    "default — inkread is offline-first.",
+                on = AppSettings.onlineLookup(this),
+            ) {
+                AppSettings.setOnlineLookup(this, !AppSettings.onlineLookup(this)); refresh()
+            },
+        )
+
         // ── How it works ───────────────────────────────────────────────────────────
         column.addView(spacer(dp(34)))
         column.addView(eyebrow("How it works"))

--- a/inkread-dict/src/import.rs
+++ b/inkread-dict/src/import.rs
@@ -96,17 +96,50 @@ pub fn is_stardict_dir(dir: &Path) -> bool {
     find(dir, "ifo").is_ok() && find(dir, "idx").is_ok()
 }
 
+/// Hard ceiling on the dictionary data block — decompressed for `.dict.dz`, on-disk for `.dict`.
+/// Mirrors the document-open / sidecar caps elsewhere in the workspace: it bounds a malformed or
+/// hostile bundle so an unbounded `.dict.dz` expansion (a "gzip bomb") cannot OOM the process.
+/// 512 MiB comfortably covers real StarDict corpora — the largest common dictionaries are
+/// ~100–200 MiB, and `.idx` offsets are 32-bit, so a larger block isn't even addressable.
+const MAX_DICT_BYTES: u64 = 512 * 1024 * 1024;
+
 /// The `.dict` data, decompressing `.dict.dz` (dictzip, gzip-compatible) when that's the only form.
+/// Both paths are size-bounded by [`MAX_DICT_BYTES`].
 fn read_dict(dir: &Path) -> DictResult<Vec<u8>> {
     if let Ok(plain) = find(dir, "dict") {
-        return read_bytes(&plain);
+        return read_capped(&plain, MAX_DICT_BYTES);
     }
     let dz = find(dir, "dict.dz")?;
     let raw = read_bytes(&dz)?;
+    decompress_capped(&raw, MAX_DICT_BYTES)
+        .map_err(|e| DictError::Backend(format!("{}: {e}", dz.display())))
+}
+
+/// `fs::read` with a stat-before-read size guard, mirroring the document-open boundary: refuse a
+/// `.dict` larger than `max` rather than slurping it whole.
+fn read_capped(path: &Path, max: u64) -> DictResult<Vec<u8>> {
+    let len = fs::metadata(path).map_err(be(path))?.len();
+    if len > max {
+        return Err(DictError::Backend(format!(
+            "{}: dictionary exceeds {max}-byte cap ({len} bytes)",
+            path.display()
+        )));
+    }
+    fs::read(path).map_err(be(path))
+}
+
+/// Gunzip `raw`, refusing to expand past `max` bytes. Reads at most `max + 1` decompressed bytes
+/// (so an over-cap stream is detected, not silently truncated) and errors if the cap is exceeded —
+/// the defence against a `.dict.dz` "gzip bomb" that would otherwise inflate into an unbounded `Vec`.
+fn decompress_capped(raw: &[u8], max: u64) -> Result<Vec<u8>, String> {
     let mut out = Vec::new();
-    GzDecoder::new(raw.as_slice())
+    GzDecoder::new(raw)
+        .take(max + 1)
         .read_to_end(&mut out)
-        .map_err(|e| DictError::Backend(format!("decompress {}: {e}", dz.display())))?;
+        .map_err(|e| format!("decompress: {e}"))?;
+    if out.len() as u64 > max {
+        return Err(format!("decompressed dictionary exceeds {max}-byte cap"));
+    }
     Ok(out)
 }
 
@@ -227,6 +260,30 @@ mod tests {
             Err(DictError::Backend(_))
         ));
         assert!(!is_stardict_dir(&dir));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn decompress_capped_rejects_a_gzip_bomb() {
+        // 64 KiB of zeros gzips to a few hundred bytes — a tiny stand-in for a real bomb.
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(&vec![0u8; 64 * 1024]).unwrap();
+        let gz = enc.finish().unwrap();
+        // Under a 1 KiB cap the 64 KiB expansion is refused, not slurped.
+        let err = decompress_capped(&gz, 1024).unwrap_err();
+        assert!(err.contains("cap"), "cap error surfaced: {err}");
+        // The same stream under an ample cap decompresses to its full size.
+        let ok = decompress_capped(&gz, 1024 * 1024).unwrap();
+        assert_eq!(ok.len(), 64 * 1024);
+    }
+
+    #[test]
+    fn read_capped_rejects_an_oversize_dict_file() {
+        let dir = scratch("oversize");
+        let path = dir.join("big.dict");
+        fs::write(&path, vec![b'x'; 4096]).unwrap();
+        assert!(read_capped(&path, 1024).is_err(), "4 KiB > 1 KiB cap");
+        assert_eq!(read_capped(&path, 1024 * 1024).unwrap().len(), 4096);
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -798,6 +798,25 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkAddPoint
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeInkAddPoints(handle, float[] xy) — batched form of nativeInkAddPoint: `xy` is packed
+// [x0,y0,x1,y1,…] (pressure 1.0, no tilt/timestamp). One JNI crossing per stroke instead of per
+// point, cutting boundary overhead on the annotation hot path.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkAddPoints<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    xy: JFloatArray<'local>,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let pts = read_f32_array(env, &xy)?;
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session.ink_add_points(&pts).map_err(|e| throw(env, &e))?;
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkEndStroke<'local>(
     mut env: EnvUnowned<'local>,
@@ -807,6 +826,28 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkEndStrok
     env.with_env(|env| -> jni::errors::Result<()> {
         let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
         session.ink_end_stroke().map_err(|e| throw(env, &e))?;
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// nativeInkSetDeferredAutosave(handle, deferred) — opt into deferred-autosave mode (the shell's
+// per-stroke-fsync power knob). When on, edits mark the page dirty and the shell flushes on a
+// trailing-edge debounce via nativeInkSave; off (default) keeps save-on-stroke-end durability.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkSetDeferredAutosave<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    deferred: jboolean,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session
+            .set_autosave_deferred(deferred)
+            .map_err(|e| throw(env, &e))?;
         Ok(())
     })
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -99,6 +99,17 @@ pub struct ReaderSession {
     /// Whether the in-progress eraser gesture has removed anything yet — gates the autosave so a
     /// no-op erase doesn't rewrite an unchanged page (needless e-ink flash / IO).
     erase_changed: bool,
+    /// When true, edits don't fsync the sidecar on every stroke-end; they mark the page dirty and
+    /// the shell flushes on a trailing-edge debounce (and on pause/page-change/close). A
+    /// power/flash-wear knob (the review's per-stroke-fsync finding) — **off by default** so the
+    /// RR7-FR6/RR20-FR2 save-on-stroke-end durability contract holds unless the shell opts in.
+    autosave_deferred: bool,
+    /// In deferred mode, whether the current page has unsaved edits awaiting [`Self::flush_ink`].
+    ink_dirty: bool,
+    /// The page index the in-memory [`Self::layer`] belongs to. Saves target this, not `page` — so a
+    /// deferred flush triggered *after* `page` has advanced (a page turn) still writes the outgoing
+    /// page. Equals `page` during normal editing; updated whenever the layer is (re)loaded.
+    layer_page: usize,
     /// The lasso clipboard (ADR-INKREAD-0010): strokes copied/cut from any page, held on the
     /// session so a paste can land on a **different** page (NeoReader's cross-page clipboard).
     clipboard: Vec<Stroke>,
@@ -214,6 +225,9 @@ impl ReaderSession {
             active_tool: Tool::Pen,
             active_width: 0.0,
             erase_changed: false,
+            autosave_deferred: false,
+            ink_dirty: false,
+            layer_page: 0,
             clipboard: Vec::new(),
             identity,
             contrast: 0,
@@ -796,6 +810,7 @@ impl ReaderSession {
         self.ink = Some(store);
         self.verify_or_stamp_identity();
         self.layer = self.load_layer_for_page(self.page);
+        self.layer_page = self.page;
         Ok(())
     }
 
@@ -898,6 +913,19 @@ impl ReaderSession {
         Ok(())
     }
 
+    /// Add a whole run of samples to the in-progress stroke (or erase along them) in one call — the
+    /// batched form of [`Self::ink_add_point`]. `xy` is packed `[x0, y0, x1, y1, …]`; pressure
+    /// defaults to 1.0 with no tilt/timestamp (the shell's stylus-capture path supplies none). This
+    /// lets the shell hand a 200-point stroke across JNI once instead of paying 200 round-trips on
+    /// the RK3566 annotation hot path (the review's per-point-JNI finding). A trailing odd float is
+    /// ignored; an invalid sample aborts the batch with the same error the per-point call raises.
+    pub fn ink_add_points(&mut self, xy: &[f32]) -> CoreResult<()> {
+        for pt in xy.chunks_exact(2) {
+            self.ink_add_point(pt[0], pt[1], 1.0, None, None, 0)?;
+        }
+        Ok(())
+    }
+
     /// Finish the in-progress stroke and autosave the page **only if it changed** (RR7-FR6 /
     /// RR20-FR2): an ink stroke that committed at least one point, or an eraser gesture that
     /// removed something. A no-op stroke/erase does not rewrite the page (saves e-ink flash + IO).
@@ -908,7 +936,7 @@ impl ReaderSession {
             self.erase_changed
         };
         if changed {
-            self.autosave_ink()?;
+            self.persist_after_edit()?;
         }
         Ok(())
     }
@@ -917,7 +945,7 @@ impl ReaderSession {
     pub fn ink_undo(&mut self) -> CoreResult<bool> {
         let changed = self.layer.undo();
         if changed {
-            self.autosave_ink()?;
+            self.persist_after_edit()?;
         }
         Ok(changed)
     }
@@ -926,21 +954,53 @@ impl ReaderSession {
     pub fn ink_redo(&mut self) -> CoreResult<bool> {
         let changed = self.layer.redo();
         if changed {
-            self.autosave_ink()?;
+            self.persist_after_edit()?;
         }
         Ok(changed)
     }
 
-    /// Flush the current page's ink to the store (RR20-FR2) — an explicit save for pause/close,
-    /// complementing the automatic autosave on stroke-end/undo/redo.
-    pub fn save_ink(&self) -> CoreResult<()> {
-        self.autosave_ink()
+    /// Enable/disable **deferred autosave** (the shell's per-stroke-fsync power knob). When enabled,
+    /// edits mark the page dirty instead of writing on each stroke-end; the shell is then responsible
+    /// for flushing on a trailing-edge debounce (and the session itself flushes on page-change /
+    /// export / explicit [`Self::save_ink`]). Switching back to immediate mode flushes any pending
+    /// edit so nothing is left unsaved.
+    pub fn set_autosave_deferred(&mut self, deferred: bool) -> CoreResult<()> {
+        if !deferred && self.ink_dirty {
+            self.flush_ink()?;
+        }
+        self.autosave_deferred = deferred;
+        Ok(())
+    }
+
+    /// Persist after an edit: write now (immediate mode), or just mark the page dirty (deferred
+    /// mode) so the shell's debounced [`Self::save_ink`] coalesces the fsync.
+    fn persist_after_edit(&mut self) -> CoreResult<()> {
+        if self.autosave_deferred {
+            self.ink_dirty = true;
+            Ok(())
+        } else {
+            self.autosave_ink()
+        }
+    }
+
+    /// Flush the current page's ink to the store (RR20-FR2) — an explicit save for pause/close and
+    /// the trailing-edge flush in deferred mode, complementing the per-edit autosave.
+    pub fn save_ink(&mut self) -> CoreResult<()> {
+        self.flush_ink()
+    }
+
+    /// Write the current page if it has pending edits (always writes in immediate mode, where
+    /// `ink_dirty` is never set), clearing the dirty flag. No-op without a store.
+    fn flush_ink(&mut self) -> CoreResult<()> {
+        self.autosave_ink()?;
+        self.ink_dirty = false;
+        Ok(())
     }
 
     /// Persist the current page's layer to the store (RR20-FR2). No-op without a store.
     fn autosave_ink(&self) -> CoreResult<()> {
         if let Some(store) = &self.ink {
-            store.save_page(self.page, &self.layer)?;
+            store.save_page(self.layer_page, &self.layer)?;
         }
         Ok(())
     }
@@ -1038,7 +1098,8 @@ impl ReaderSession {
     /// written. Colours are preserved (true RGBA). Gathers all pages from the sidecar after first
     /// flushing the current page, so unsaved edits are included.
     pub fn export_pdf(&mut self, out_path: &str, flatten: bool) -> CoreResult<()> {
-        self.autosave_ink()?; // flush the current page's edits to the sidecar first
+        validate_export_path(out_path)?; // contain the write target before touching the filesystem
+        self.flush_ink()?; // flush the current page's edits to the sidecar first
         let mode = if flatten {
             ExportMode::Flatten
         } else {
@@ -1075,8 +1136,15 @@ impl ReaderSession {
     /// Swap the in-memory layer to the current page's stored ink on a page change. Any pending
     /// stroke is dropped; the load degrades safely (see [`Self::load_layer_for_page`]).
     fn load_ink_for_current_page(&mut self) {
+        // In deferred mode the outgoing page may hold unsaved edits — flush before the layer is
+        // swapped out, or they'd be lost on the page turn. Best-effort, matching this module's
+        // degrade-safely stance: a transient write error must not block navigation.
+        if self.ink_dirty {
+            let _ = self.flush_ink(); // saves under `layer_page` (the outgoing page), not the new one
+        }
         self.layer.cancel_stroke();
         self.layer = self.load_layer_for_page(self.page);
+        self.layer_page = self.page;
         // A page turn resets the view to fit (RR5-FR3): the old pan/zoom is meaningless on a new page.
         self.zoom = 1.0;
         self.pan_x = 0.0;
@@ -1098,6 +1166,36 @@ impl ReaderSession {
             }
             Err(_) => InkLayer::new(),
         }
+    }
+}
+
+/// Contain the PDF-export write target before it reaches pdfium's `save_to_file` (IR security, the
+/// review's "export path lacks native containment"). The shell chooses the path with all-files
+/// access, so the core can't know Android's storage roots — but it *can* reject the shapes a buggy
+/// or compromised shell should never produce: a relative path, a `..` traversal component, or a
+/// parent directory that doesn't already exist (export creates a file, never a directory tree).
+/// This bounds "write anywhere the UID can reach via traversal" without second-guessing legitimate
+/// user-chosen destinations.
+fn validate_export_path(out_path: &str) -> CoreResult<()> {
+    use std::path::{Component, Path};
+    let bad = |why: &str| {
+        Err(CoreError::InvalidArgument(format!(
+            "export path {why}: {out_path}"
+        )))
+    };
+    if out_path.is_empty() {
+        return bad("is empty");
+    }
+    let path = Path::new(out_path);
+    if !path.is_absolute() {
+        return bad("must be absolute");
+    }
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return bad("must not contain `..`");
+    }
+    match path.parent() {
+        Some(dir) if dir.is_dir() => Ok(()),
+        _ => bad("parent directory does not exist"),
     }
 }
 

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -548,6 +548,91 @@ fn eraser_removes_strokes_and_autosaves() {
 }
 
 #[test]
+fn deferred_autosave_holds_writes_until_an_explicit_flush() {
+    // The power knob: in deferred mode a stroke is held in memory and not fsynced on stroke-end;
+    // the shell's debounced save_ink flushes it. (Default immediate mode is covered above.)
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    s.set_autosave_deferred(true).unwrap();
+
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    assert_eq!(s.ink_strokes().len(), 1, "stroke is live in the layer");
+    assert!(
+        store.pages_with_ink().unwrap().is_empty(),
+        "deferred: nothing persisted on stroke-end"
+    );
+
+    s.save_ink().unwrap();
+    assert_eq!(
+        store.pages_with_ink().unwrap(),
+        vec![0],
+        "explicit flush persists the page"
+    );
+}
+
+#[test]
+fn deferred_autosave_flushes_before_a_page_turn() {
+    // A page turn must flush the outgoing page's pending edits, or deferred ink would be lost when
+    // the layer is swapped for the new page.
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    s.set_autosave_deferred(true).unwrap();
+
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]); // page 0, not yet flushed
+    assert!(store.pages_with_ink().unwrap().is_empty());
+
+    s.on_gesture(Gesture::NextPage); // flushes page 0 before loading page 1
+    assert_eq!(
+        store.pages_with_ink().unwrap(),
+        vec![0],
+        "page 0 flushed on the turn"
+    );
+    assert_eq!(s.ink_strokes().len(), 0, "page 1 starts empty");
+}
+
+#[test]
+fn disabling_deferred_autosave_flushes_pending_edits() {
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    s.set_autosave_deferred(true).unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    assert!(store.pages_with_ink().unwrap().is_empty());
+
+    s.set_autosave_deferred(false).unwrap(); // turning the knob off must not strand the edit
+    assert_eq!(store.pages_with_ink().unwrap(), vec![0]);
+}
+
+#[test]
+fn ink_add_points_batches_a_whole_stroke() {
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    s.ink_begin_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0)
+        .unwrap();
+    // Packed [x0,y0,x1,y1,x2,y2]; the trailing odd float is ignored.
+    s.ink_add_points(&[0.1, 0.1, 0.2, 0.2, 0.3, 0.3, 0.9])
+        .unwrap();
+    s.ink_end_stroke().unwrap();
+    let strokes = s.ink_strokes();
+    assert_eq!(strokes.len(), 1);
+    assert_eq!(strokes[0].points.len(), 3, "three (x,y) pairs landed");
+}
+
+#[test]
+fn validate_export_path_contains_the_write_target() {
+    let dir = std::env::temp_dir();
+    let ok = dir.join("inkread-export.pdf");
+    assert!(validate_export_path(ok.to_str().unwrap()).is_ok());
+
+    // Relative, traversal, and non-existent-parent paths are all refused.
+    assert!(validate_export_path("export.pdf").is_err());
+    assert!(validate_export_path(dir.join("../export.pdf").to_str().unwrap()).is_err());
+    assert!(validate_export_path("/no/such/dir/export.pdf").is_err());
+    assert!(validate_export_path("").is_err());
+}
+
+#[test]
 fn ink_works_in_memory_without_a_store() {
     // A store-less session still captures and edits ink (just no persistence) — no panic.
     let mut s = session(1, DeviceCapabilities::supernote_full());


### PR DESCRIPTION
Addresses the actionable findings from the latest re-review of `feat/mvp`, fixed in the layer each belongs to. The Rust core stays host-testable; **+9 unit tests**.

## Power / efficiency
- **Deferred ink autosave (opt-in).** Edits mark the page dirty; the shell flushes on a 1.5 s trailing debounce (and on pause/close/page-turn) instead of fsyncing the sidecar on every stroke-end. Default stays **immediate**, so the RR7-FR6/RR20-FR2 save-on-stroke-end contract and all existing tests are unchanged. A new `layer_page` ensures a post-turn flush writes the *outgoing* page, not the new one.
- **Batched ink JNI** — `nativeInkAddPoints(float[])`: one JNI crossing per stroke instead of one per sample on the annotation hot path.
- **HomeActivity** skips the full view rebuild on resume when the shelf (recents order + per-book progress) is unchanged.

## Security
- **StarDict import bounded** — `MAX_DICT_BYTES` (512 MiB) with a capped gzip decode (gzip-bomb defence) + stat-before-read for plain `.dict`.
- **Export path containment** — `validate_export_path` rejects relative paths, `..` traversal, and non-existent parent dirs before pdfium writes.
- **SAF import capped** — `copyCapped` aborts + deletes a partial copy once it exceeds the 2 GiB native open limit, rather than writing the whole file first.
- **Online dictionary opt-in** — Wiktionary fallback defaults off, exposed in Settings (offline-first).

## UX / power
- **Cancelable full-document search** — a "Searching…" dialog flips a volatile flag the engine-thread scan polls each page, aborting a long scan instead of pinning the SoC to the last page.

## Review findings status
Implemented: per-stroke fsync, per-point JNI, online-dict default, StarDict gzip cap, export path validation, SAF import cap, search cancel, HomeActivity resume.

Deferred (with reasons):
- **#3 repaintPanel render/flash split (P0)** — biggest power lever, but a wrong per-site call yields a stale panel / missing ink and can't be verified host-side (`adb screencap` is black on this EPD). Best done device-in-hand.
- **#4 open-path fingerprint (P1)** — achievable slice is a modest one-pass win with wide ripple; the real win (mmap/streaming) is a larger refactor.
- **#5 dual book-id (P1)** — needs a data migration for existing sideloads.

## Validation
- `cargo fmt` / `cargo clippy --workspace --features reader-core/jni-bridge --all-targets` (warnings = errors) clean.
- `cargo test --workspace` green, incl. new tests for deferred autosave, export-path validation, batched points, and the StarDict gzip-bomb cap.
- Kotlin **not** compile-checked in this environment (JDK 26 vs the project's bundled Kotlin compiler fails at configuration); changes use the files' existing dialog/stream/JNI patterns. Recommend a device build + on-device smoke of ink-save-on-pause, search cancel, and import of an oversized file.