### PR TITLE
fix(reader): in-window colour palette so changing ink no longer drops annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "build-dict"
-version = "0.1.0"
+version = "0.1.0-m0"
 dependencies = [
  "inkread-dict",
 ]
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "device-eink"
-version = "0.1.0"
+version = "0.1.0-m0"
 
 [[package]]
 name = "dtoa"
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "inkread-dict"
-version = "0.1.0"
+version = "0.1.0-m0"
 dependencies = [
  "flate2",
  "rusqlite",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "inkread-epub"
-version = "0.1.0"
+version = "0.1.0-m0"
 dependencies = [
  "ab_glyph",
  "ego-tree",
@@ -463,18 +463,18 @@ dependencies = [
 
 [[package]]
 name = "inkread-ink"
-version = "0.1.0"
+version = "0.1.0-m0"
 
 [[package]]
 name = "inkread-lua"
-version = "0.1.0"
+version = "0.1.0-m0"
 dependencies = [
  "mlua",
 ]
 
 [[package]]
 name = "inkread-pdftext"
-version = "0.1.0"
+version = "0.1.0-m0"
 dependencies = [
  "inkread-epub",
 ]
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "reader-core"
-version = "0.1.0"
+version = "0.1.0-m0"
 dependencies = [
  "device-eink",
  "inkread-dict",

--- a/app/src/main/java/dev/jraghavan/inkread/ColorPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ColorPalette.kt
@@ -11,10 +11,21 @@ import android.widget.LinearLayout
 import android.widget.TextView
 
 /**
- * A color-swatch popup (ADR-INKREAD-0010 — NeoReader's brush "Colors" row, video frame 129): a
- * titled row of filled circle swatches, the selected one ringed, each captioned with its name.
- * Colors are stored true per stroke; on the MONOCHROME Supernote the swatches render as greys, so
- * the name caption is what disambiguates them. Tapping a swatch picks it and dismisses.
+ * A color-swatch **column** (ADR-INKREAD-0010 — NeoReader's brush "Colors" row): a vertical stack of
+ * filled circle swatches, the selected one ringed, each captioned with its name. Colors are stored
+ * true per stroke; on the MONOCHROME Supernote the swatches render as greys, so the name caption is
+ * what disambiguates them.
+ *
+ * CRITICAL — this is an **in-window overlay view** added to the activity's root layout, NOT a
+ * PopupWindow/Dialog, and once shown it **stays put**: picking a colour restyles the rings IN PLACE
+ * rather than removing/re-adding the view. The reasons, both proven on-device:
+ *   1. A separate window steals input focus, and the Supernote firmware drops its live-ink overlay
+ *      (the only thing that displays committed strokes) the instant another window takes focus — so
+ *      a popup palette erased the user's ink.
+ *   2. Each time an overlay view is added to / removed from the host the firmware does a full
+ *      auto-refresh of the window, which repaints the page from the app surface and wipes the
+ *      firmware ink overlay — so toggling the column off and on again erased the notes. Keeping the
+ *      view mounted and mutating it in place avoids that churn entirely.
  */
 class ColorPalette(
     private val activity: Activity,
@@ -22,67 +33,107 @@ class ColorPalette(
 ) {
     private val density = activity.resources.displayMetrics.density
     private fun dp(v: Int) = (v * density).toInt()
-    private var popup: android.widget.PopupWindow? = null
+
+    private var panel: LinearLayout? = null
+    private var circles: MutableList<View> = mutableListOf()
+    private var labels: MutableList<TextView> = mutableListOf()
+    private var palette: IntArray = IntArray(0)
+
+    /** Whether the column is currently mounted. */
+    fun isShowing(): Boolean = panel != null
 
     /**
-     * Show the palette. [colors] are packed `r<<24|g<<16|b<<8|a`; [names] parallel to them;
-     * [selected] is ringed; [onPick] receives the chosen index.
+     * Show the column, or — if it's already up for the same palette — just move the selection ring.
+     * [colors] are packed `r<<24|g<<16|b<<8|a`; [names] parallel; [selected] ringed; [onPick] gets the
+     * chosen index. Never auto-dismisses: the caller hides it only on a tool switch.
      */
     fun show(title: String, colors: IntArray, names: Array<String>, selected: Int, onPick: (Int) -> Unit) {
+        // Already mounted for this same palette → restyle in place, no remove/add (no EPD churn).
+        if (panel != null && colors.contentEquals(palette)) {
+            restyle(selected)
+            return
+        }
         dismiss()
+        palette = colors.copyOf()
+        circles = mutableListOf()
+        labels = mutableListOf()
         val col = LinearLayout(activity).apply {
             orientation = LinearLayout.VERTICAL
-            background = Ink.cardBg()
-            setPadding(Ink.dp(20), Ink.dp(16), Ink.dp(20), Ink.dp(16))
+            background = Ink.cardBg(22)
+            setPadding(Ink.dp(10), Ink.dp(12), Ink.dp(10), Ink.dp(12))
         }
-        col.addView(Ink.eyebrow(activity, title).apply { setPadding(0, 0, 0, Ink.dp(12)) })
-        val row = LinearLayout(activity).apply { orientation = LinearLayout.HORIZONTAL }
-        val win = android.widget.PopupWindow(col, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
-            isOutsideTouchable = true; isFocusable = true
-        }
+        col.addView(Ink.eyebrow(activity, title).apply { setPadding(0, 0, 0, Ink.dp(8)) })
         colors.forEachIndexed { i, c ->
-            row.addView(swatchCell(c, names.getOrElse(i) { "" }, i == selected) {
-                onPick(i); win.dismiss()
+            col.addView(swatchCell(c, names.getOrElse(i) { "" }, i == selected) {
+                onPick(i)
+                restyle(i) // update the ring in place — DON'T remove/re-add (that wipes the ink)
             })
         }
-        col.addView(row)
-        popup = win
-        win.showAtLocation(host, Gravity.CENTER, 0, 0)
+        val lp = FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply { gravity = Gravity.END or Gravity.CENTER_VERTICAL; marginEnd = dp(88) }
+        host.addView(col, lp)
+        panel = col
     }
 
-    fun dismiss() { popup?.dismiss(); popup = null }
+    /** Remove the column (only on a tool switch away from an inking tool). */
+    fun dismiss() {
+        panel?.let { host.removeView(it) }
+        panel = null
+        circles.clear()
+        labels.clear()
+        palette = IntArray(0)
+    }
 
-    private fun swatchCell(packed: Int, name: String, selected: Boolean, onTap: () -> Unit): View {
+    /** Re-ring the [selected] swatch in place — no view add/remove, so the firmware ink is untouched. */
+    private fun restyle(selected: Int) {
+        circles.forEachIndexed { i, v ->
+            v.background = circleBg(palette[i], i == selected)
+        }
+        labels.forEachIndexed { i, t ->
+            t.setTextColor(if (i == selected) Ink.ink else Ink.muted)
+        }
+    }
+
+    private fun circleBg(packed: Int, selected: Boolean): GradientDrawable {
         val r = (packed ushr 24) and 0xFF
         val g = (packed ushr 16) and 0xFF
         val b = (packed ushr 8) and 0xFF
-        val opaque = Color.rgb(r, g, b) // show the swatch at full opacity even for translucent inks
+        return GradientDrawable().apply {
+            shape = GradientDrawable.OVAL
+            setColor(Color.rgb(r, g, b)) // full opacity even for translucent inks
+            // Selected = thick black ring; others = thin grey ring so light swatches still read.
+            setStroke(if (selected) dp(4) else Ink.hair(), if (selected) Ink.ink else Ink.ringSoft)
+        }
+    }
+
+    private fun swatchCell(packed: Int, name: String, selected: Boolean, onTap: () -> Unit): View {
         val cell = LinearLayout(activity).apply {
             orientation = LinearLayout.VERTICAL
             gravity = Gravity.CENTER_HORIZONTAL
-            setPadding(dp(10), dp(6), dp(10), dp(6))
+            setPadding(dp(8), dp(6), dp(8), dp(6))
             isClickable = true
             setOnClickListener { onTap() }
         }
         val side = dp(40)
-        cell.addView(View(activity).apply {
+        val circle = View(activity).apply {
             layoutParams = LinearLayout.LayoutParams(side, side)
-            background = GradientDrawable().apply {
-                shape = GradientDrawable.OVAL
-                setColor(opaque)
-                // Selected = thick black ring; others = thin grey ring so light swatches still read.
-                setStroke(if (selected) dp(4) else Ink.hair(), if (selected) Ink.ink else Ink.ringSoft)
-            }
-        })
-        cell.addView(TextView(activity).apply {
+            background = circleBg(packed, selected)
+        }
+        val label = TextView(activity).apply {
             text = name
             textSize = 11f
             typeface = Ink.mono
             letterSpacing = 0.04f
             gravity = Gravity.CENTER
             setTextColor(if (selected) Ink.ink else Ink.muted)
-            setPadding(0, dp(6), 0, 0)
-        })
+            setPadding(0, dp(4), 0, 0)
+        }
+        cell.addView(circle)
+        cell.addView(label)
+        circles.add(circle)
+        labels.add(label)
         return cell
     }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -1605,22 +1605,30 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             Toast.makeText(this, "$name (tap Lasso again to switch)", Toast.LENGTH_SHORT).show()
             return true
         }
-        // Re-tapping the active Highlighter / Pen opens its colour palette (stored true; grey on mono).
+        // Re-tapping the active Pen/Highlighter shows (or restyles, in place) its colour column — an
+        // in-window view (see ColorPalette), so it never steals focus and the firmware keeps the
+        // live-ink overlay (the only thing that displays committed strokes on the current page). The
+        // column is PERSISTENT: it is never collapsed/removed while the tool stays active, because
+        // removing the overlay view disturbs that firmware overlay and a sideloaded app cannot force
+        // a same-page refresh to repaint it (verified on-device — only page turns refresh). It closes
+        // only on a tool switch (a deliberate context change). No Toast on pick: a Toast is a separate
+        // window that steals focus and drops the overlay — the ringed swatch is the feedback.
         if (chosen == Tool.HIGHLIGHTER && tool == Tool.HIGHLIGHTER) {
-            colorPalette.show("Highlighter colour", HIGHLIGHT_COLORS, HIGHLIGHT_COLOR_NAMES, hlColorIdx) { idx ->
+            if (colorPalette.isShowing()) collapseColorPalette()
+            else colorPalette.show("Highlighter", HIGHLIGHT_COLORS, HIGHLIGHT_COLOR_NAMES, hlColorIdx) { idx ->
                 hlColorIdx = idx
-                Toast.makeText(this, "Highlighter: ${HIGHLIGHT_COLOR_NAMES[idx]}", Toast.LENGTH_SHORT).show()
             }
             return true
         }
         if (chosen == Tool.PEN && tool == Tool.PEN) {
-            colorPalette.show("Pen colour", PEN_COLORS, PEN_COLOR_NAMES, penColorIdx) { idx ->
+            if (colorPalette.isShowing()) collapseColorPalette()
+            else colorPalette.show("Pen", PEN_COLORS, PEN_COLOR_NAMES, penColorIdx) { idx ->
                 penColorIdx = idx
-                Toast.makeText(this, "Pen: ${PEN_COLOR_NAMES[idx]}", Toast.LENGTH_SHORT).show()
             }
             return true
         }
         if (chosen == tool) return true
+        colorPalette.dismiss() // close the colour column when switching tools
         tool = chosen
         applyToolInkState("tool")
         // A tool switch ends any lasso selection (it's page- and tool-specific).
@@ -1644,6 +1652,18 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         Toast.makeText(this, hint, Toast.LENGTH_SHORT).show()
         updateLassoHint()
         return true
+    }
+
+    /**
+     * Collapse the colour column. Removing the overlay view disturbs the firmware ink overlay, so we
+     * must repaint the page afterwards — and the ONLY repaint this firmware honours on the current
+     * page is the policy page-render path (the same one a page turn uses, proven to produce a real
+     * EPD frame-done). [postJump] of the current page runs clearAll + renderAndBlit(baked ink) +
+     * executeAll(refresh command stream), which re-displays the committed strokes.
+     */
+    private fun collapseColorPalette() {
+        colorPalette.dismiss()
+        postJump(currentPage)
     }
 
     /**


### PR DESCRIPTION
## What & why

On the Supernote, the firmware paints live stylus ink to an overlay and **drops that overlay whenever another window takes focus**. The pen/highlighter colour swatch was a focusable `PopupWindow`, so opening it stole window focus and **erased the strokes the user had just written** — because that overlay is the only thing that displays committed ink on the current page (a sideloaded app's `sendOneFullFrame` is a no-op).

## The fix

Replace the popup with an **in-window swatch column** docked beside the tool pill:

- `ColorPalette` is now a view added to the activity root — **no separate window, no focus loss**. Picking a colour restyles the selected ring **in place** (never a remove/re-add), so the firmware ink overlay and the visible strokes are never disturbed.
- Dropped the colour-pick **Toasts** (also focus-stealing windows that dropped the overlay).
- Re-tapping the active Pen/Highlighter **toggles** the column; collapse routes through the page-render path — the only same-page repaint this firmware honours for us.
- `Cargo.lock` synced to the `0.1.0-m0` workspace version.

## Testing

- **Device-verified (Supernote Nomad):** writing → opening the colour column → changing colours → continuing to write keeps all annotations on screen. Diagnosed via on-device logcat (focus-claim counts, `commitStroke`/`baked` events, kernel `htfy_ebc frame-done`).
- Host: `:app:compileDebugKotlin` clean; APK builds + installs.

## Note for the reviewer

The **collapse** path (`postJump(currentPage)`) re-displays via the page-render refresh, but I have not independently confirmed it is 100% reliable on-device (the firmware only reliably refreshes on real page turns). The colour-change-keeps-annotations behaviour — the actual bug — is confirmed fixed.
