### PR TITLE
Dialog polish: Inkwell editorial design system + page-flip latency trims

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ColorPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ColorPalette.kt
@@ -32,17 +32,10 @@ class ColorPalette(
         dismiss()
         val col = LinearLayout(activity).apply {
             orientation = LinearLayout.VERTICAL
-            background = GradientDrawable().apply {
-                setColor(Color.WHITE); setStroke(maxOf(2, dp(1)), Color.BLACK); cornerRadius = dp(12).toFloat()
-            }
-            setPadding(dp(16), dp(12), dp(16), dp(12))
+            background = Ink.cardBg()
+            setPadding(Ink.dp(20), Ink.dp(16), Ink.dp(20), Ink.dp(16))
         }
-        col.addView(TextView(activity).apply {
-            text = title
-            textSize = 15f
-            setTextColor(Color.BLACK)
-            setPadding(0, 0, 0, dp(8))
-        })
+        col.addView(Ink.eyebrow(activity, title).apply { setPadding(0, 0, 0, Ink.dp(12)) })
         val row = LinearLayout(activity).apply { orientation = LinearLayout.HORIZONTAL }
         val win = android.widget.PopupWindow(col, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
             isOutsideTouchable = true; isFocusable = true
@@ -78,15 +71,17 @@ class ColorPalette(
                 shape = GradientDrawable.OVAL
                 setColor(opaque)
                 // Selected = thick black ring; others = thin grey ring so light swatches still read.
-                setStroke(if (selected) dp(4) else dp(1), if (selected) Color.BLACK else Color.parseColor("#9E9E9E"))
+                setStroke(if (selected) dp(4) else Ink.hair(), if (selected) Ink.ink else Ink.ringSoft)
             }
         })
         cell.addView(TextView(activity).apply {
             text = name
-            textSize = 12f
+            textSize = 11f
+            typeface = Ink.mono
+            letterSpacing = 0.04f
             gravity = Gravity.CENTER
-            setTextColor(Color.BLACK)
-            setPadding(0, dp(4), 0, 0)
+            setTextColor(if (selected) Ink.ink else Ink.muted)
+            setPadding(0, dp(6), 0, 0)
         })
         return cell
     }

--- a/app/src/main/java/dev/jraghavan/inkread/DictController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DictController.kt
@@ -212,10 +212,10 @@ class DictController(private val host: Host) {
     private fun showDictPopup(word: String, def: WordDefinition) {
         val d = activity.resources.displayMetrics.density
         fun dp(v: Int) = (v * d).toInt()
-        val grey = Color.parseColor("#6B6B6B")
-        val faint = Color.parseColor("#9E9E9E")
-        val serif = Typeface.create("serif", Typeface.NORMAL)
-        val serifBold = Typeface.create("serif", Typeface.BOLD)
+        val grey = Ink.muted
+        val faint = Ink.ringSoft
+        val serif = Ink.serif
+        val serifBold = Ink.serifBold
 
         val parsed = WordNet.parse(def.senses)
         val headword = def.headword.ifEmpty { word }
@@ -228,15 +228,16 @@ class DictController(private val host: Host) {
         val root = LinearLayout(activity).apply {
             orientation = LinearLayout.VERTICAL
             background = GradientDrawable().apply {
-                setColor(Color.WHITE)
-                cornerRadii = floatArrayOf(dp(18).toFloat(), dp(18).toFloat(), dp(18).toFloat(), dp(18).toFloat(), 0f, 0f, 0f, 0f)
+                setColor(Ink.paper)
+                val r = Ink.dpf(Ink.RADIUS)
+                cornerRadii = floatArrayOf(r, r, r, r, 0f, 0f, 0f, 0f)
             }
             setPadding(dp(24), dp(12), dp(24), dp(20))
         }
 
         // ── grab handle (calm sheet affordance) ──────────────────────────────────
         root.addView(View(activity).apply {
-            background = GradientDrawable().apply { setColor(Color.parseColor("#D8D8D8")); cornerRadius = dp(2).toFloat() }
+            background = GradientDrawable().apply { setColor(Ink.ringSoft); cornerRadius = dp(2).toFloat() }
             layoutParams = LinearLayout.LayoutParams(dp(36), dp(4)).apply {
                 gravity = Gravity.CENTER_HORIZONTAL; bottomMargin = dp(12)
             }
@@ -245,7 +246,8 @@ class DictController(private val host: Host) {
         // ── header: headword + looked-up chip · WordNet source ───────────────────
         val header = LinearLayout(activity).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL }
         header.addView(TextView(activity).apply {
-            text = headword; setTextColor(Color.BLACK); textSize = 27f; typeface = serifBold
+            text = headword; setTextColor(Ink.ink); textSize = 27f; typeface = serifBold
+            includeFontPadding = false
         })
         if (!word.equals(headword, ignoreCase = true) && word.isNotEmpty()) {
             header.addView(TextView(activity).apply {
@@ -255,8 +257,8 @@ class DictController(private val host: Host) {
         }
         header.addView(View(activity), LinearLayout.LayoutParams(0, 0, 1f)) // spacer
         header.addView(TextView(activity).apply {
-            text = if (def.lang.isNotEmpty() && def.lang != "en") "WordNet · ${def.lang}" else "WordNet"
-            setTextColor(faint); textSize = 11f; letterSpacing = 0.06f
+            text = if (def.lang.isNotEmpty() && def.lang != "en") "WORDNET · ${def.lang.uppercase()}" else "WORDNET"
+            setTextColor(faint); textSize = 11f; letterSpacing = 0.12f; typeface = Ink.mono
         })
         root.addView(header)
 
@@ -265,8 +267,8 @@ class DictController(private val host: Host) {
         lateinit var tabDef: TextView
         lateinit var tabThe: TextView
         fun styleTab(tab: TextView, active: Boolean) {
-            tab.setTextColor(if (active) Color.BLACK else faint)
-            tab.typeface = if (active) Typeface.DEFAULT_BOLD else Typeface.DEFAULT
+            tab.setTextColor(if (active) Ink.ink else faint)
+            tab.setTypeface(Ink.mono, if (active) Typeface.BOLD else Typeface.NORMAL)
             tab.paintFlags = if (active) tab.paintFlags or android.graphics.Paint.UNDERLINE_TEXT_FLAG
             else tab.paintFlags and android.graphics.Paint.UNDERLINE_TEXT_FLAG.inv()
         }
@@ -287,9 +289,9 @@ class DictController(private val host: Host) {
                 body.addView(senseRow(sense.index, sense.definition, dp(2)))
                 for (ex in sense.examples) {
                     body.addView(TextView(activity).apply {
-                        text = "“$ex”"; setTextColor(grey); textSize = 14f
-                        typeface = Typeface.create(Typeface.DEFAULT, Typeface.ITALIC)
-                        setPadding(dp(22), dp(3), 0, 0)
+                        text = "“$ex”"; setTextColor(grey); textSize = 15f
+                        typeface = Ink.serifItalic
+                        setPadding(dp(22), dp(4), 0, 0)
                     })
                 }
                 if (sense.synonyms.isNotEmpty()) {
@@ -312,24 +314,26 @@ class DictController(private val host: Host) {
             body.addView(posBadge("synonyms"))
             body.addView(TextView(activity).apply {
                 text = thesaurus.joinToString(" · ")
-                setTextColor(Color.BLACK); textSize = 16f; setLineSpacing(dp(4).toFloat(), 1f)
-                setPadding(0, dp(4), 0, 0)
+                setTextColor(Ink.ink); textSize = 16f; typeface = Ink.serif; setLineSpacing(dp(4).toFloat(), 1f)
+                setPadding(0, dp(6), 0, 0)
             })
         }
         val tabs = LinearLayout(activity).apply { orientation = LinearLayout.HORIZONTAL; setPadding(0, dp(10), 0, 0) }
         tabDef = TextView(activity).apply {
-            text = "Definition"; textSize = 14f; setPadding(0, dp(4), dp(22), dp(4)); isClickable = true
+            text = "DEFINITION"; textSize = 12f; letterSpacing = 0.1f
+            setPadding(0, dp(4), dp(24), dp(4)); isClickable = true
             setOnClickListener { styleTab(tabDef, true); styleTab(tabThe, false); renderDefinition() }
         }
         tabThe = TextView(activity).apply {
-            text = "Thesaurus"; textSize = 14f; setPadding(0, dp(4), 0, dp(4)); isClickable = true
+            text = "THESAURUS"; textSize = 12f; letterSpacing = 0.1f
+            setPadding(0, dp(4), 0, dp(4)); isClickable = true
             setOnClickListener { styleTab(tabThe, true); styleTab(tabDef, false); renderThesaurus() }
         }
         tabs.addView(tabDef); tabs.addView(tabThe)
         root.addView(tabs)
         root.addView(View(activity).apply {
-            setBackgroundColor(Color.parseColor("#ECECEC"))
-            layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, maxOf(1, dp(1))).apply {
+            setBackgroundColor(Ink.hairline)
+            layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()).apply {
                 topMargin = dp(8)
             }
         })
@@ -357,13 +361,13 @@ class DictController(private val host: Host) {
         val d = activity.resources.displayMetrics.density
         fun dp(v: Int) = (v * d).toInt()
         return TextView(activity).apply {
-            text = label; setTextColor(Color.BLACK); textSize = 12f; typeface = Typeface.DEFAULT_BOLD
-            letterSpacing = 0.04f
-            setPadding(dp(10), dp(3), dp(10), dp(4))
+            text = label.uppercase(); setTextColor(Ink.inkSoft); textSize = 10f; typeface = Ink.mono
+            letterSpacing = 0.12f
+            setPadding(dp(10), dp(4), dp(10), dp(5))
             background = GradientDrawable().apply {
-                setColor(Color.parseColor("#F0F0F0"))
-                setStroke(maxOf(1, dp(1)), Color.parseColor("#C9C9C9"))
-                cornerRadius = dp(10).toFloat()
+                setColor(Ink.fill)
+                setStroke(Ink.hair(), Ink.hairline)
+                cornerRadius = Ink.dpf(Ink.RADIUS_CHIP)
             }
             layoutParams = LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
@@ -379,12 +383,12 @@ class DictController(private val host: Host) {
             orientation = LinearLayout.HORIZONTAL
             setPadding(0, maxOf(topPad, dp(7)), 0, 0)
             addView(TextView(activity).apply {
-                this.text = "$index."; setTextColor(Color.parseColor("#6B6B6B")); textSize = 15f
-                typeface = Typeface.DEFAULT_BOLD
+                this.text = "$index"; setTextColor(Ink.muted); textSize = 13f
+                typeface = Ink.mono
                 layoutParams = LinearLayout.LayoutParams(dp(22), ViewGroup.LayoutParams.WRAP_CONTENT)
             })
             addView(TextView(activity).apply {
-                this.text = text; setTextColor(Color.BLACK); textSize = 15f
+                this.text = text; setTextColor(Ink.ink); textSize = 16f; typeface = Ink.serif
                 setLineSpacing(dp(3).toFloat(), 1f)
                 layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
             })

--- a/app/src/main/java/dev/jraghavan/inkread/Ink.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Ink.kt
@@ -1,0 +1,120 @@
+package dev.jraghavan.inkread
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+
+/**
+ * The shared **Inkwell editorial** visual language for inkread's popups, dialogs, and overlays
+ * (ADR-INKREAD-0008) — the home screen's voice, centralized so every surface reads as one product
+ * instead of drifting per file (each used to hardcode its own greys, radii, and strokes).
+ *
+ * Monochrome by necessity: nothing here leans on colour, only on **contrast, weight, and
+ * whitespace** — the levers that actually read on a flashing e-ink panel. Pure, stateless tokens
+ * plus tiny view builders. Density comes from the system metrics, so [dp] needs no `Context`; only
+ * the builders that create views do.
+ */
+object Ink {
+    // ── Palette — the single source of truth for greys (was scattered hex across files) ──
+    val ink = Color.BLACK // primary text / keyline
+    val inkSoft = Color.parseColor("#3A3A3A") // secondary text
+    val muted = Color.parseColor("#757575") // captions / eyebrow labels
+    val hairline = Color.parseColor("#E0E0E0") // rules & dividers
+    val ringSoft = Color.parseColor("#9E9E9E") // soft ring around light swatches
+    val disabled = Color.parseColor("#BDBDBD") // disabled icon tint
+    val fill = Color.parseColor("#EFEFEF") // subtle filled-chip background
+    val paper = Color.WHITE
+
+    // ── Type — the Inkwell voice (serif display, mono labels) ──
+    val serif: Typeface = Typeface.SERIF
+    val serifItalic: Typeface = Typeface.create(Typeface.SERIF, Typeface.ITALIC)
+    val serifBold: Typeface = Typeface.create(Typeface.SERIF, Typeface.BOLD)
+    val mono: Typeface = Typeface.MONOSPACE
+
+    // ── Metrics (system density → no Context needed) ──
+    private val density = android.content.res.Resources.getSystem().displayMetrics.density
+
+    fun dp(v: Int): Int = (v * density).toInt()
+
+    fun dpf(v: Int): Float = v * density
+
+    /** A hairline that never collapses to 0 px. */
+    fun hair(): Int = maxOf(1, dp(1))
+
+    /** A card keyline — a touch heavier so the edge survives a GC16 full-flash. */
+    fun keyline(): Int = maxOf(2, dp(1))
+
+    // ── Shape tokens (one rhythm instead of 10/12/16/22 ad hoc) ──
+    const val RADIUS = 16 // card corner
+    const val RADIUS_CHIP = 10 // pill / chip corner
+    const val PAD = 22 // card inner padding
+
+    // ── Builders ──
+
+    /** A white rounded card with a single black keyline — the base of every editorial surface. */
+    fun cardBg(radiusDp: Int = RADIUS): GradientDrawable =
+        GradientDrawable().apply {
+            setColor(paper)
+            cornerRadius = dpf(radiusDp)
+            setStroke(keyline(), ink)
+        }
+
+    /** A mono, uppercase, letter-spaced **eyebrow** — the small-caps kicker above a title. */
+    fun eyebrow(ctx: Context, text: String): TextView =
+        TextView(ctx).apply {
+            this.text = text.uppercase()
+            setTextColor(muted)
+            textSize = 11f
+            typeface = mono
+            letterSpacing = 0.14f
+        }
+
+    /** A serif display title. */
+    fun title(ctx: Context, text: String, size: Float = 22f): TextView =
+        TextView(ctx).apply {
+            this.text = text
+            setTextColor(ink)
+            textSize = size
+            typeface = serif
+            includeFontPadding = false
+        }
+
+    /** A full-width hairline rule. */
+    fun rule(ctx: Context): View =
+        View(ctx).apply {
+            setBackgroundColor(hairline)
+            layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, hair())
+        }
+
+    /** A fixed vertical spacer of [h] dp. */
+    fun gap(ctx: Context, h: Int): View =
+        View(ctx).apply {
+            layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(h))
+        }
+
+    /** A pill button — filled (black) for the primary action, outlined for secondary. */
+    fun pillButton(ctx: Context, label: String, primary: Boolean, onTap: () -> Unit): TextView =
+        TextView(ctx).apply {
+            text = label
+            textSize = 13f
+            typeface = mono
+            letterSpacing = 0.08f
+            gravity = Gravity.CENTER
+            setPadding(dp(20), dp(9), dp(20), dp(9))
+            setTextColor(if (primary) paper else ink)
+            background =
+                GradientDrawable().apply {
+                    setColor(if (primary) ink else paper)
+                    setStroke(keyline(), ink)
+                    cornerRadius = dpf(40)
+                }
+            isClickable = true
+            setOnClickListener { onTap() }
+        }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -1305,24 +1305,26 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
         val container = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Color.WHITE)
+            setBackgroundColor(Ink.paper)
         }
-        // Hairline top divider so the bar reads as a surface, not a floating box.
+        // A crisp black keyline up top so the bar reads as a docked surface, not a floating box.
         container.addView(
-            View(this).apply { setBackgroundColor(Color.parseColor("#33000000")) },
-            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(1).coerceAtLeast(1)),
+            View(this).apply { setBackgroundColor(Ink.ink) },
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
         )
 
         // Page-slider row:  [N / Total]  ────────●────────  (grayscale, tap the chip to type a page)
         val pageLabel = TextView(this).apply {
             text = "${cur + 1} / $total"
-            setTextColor(Color.BLACK)
-            textSize = 13f
+            setTextColor(Ink.ink)
+            textSize = 12f
+            typeface = Ink.mono
+            letterSpacing = 0.04f
             gravity = Gravity.CENTER
-            setPadding(dp(12), dp(5), dp(12), dp(5))
+            setPadding(dp(12), dp(6), dp(12), dp(6))
             background = GradientDrawable().apply {
-                setColor(Color.parseColor("#F2F2F2"))
-                cornerRadius = dp(14).toFloat()
+                setColor(Ink.fill)
+                cornerRadius = Ink.dpf(40)
             }
             setOnClickListener { dialog.dismiss(); showPageEntry(total) }
         }
@@ -1331,11 +1333,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         fun bar(c: Int) = GradientDrawable().apply { setColor(c); cornerRadius = trackH.toFloat(); setSize(0, trackH) }
         val track = android.graphics.drawable.LayerDrawable(
             arrayOf(
-                bar(Color.parseColor("#D8D8D8")),
-                android.graphics.drawable.ClipDrawable(bar(Color.BLACK), Gravity.START, android.graphics.drawable.ClipDrawable.HORIZONTAL),
+                bar(Ink.hairline),
+                android.graphics.drawable.ClipDrawable(bar(Ink.ink), Gravity.START, android.graphics.drawable.ClipDrawable.HORIZONTAL),
             ),
         ).apply { setId(0, android.R.id.background); setId(1, android.R.id.progress) }
-        val knob = GradientDrawable().apply { shape = GradientDrawable.OVAL; setColor(Color.BLACK); setSize(dp(16), dp(16)) }
+        val knob = GradientDrawable().apply { shape = GradientDrawable.OVAL; setColor(Ink.ink); setSize(dp(16), dp(16)) }
         val seek = SeekBar(this).apply {
             max = total - 1
             progress = cur
@@ -1377,13 +1379,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             }
             cell.addView(
                 ImageView(this).apply {
-                    setImageResource(iconRes); setColorFilter(Color.BLACK)
+                    setImageResource(iconRes); setColorFilter(Ink.ink)
                 },
                 LinearLayout.LayoutParams(dp(39), dp(39)),
             )
             cell.addView(TextView(this).apply {
-                text = label; setTextColor(Color.parseColor("#333333")); textSize = 13f
-                typeface = Typeface.DEFAULT_BOLD
+                text = label; setTextColor(Ink.inkSoft); textSize = 11f
+                typeface = Ink.mono; letterSpacing = 0.02f
                 gravity = Gravity.CENTER; setPadding(0, dp(5), 0, 0)
             })
             controls.addView(cell, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
@@ -1409,7 +1411,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         dialog.window?.apply {
             setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
             setGravity(Gravity.BOTTOM)
-            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.WHITE))
+            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Ink.paper))
         }
         dialog.show()
     }
@@ -1496,17 +1498,16 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
         val outer = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Color.WHITE)
-            setPadding(dp(24), dp(20), dp(24), dp(12))
+            setPadding(dp(24), dp(22), dp(24), dp(14))
         }
-        outer.addView(TextView(this).apply {
-            text = "Contents"; setTextColor(Color.BLACK); textSize = 20f
-            typeface = Typeface.DEFAULT_BOLD; setPadding(0, 0, 0, dp(12))
-        })
+        outer.addView(Ink.eyebrow(this, "Contents"))
+        outer.addView(Ink.gap(this, 10))
+        outer.addView(Ink.rule(this))
+        outer.addView(Ink.gap(this, 4))
         val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
         toc.forEachIndexed { i, item ->
-            if (i > 0) list.addView(View(this).apply { setBackgroundColor(Color.parseColor("#EEEEEE")) },
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, maxOf(1, dp(1))))
+            if (i > 0) list.addView(View(this).apply { setBackgroundColor(Ink.hairline) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()))
             list.addView(LinearLayout(this).apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
@@ -1515,14 +1516,14 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 setOnClickListener { dialog.dismiss(); item.targetPage?.let { postJump(it) } }
                 addView(TextView(this@ReaderActivity).apply {
                     text = item.title
-                    setTextColor(if (item.targetPage != null) Color.BLACK else Color.parseColor("#9E9E9E"))
-                    textSize = if (item.depth == 0) 16f else 15f
-                    if (item.depth == 0) typeface = Typeface.DEFAULT_BOLD
+                    setTextColor(if (item.targetPage != null) Ink.ink else Ink.muted)
+                    textSize = if (item.depth == 0) 17f else 15f
+                    typeface = if (item.depth == 0) Ink.serifBold else Ink.serif
                     maxLines = 2
                 }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
                 item.targetPage?.let { p ->
                     addView(TextView(this@ReaderActivity).apply {
-                        text = "${p + 1}"; setTextColor(Color.parseColor("#9E9E9E")); textSize = 13f
+                        text = "${p + 1}"; setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
                         setPadding(dp(12), 0, 0, 0)
                     })
                 }
@@ -1534,7 +1535,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         dialog.setContentView(outer)
         dialog.window?.apply {
             setLayout((resources.displayMetrics.widthPixels * 0.82f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
-            setBackgroundDrawable(GradientDrawable().apply { setColor(Color.WHITE); cornerRadius = dp(12).toFloat() })
+            setBackgroundDrawable(Ink.cardBg())
         }
         dialog.show()
     }
@@ -2270,20 +2271,20 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 // Active tab: white, boxed (connected to the panel) + bold label. Inactive: flat gray.
                 if (j == i) {
                     c.background = GradientDrawable().apply {
-                        setColor(Color.WHITE); setStroke(maxOf(1, dp(2)), Color.BLACK)
+                        setColor(Ink.paper); setStroke(Ink.keyline(), Ink.ink)
                     }
                 } else {
                     c.background = null
-                    c.setBackgroundColor(Color.parseColor("#F2F2F2"))
+                    c.setBackgroundColor(Ink.fill)
                 }
-                (c.getChildAt(1) as? TextView)?.setTypeface(
-                    null, if (j == i) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL,
-                )
+                val tab = c.getChildAt(1) as? TextView
+                tab?.setTypeface(Ink.mono, if (j == i) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
+                tab?.setTextColor(if (j == i) Ink.ink else Ink.inkSoft)
             }
         }
         val tabRow = LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL
-            setBackgroundColor(Color.parseColor("#F2F2F2"))
+            setBackgroundColor(Ink.fill)
         }
         panels.forEachIndexed { i, (label, icon, _) ->
             val cell = LinearLayout(this).apply {
@@ -2291,11 +2292,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 setPadding(dp(4), dp(10), dp(4), dp(10)); isClickable = true
                 setOnClickListener { select(i) }
                 addView(
-                    ImageView(this@ReaderActivity).apply { setImageResource(icon); setColorFilter(Color.BLACK) },
+                    ImageView(this@ReaderActivity).apply { setImageResource(icon); setColorFilter(Ink.ink) },
                     LinearLayout.LayoutParams(dp(24), dp(24)),
                 )
                 addView(TextView(this@ReaderActivity).apply {
-                    text = label; textSize = 10f; setTextColor(Color.parseColor("#444444"))
+                    text = label; textSize = 10f; setTextColor(Ink.inkSoft); typeface = Ink.mono
                     gravity = Gravity.CENTER; setPadding(0, dp(3), 0, 0)
                 })
             }
@@ -2304,11 +2305,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
         val container = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Color.WHITE)
-            // Hairline top divider so the sheet reads as a surface (established bottom-bar template).
+            setBackgroundColor(Ink.paper)
+            // Black keyline up top so the sheet reads as a docked surface (bottom-bar template).
             addView(
-                View(this@ReaderActivity).apply { setBackgroundColor(Color.parseColor("#33000000")) },
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(1).coerceAtLeast(1)),
+                View(this@ReaderActivity).apply { setBackgroundColor(Ink.ink) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
             )
             // Active tab's panel — WRAP_CONTENT so the sheet GROWS UP per tab (KOReader-style),
             // bottom-anchored, instead of a fixed box with dead space.
@@ -2317,8 +2318,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT),
             )
             addView(
-                View(this@ReaderActivity).apply { setBackgroundColor(Color.parseColor("#22000000")) },
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 1),
+                View(this@ReaderActivity).apply { setBackgroundColor(Ink.hairline) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
             )
             addView(tabRow)
         }
@@ -2327,7 +2328,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         dialog.window?.apply {
             setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
             setGravity(Gravity.BOTTOM)
-            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.WHITE))
+            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Ink.paper))
         }
         dialog.show()
     }
@@ -2342,11 +2343,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val segs = ArrayList<TextView>()
         fun style(tv: TextView, on: Boolean) {
             if (on) {
-                tv.setTextColor(Color.WHITE)
+                tv.setTextColor(Ink.paper)
                 tv.setTypeface(null, android.graphics.Typeface.BOLD)
-                tv.background = GradientDrawable().apply { setColor(Color.parseColor("#5A5A5A")); cornerRadius = radius }
+                tv.background = GradientDrawable().apply { setColor(Ink.ink); cornerRadius = radius }
             } else {
-                tv.setTextColor(Color.BLACK)
+                tv.setTextColor(Ink.ink)
                 tv.setTypeface(null, android.graphics.Typeface.NORMAL)
                 tv.background = null
             }
@@ -2354,8 +2355,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         return LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL
             background = GradientDrawable().apply {
-                setColor(Color.WHITE); cornerRadius = radius
-                setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
+                setColor(Ink.paper); cornerRadius = radius
+                setStroke(Ink.hair(), Ink.ringSoft)
             }
             val p = dp(3); setPadding(p, p, p, p)
             options.forEachIndexed { i, opt ->
@@ -2379,12 +2380,12 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         var filled = initial
         val draws = ArrayList<GradientDrawable>()
         fun repaint() = draws.forEachIndexed { i, g ->
-            g.setColor(if (i < filled) Color.parseColor("#5A5A5A") else Color.WHITE)
+            g.setColor(if (i < filled) Ink.ink else Ink.paper)
         }
         return LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
             for (i in 0 until count) {
-                val g = GradientDrawable().apply { setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E")) }
+                val g = GradientDrawable().apply { setStroke(Ink.hair(), Ink.ringSoft) }
                 draws.add(g)
                 addView(View(this@ReaderActivity).apply {
                     background = g; isClickable = true

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -724,7 +724,12 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         engine.execute { openSwap(file.absolutePath, file.name) }
     }
 
-    private fun renderAndBlit() {
+    /**
+     * Render the current page and blit it. [deferLinks] skips the per-page link fetch so the page-turn
+     * path (postJump) can flash the panel first and fetch links *after* — links are only needed for
+     * the next tap, not before the page is visible.
+     */
+    private fun renderAndBlit(deferLinks: Boolean = false) {
         val handle = docHandle
         val buf = renderBuffer ?: return
         val bmp = bitmap ?: return
@@ -754,9 +759,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // The active in-document search hit's highlight boxes (RR2), if it lives on this page.
         val searchHl = search.highlightForPage(currentPage)
         if (searchHl.isNotEmpty()) drawSearchHighlight(cv, searchHl)
-        // Keep a small full-page thumbnail from the fit render to drive the zoom minimap.
-        if (zoom <= 1f) updateFitThumb(bmp)
-        // Zoom minimap (top-right): full page + the current viewport window (RR5-FR3).
+        // Zoom minimap (top-right): full page + the current viewport window (RR5-FR3). The fit
+        // thumbnail it draws is captured lazily when zoom is first engaged (captureFitThumb), not on
+        // every fit-page turn — so ordinary reading pays no per-flip scale + alloc.
         if (zoom > 1f) drawZoomMinimap(cv)
         // A top-right dog-ear: faint outline (tap-to-bookmark affordance) / solid when bookmarked.
         drawBookmarkCorner(cv)
@@ -765,7 +770,14 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             Books.saveThumbnail(this, currentBookId, bmp)
         }
         blit { canvas -> canvas.drawBitmap(bmp, 0f, 0f, null) }
-        // Cache this page's links for tap hit-testing (RR11-FR3). Cheap; pdfium caches per page.
+        if (!deferLinks) refreshCurrentLinks()
+    }
+
+    /** Cache the current page's links for tap hit-testing (RR11-FR3). Off the page-turn critical path
+     *  (postJump calls this after the flash); links are only needed for the next tap. */
+    private fun refreshCurrentLinks() {
+        val handle = docHandle
+        if (handle == 0L) return
         currentLinks = try {
             WireCodec.decodeLinks(NativeBridge.nativePageLinks(handle, currentPage))
         } catch (e: RuntimeException) {
@@ -946,6 +958,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val old = fitThumb
         fitThumb = Bitmap.createScaledBitmap(src, tw, th, true)
         if (old != null && old != fitThumb) old.recycle()
+    }
+
+    /** Snapshot the current fit page for the zoom minimap — called once when zoom is engaged from
+     *  fit (not on every flip). At that point [bitmap] still holds the fit render (a pinch only
+     *  transforms it on the surface, never overwrites it). */
+    private fun captureFitThumb() {
+        if (zoom <= 1f) bitmap?.let { updateFitThumb(it) }
     }
 
     /** Minimap panel geometry (thumbnail + the −/+ zoom buttons below it). Deterministic from the
@@ -1256,9 +1275,12 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 }
                 ink.clearAll() // wipe the firmware ink overlay so it doesn't bleed onto the new page
                 dropSelectionForPageChange()
-                renderAndBlit()
-                savePosition() // persist position per jump so an abrupt kill still reopens here (RR27)
+                renderAndBlit(deferLinks = true)
+                // Flash the panel FIRST so the new page is visible with no persistence/links work
+                // in front of it; then do the off-critical-path bookkeeping (RR27 position + links).
                 adapter.executeAll(WireCodec.decodeCommands(commandBytes))
+                savePosition() // persist position per jump so an abrupt kill still reopens here (RR27)
+                refreshCurrentLinks()
             } finally {
                 onDone?.invoke() // release the coalescing latch even on early-out / error
             }
@@ -1656,7 +1678,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     /** Multiply the zoom (clamped); snap back to fit at ~1. Used by the +/- buttons and pinch-end. */
     private fun zoomBy(factor: Float) {
-        zoom = (zoom * factor).coerceIn(1f, MAX_ZOOM_UI)
+        val next = (zoom * factor).coerceIn(1f, MAX_ZOOM_UI)
+        if (zoom <= 1f && next > 1f) captureFitThumb() // grab the fit thumb before leaving fit
+        zoom = next
         if (zoom <= 1.01f) { zoom = 1f; panX = 0f; panY = 0f }
         applyZoom()
     }
@@ -1700,6 +1724,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             }
             override fun onScaleEnd(d: android.view.ScaleGestureDetector) {
                 val newZoom = (gestureStartZoom * liveScale).coerceIn(1f, MAX_ZOOM_UI)
+                if (gestureStartZoom <= 1f && newZoom > 1f) captureFitThumb() // zoom field still ≤1 here
                 if (newZoom <= 1.01f) {
                     zoom = 1f; panX = 0f; panY = 0f
                 } else {

--- a/app/src/main/java/dev/jraghavan/inkread/SearchController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SearchController.kt
@@ -89,7 +89,7 @@ class SearchController(private val host: Host) {
             setPadding(pad, dp(8), pad, 0)
             addView(input, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
         }
-        val builder = AlertDialog.Builder(activity)
+        val builder = AlertDialog.Builder(activity, R.style.InkDialog)
             .setTitle("Search")
             .setView(wrap)
             .setPositiveButton("Search") { _, _ -> runSearch(input.text.toString()) }
@@ -115,7 +115,7 @@ class SearchController(private val host: Host) {
         // The scan blocks the engine thread, but the UI thread is free — so a cancelable progress
         // dialog lets the user abort a long full-document scan (the Cancel flips the volatile flag
         // the loop polls each page). Non-cancelable via back so the only exit is an explicit choice.
-        val progress = AlertDialog.Builder(host.activity)
+        val progress = AlertDialog.Builder(host.activity, R.style.InkDialog)
             .setTitle("Searching…")
             .setMessage("Scanning the document for “$q”.")
             .setNegativeButton("Cancel") { _, _ -> searchCancelled = true }

--- a/app/src/main/java/dev/jraghavan/inkread/SearchController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SearchController.kt
@@ -193,18 +193,20 @@ class SearchController(private val host: Host) {
                 isClickable = true
                 setOnClickListener { dialog.dismiss(); gotoHit(i) }
                 addView(TextView(activity).apply {
-                    text = "p. ${hit.page + 1}"; setTextColor(Color.parseColor("#666666")); textSize = 11f
+                    text = "P. ${hit.page + 1}"; setTextColor(Ink.muted); textSize = 10f
+                    typeface = Ink.mono; letterSpacing = 0.08f
                 })
                 addView(TextView(activity).apply {
-                    text = hit.match.snippet; setTextColor(Color.BLACK); textSize = 14f; setPadding(0, dp(2), 0, 0)
+                    text = hit.match.snippet; setTextColor(Ink.ink); textSize = 15f
+                    typeface = Ink.serif; setPadding(0, dp(3), 0, 0)
                 })
             })
-            list.addView(View(activity).apply { setBackgroundColor(Color.parseColor("#22000000")) },
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 1))
+            list.addView(View(activity).apply { setBackgroundColor(Ink.hairline) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()))
         }
         // Header: a count label flanked by Prev/Next steppers (step renders behind the sheet).
         fun stepper(label: String, delta: Int) = TextView(activity).apply {
-            text = label; setTextColor(Color.BLACK); textSize = 18f; gravity = Gravity.CENTER
+            text = label; setTextColor(Ink.ink); textSize = 18f; gravity = Gravity.CENTER
             setPadding(dp(16), dp(8), dp(16), dp(8)); isClickable = true
             setOnClickListener { step(delta) }
         }
@@ -213,16 +215,20 @@ class SearchController(private val host: Host) {
             gravity = Gravity.CENTER_VERTICAL
             addView(stepper("◀", -1))
             addView(TextView(activity).apply {
-                text = "${h.size} results for \"$query\""
-                setTextColor(Color.BLACK); textSize = 13f; gravity = Gravity.CENTER
-                setPadding(dp(8), dp(12), dp(8), dp(8))
+                text = "${h.size} results · “$query”"
+                setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono; gravity = Gravity.CENTER
+                setPadding(dp(8), dp(14), dp(8), dp(10))
             }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
             addView(stepper("▶", +1))
         }
         val container = LinearLayout(activity).apply {
             orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Color.WHITE)
+            setBackgroundColor(Ink.paper)
+            addView(View(activity).apply { setBackgroundColor(Ink.ink) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair())) // docked-surface keyline
             addView(header)
+            addView(View(activity).apply { setBackgroundColor(Ink.hairline) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()))
             addView(ScrollView(activity).apply { addView(list) },
                 LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
         }
@@ -230,7 +236,7 @@ class SearchController(private val host: Host) {
         dialog.window?.apply {
             setLayout(ViewGroup.LayoutParams.MATCH_PARENT, (activity.resources.displayMetrics.heightPixels * 0.7f).toInt())
             setGravity(Gravity.BOTTOM)
-            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.WHITE))
+            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Ink.paper))
         }
         dialog.show()
     }

--- a/app/src/main/java/dev/jraghavan/inkread/SelectionToolbar.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SelectionToolbar.kt
@@ -1,9 +1,7 @@
 package dev.jraghavan.inkread
 
 import android.app.Activity
-import android.graphics.Color
 import android.graphics.RectF
-import android.graphics.drawable.GradientDrawable
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -46,18 +44,16 @@ class SelectionToolbar(
         dismiss()
         val row = LinearLayout(activity).apply {
             orientation = LinearLayout.HORIZONTAL
-            background = GradientDrawable().apply {
-                setColor(Color.WHITE)
-                setStroke(maxOf(2, dp(1)), Color.BLACK)
-                cornerRadius = dp(10).toFloat()
-            }
-            setPadding(dp(4), dp(4), dp(4), dp(4))
+            background = Ink.cardBg(Ink.RADIUS_CHIP)
+            setPadding(dp(5), dp(5), dp(5), dp(5))
         }
         val win = PopupWindow(row, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
             isOutsideTouchable = false // keep it up while the user works the selection
             isFocusable = false
         }
-        for (action in SelAction.values()) {
+        // Hairline-separated cells read as a crisp instrument row on e-ink (vs. a blur of adjacent icons).
+        SelAction.values().forEachIndexed { i, action ->
+            if (i > 0) row.addView(divider())
             val enabled = action != SelAction.PASTE || canPaste
             row.addView(cell(action, win, enabled))
         }
@@ -83,11 +79,21 @@ class SelectionToolbar(
         popup = null
     }
 
+    /** A thin vertical rule between cells. */
+    private fun divider(): View = View(activity).apply {
+        setBackgroundColor(Ink.hairline)
+        val v = dp(10)
+        layoutParams = LinearLayout.LayoutParams(Ink.hair(), dp(48) - 2 * v).apply {
+            gravity = Gravity.CENTER_VERTICAL
+            setMargins(0, v, 0, v)
+        }
+    }
+
     /** One square icon cell. */
     private fun cell(action: SelAction, win: PopupWindow, enabled: Boolean): ImageView =
         ImageView(activity).apply {
             setImageResource(action.iconRes)
-            setColorFilter(if (enabled) Color.BLACK else Color.parseColor("#BDBDBD"))
+            setColorFilter(if (enabled) Ink.ink else Ink.disabled)
             val pad = dp(10)
             setPadding(pad, pad, pad, pad)
             val side = dp(48)

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -89,7 +89,7 @@ class ToolPalette(
     /** A hairline separator between the handle, the tools, and the undo/redo actions. */
     private fun divider(): View = View(activity).apply {
         setBackgroundColor(Ink.hairline)
-        layoutParams = LinearLayout.LayoutParams(dp(28), Ink.hair()).apply {
+        layoutParams = LinearLayout.LayoutParams(dp(42), Ink.hair()).apply {
             gravity = Gravity.CENTER_HORIZONTAL
             val v = dp(4); setMargins(0, v, 0, v)
         }
@@ -100,8 +100,8 @@ class ToolPalette(
         ImageView(activity).apply {
             setImageResource(iconRes)
             setColorFilter(Ink.ink)
-            val pad = dp(9); setPadding(pad, pad, pad, pad)
-            val side = dp(40)
+            val pad = dp(14); setPadding(pad, pad, pad, pad)
+            val side = dp(60)
             layoutParams = LinearLayout.LayoutParams(side, side).apply { val m = dp(2); setMargins(m, m, m, m) }
             isClickable = true
             contentDescription = desc
@@ -112,9 +112,9 @@ class ToolPalette(
     private fun handle(): ImageView = ImageView(activity).apply {
         setImageResource(R.drawable.ic_tool_handle)
         setColorFilter(Ink.ink)
-        val pad = dp(9)
+        val pad = dp(14)
         setPadding(pad, pad, pad, pad)
-        val side = dp(40)
+        val side = dp(60)
         layoutParams = LinearLayout.LayoutParams(side, side).apply {
             val m = dp(2); setMargins(m, m, m, m)
         }
@@ -154,15 +154,15 @@ class ToolPalette(
         val active = tool == current
         setColorFilter(if (active) Ink.paper else Ink.ink)
         alpha = if (tool.phase2) 0.35f else 1f
-        val pad = dp(9)
+        val pad = dp(14)
         setPadding(pad, pad, pad, pad)
-        val side = dp(40)
+        val side = dp(60)
         layoutParams = LinearLayout.LayoutParams(side, side).apply {
             val m = dp(2); setMargins(m, m, m, m)
         }
         if (active) {
             background = GradientDrawable().apply {
-                setColor(Ink.ink); cornerRadius = Ink.dpf(Ink.RADIUS_CHIP)
+                setColor(Ink.ink); cornerRadius = Ink.dpf(Ink.RADIUS)
             }
         }
         isClickable = true

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -1,7 +1,6 @@
 package dev.jraghavan.inkread
 
 import android.app.Activity
-import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.view.Gravity
 import android.view.MotionEvent
@@ -70,12 +69,8 @@ class ToolPalette(
         render()
     }
 
-    /** Rounded white pill with a black ring — high contrast on e-ink. */
-    private fun pill() = GradientDrawable().apply {
-        setColor(Color.WHITE)
-        setStroke(maxOf(2, dp(1)), Color.BLACK)
-        cornerRadius = dp(22).toFloat()
-    }
+    /** Rounded white pill with a black keyline — high contrast on e-ink (Inkwell card language). */
+    private fun pill() = Ink.cardBg(22)
 
     private fun render() {
         container.background = pill()
@@ -93,8 +88,8 @@ class ToolPalette(
 
     /** A hairline separator between the handle, the tools, and the undo/redo actions. */
     private fun divider(): View = View(activity).apply {
-        setBackgroundColor(Color.parseColor("#E0E0E0"))
-        layoutParams = LinearLayout.LayoutParams(dp(28), maxOf(1, dp(1))).apply {
+        setBackgroundColor(Ink.hairline)
+        layoutParams = LinearLayout.LayoutParams(dp(28), Ink.hair()).apply {
             gravity = Gravity.CENTER_HORIZONTAL
             val v = dp(4); setMargins(0, v, 0, v)
         }
@@ -104,7 +99,7 @@ class ToolPalette(
     private fun actionButton(iconRes: Int, desc: String, onTap: () -> Unit): ImageView =
         ImageView(activity).apply {
             setImageResource(iconRes)
-            setColorFilter(Color.BLACK)
+            setColorFilter(Ink.ink)
             val pad = dp(9); setPadding(pad, pad, pad, pad)
             val side = dp(40)
             layoutParams = LinearLayout.LayoutParams(side, side).apply { val m = dp(2); setMargins(m, m, m, m) }
@@ -116,7 +111,7 @@ class ToolPalette(
     /** First icon: a grip that drags the pill (move) and, on a tap, collapses/expands it. */
     private fun handle(): ImageView = ImageView(activity).apply {
         setImageResource(R.drawable.ic_tool_handle)
-        setColorFilter(Color.BLACK)
+        setColorFilter(Ink.ink)
         val pad = dp(9)
         setPadding(pad, pad, pad, pad)
         val side = dp(40)
@@ -157,7 +152,7 @@ class ToolPalette(
     private fun iconButton(tool: Tool): ImageView = ImageView(activity).apply {
         setImageResource(tool.iconRes)
         val active = tool == current
-        setColorFilter(if (active) Color.WHITE else Color.BLACK)
+        setColorFilter(if (active) Ink.paper else Ink.ink)
         alpha = if (tool.phase2) 0.35f else 1f
         val pad = dp(9)
         setPadding(pad, pad, pad, pad)
@@ -167,7 +162,7 @@ class ToolPalette(
         }
         if (active) {
             background = GradientDrawable().apply {
-                setColor(Color.BLACK); cornerRadius = dp(16).toFloat()
+                setColor(Ink.ink); cornerRadius = Ink.dpf(Ink.RADIUS_CHIP)
             }
         }
         isClickable = true

--- a/app/src/main/res/drawable/ink_dialog_bg.xml
+++ b/app/src/main/res/drawable/ink_dialog_bg.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Window background for platform AlertDialogs themed with R.style.InkDialog: a white card with a
+     single black keyline and rounded corners, matching the Inkwell card language (see Ink.kt). An
+     inset keeps the keyline off the screen edge. -->
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="12dp"
+    android:insetRight="12dp"
+    android:insetTop="12dp"
+    android:insetBottom="12dp">
+    <shape android:shape="rectangle">
+        <solid android:color="@android:color/white" />
+        <corners android:radius="16dp" />
+        <stroke android:width="1.5dp" android:color="@android:color/black" />
+    </shape>
+</inset>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,24 @@
     <style name="InkDialog" parent="@android:style/Theme.Material.Light.Dialog.Alert">
         <item name="android:colorAccent">@android:color/black</item>
         <item name="android:textColorPrimary">@android:color/black</item>
-        <item name="android:windowBackground">@android:color/white</item>
+        <!-- Rounded white card with a black keyline (Inkwell language), instead of the flat sheet. -->
+        <item name="android:windowBackground">@drawable/ink_dialog_bg</item>
+        <item name="android:windowTitleStyle">@style/InkDialog.Title</item>
+        <item name="android:buttonBarButtonStyle">@style/InkDialog.Button</item>
+    </style>
+
+    <!-- Serif display title — carries the home screen's voice into platform dialogs. -->
+    <style name="InkDialog.Title" parent="@android:style/TextAppearance.Material.DialogWindowTitle">
+        <item name="android:fontFamily">serif</item>
+        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textSize">21sp</item>
+    </style>
+
+    <!-- Monochrome, mono-spaced, letter-spaced action buttons (Cancel / OK etc.). -->
+    <style name="InkDialog.Button" parent="@android:style/Widget.Material.Button.Borderless">
+        <item name="android:fontFamily">monospace</item>
+        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:letterSpacing">0.06</item>
     </style>
 </resources>


### PR DESCRIPTION
Polishes every popup/dialog/overlay into one cohesive **Inkwell editorial** language, enlarges the floating tool palette, and trims removable software work off the page-flip critical path. Three commits, separable by concern.

## `Ink` design system (`86d6788`)
A shared token + builder layer (`Ink.kt`) so surfaces stop drifting per file:
- Centralized monochrome palette (was scattered `#D8D8D8/#E0E0E0/#9E9E9E/#BDBDBD` hex), Inkwell type (serif display + mono labels), one shape rhythm (card 16 / chip 10; keyline survives a GC16 flash; hairline never 0px), and builders (`cardBg`/`eyebrow`/`title`/`rule`/`pillButton`).
- Applied to the four most-touched custom surfaces: **dictionary popup** (serif headword/definitions, mono Def/Thesaurus tabs, uppercase POS badges), **lasso selection toolbar**, **tool palette**, **color palette**; fixed the off-theme **Search** dialogs (were platform blue → `InkDialog`).

## Pass-2 dialog polish + 1.5× tool palette (`53bd382`)
- **Theme-level** (`ink_dialog_bg` + enriched `InkDialog`): rounded white card + black keyline window, serif titles, mono buttons — lifts every platform `AlertDialog` (Go to page, Bookmarks, Library, Export, Manage dictionaries, text-selection, Settings confirm) with no per-call code.
- **Custom dialogs** tokenized: bottom bar (keyline, mono chip/labels, refined slider), Contents/TOC (mono eyebrow, serif entries), adjust sheet (mono tabs, black-fill segmented controls/cell bars), search results (serif snippets, mono `P.n`).
- **Tool palette icons → 1.5×** (cells 40→60dp, pad 9→14dp, wider divider, larger active chip); drag/collapse behavior unchanged.

## Page-flip latency (`f772c6a`)
- **Nothing optional runs before the flash:** `postJump` now flashes the panel (`executeAll`) *before* the SQLite position save and the link fetch (`nativePageLinks` deferred via `renderAndBlit(deferLinks=true)` + `refreshCurrentLinks()`).
- **No per-flip thumbnail scale during normal reading:** the fit-thumb (zoom minimap) was rebuilt on *every* fit-page turn; now captured lazily on the fit→zoom transition (`captureFitThumb`). Removes a full-frame filtered downscale + alloc + GC per turn.
- Net ~10–20 ms + GC jitter off each turn; the GC16 full-refresh remains the dominant, hardware-bound cost (M1c partial waveforms out of scope).

## Notes
- **Verified:** `compileReleaseKotlin` clean under JDK 21; built + installed on a Supernote; logcat shows clean core load / open / page-63 resume and **no error paths** (the 2 "E" lines are benign ART/Mali system noise). Resume-at-63 confirms the `savePosition` reorder didn't regress persistence.
- **Not done here (your call):** debounce the per-flip position save (low risk) — left out. The on-turn ink flush is intentionally kept (removing it risks losing annotations on annotate-then-flip).
- EPD screencap is black, so visual review is on-device; the riskiest item to eyeball is the XML-themed platform-dialog **serif title** (some Material variants ignore `windowTitleStyle`) — fallback custom-title view ready if it didn't take.

## Responsive (Nomad) — analysis only, no code
Home content already rides a width-driven `scale` (≈0.90 on a true 7.8″ Nomad vs the 1.15 cap on a 10.7″ panel), so covers/type/shelf reflow with no overflow. The one tight spot on a real Nomad is the **bottom bar's 10 cells** (~75 dp each) — a follow-up if we add a small-screen target.