### PR TITLE
fix(reader): first-palm rejection + host tests; style(home): quiet footer tagline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,22 @@ jobs:
       # (ADR Decision 2); a new dep with an unvetted license fails the build (RR18-AC2).
       - name: Verify dependency licenses against the allowlist
         run: ./scripts/check-licenses.sh
+
+  android-unit-tests:
+    name: android unit tests (host JVM)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # JVM unit tests for pure Kotlin logic (PalmFilter palm-rejection) — run on the host, NO
+      # emulator: a generic AVD can't simulate the Supernote EMR pen / EPD, so device-shaped
+      # decisions are validated here against the real captured contact metrics. The runner's
+      # preinstalled Android SDK (ANDROID_HOME, platform-34) configures the app module; no NDK,
+      # no libreader.so, no device needed.
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+      - name: Run app JVM unit tests (:app:testDebugUnitTest)
+        run: ./gradlew :app:testDebugUnitTest --console=plain

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,4 +57,8 @@ dependencies {
     // ignores. Bump these together with compileSdk + AGP, not piecemeal.
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
+
+    // Host JVM unit tests for pure logic (e.g. PalmFilter) — run via :app:testDebugUnitTest, no
+    // emulator/device needed (an emulator can't simulate the Supernote EMR pen anyway).
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -263,8 +263,10 @@ class HomeActivity : Activity() {
         gravity = Gravity.CENTER_HORIZONTAL
         addView(TextView(this@HomeActivity).apply {
             text = swashCaps("Super Reader for a Super You")
-            setTextColor(inkSoft); textSize = fs(31f); typeface = scriptBold
-            paint.isFakeBoldText = true; gravity = Gravity.CENTER; includeFontPadding = false
+            // Subtle footer: small (matches the version eyebrow's 12sp) and light (muted grey, not
+            // the heavy dark script it was) so it reads as a quiet tagline, not a headline.
+            setTextColor(textMuted); textSize = fs(12f); typeface = script
+            gravity = Gravity.CENTER; includeFontPadding = false
         })
         addView(LinearLayout(this@HomeActivity).apply {
             orientation = LinearLayout.HORIZONTAL

--- a/app/src/main/java/dev/jraghavan/inkread/PalmFilter.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/PalmFilter.kt
@@ -1,0 +1,52 @@
+package dev.jraghavan.inkread
+
+/**
+ * Pure palm / stray-touch decision (RR19 palm rejection), extracted from [ReaderActivity] so it can
+ * be unit-tested on the host JVM with the real contact metrics captured on-device (no emulator can
+ * simulate the Supernote's EMR pen + EPD, so device-shaped logic is validated here instead).
+ *
+ * A **finger** touch is treated as a resting palm — and therefore ignored for navigation and the
+ * word-lookup gestures — when ANY of these hold:
+ *  - it is multi-pointer (a second contact while writing), or
+ *  - the EMR pen is currently **in proximity** (hovering), or
+ *  - it landed within [palmRejectMs] of the last pen event (touch OR hover), or
+ *  - a stroke is in progress, or
+ *  - its contact major is a large fraction ([touchMajorFrac]) of the panel height.
+ *
+ * The "at the outset" gap this addresses: palm rejection used to be bootstrapped only by *recent*
+ * pen activity, so the very first palm that lands BEFORE the pen has hovered/touched leaked through
+ * (the panel reports a fairly small touch-major even for a palm). Proximity (hover) tracking plus a
+ * tightened size threshold catch that first contact without waiting for the pen to engage.
+ */
+object PalmFilter {
+
+    /**
+     * @param isStylusTool   the touch's tool is a stylus/eraser — never a palm.
+     * @param pointerCount   number of active pointers in the event.
+     * @param penHovering    the EMR pen is currently in proximity (hover enter/move seen, no exit).
+     * @param strokeInProgress an ink stroke is being captured right now.
+     * @param msSinceStylus  elapsed ms since the last pen touch/hover event.
+     * @param palmRejectMs   reject a finger within this long of pen activity.
+     * @param touchMajorPx   the contact's major axis in pixels (panel-reported).
+     * @param viewHeightPx   panel height in pixels (0 ⇒ unknown, size test skipped).
+     * @param touchMajorFrac contact-major ≥ this fraction of [viewHeightPx] ⇒ a palm.
+     */
+    fun isPalm(
+        isStylusTool: Boolean,
+        pointerCount: Int,
+        penHovering: Boolean,
+        strokeInProgress: Boolean,
+        msSinceStylus: Long,
+        palmRejectMs: Long,
+        touchMajorPx: Float,
+        viewHeightPx: Int,
+        touchMajorFrac: Float,
+    ): Boolean {
+        if (isStylusTool) return false
+        if (pointerCount > 1) return true
+        if (penHovering) return true
+        if (msSinceStylus <= palmRejectMs) return true
+        if (strokeInProgress) return true
+        return viewHeightPx > 0 && touchMajorPx >= viewHeightPx * touchMajorFrac
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -79,6 +79,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
      *  [PALM_REJECT_MS] of it is treated as a resting palm and ignored for navigation. */
     @Volatile private var lastStylusMs = 0L
 
+    /** True while the EMR pen is in proximity (hover enter/move seen, no exit yet). The hand rests as
+     *  the pen approaches, so any finger that lands while the pen hovers is a palm — this rejects the
+     *  FIRST palm at the start of writing, before the pen has actually touched (RR19). */
+    @Volatile private var penHovering = false
+
     /** Single worker thread for all engine/JNI/document work (serialized per RR21). */
     private val engine = Executors.newSingleThreadExecutor { r -> Thread(r, "inkread-engine") }
 
@@ -455,6 +460,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val tool = event.getToolType(0)
         if (tool == MotionEvent.TOOL_TYPE_STYLUS || tool == MotionEvent.TOOL_TYPE_ERASER) {
             lastStylusMs = SystemClock.uptimeMillis()
+            // Track pen proximity: HOVER_ENTER/MOVE ⇒ near the glass, HOVER_EXIT ⇒ lifted away. A
+            // finger that lands while the pen hovers is the accompanying palm (rejected immediately,
+            // without waiting for the PALM_REJECT_MS window to be primed by a touch).
+            penHovering = event.actionMasked != MotionEvent.ACTION_HOVER_EXIT
         }
         return super.dispatchGenericMotionEvent(event)
     }
@@ -1103,12 +1112,17 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
      */
     private fun isPalmTouch(e: MotionEvent): Boolean {
         val toolType = e.getToolType(0)
-        if (toolType == MotionEvent.TOOL_TYPE_STYLUS || toolType == MotionEvent.TOOL_TYPE_ERASER) return false
-        if (e.pointerCount > 1) return true
-        if (SystemClock.uptimeMillis() - lastStylusMs <= PALM_REJECT_MS) return true
-        if (strokeBuf.isNotEmpty()) return true
-        val vh = surfaceView.height
-        return vh > 0 && e.getTouchMajor(0) >= vh * PALM_TOUCH_MAJOR_FRAC
+        return PalmFilter.isPalm(
+            isStylusTool = toolType == MotionEvent.TOOL_TYPE_STYLUS || toolType == MotionEvent.TOOL_TYPE_ERASER,
+            pointerCount = e.pointerCount,
+            penHovering = penHovering,
+            strokeInProgress = strokeBuf.isNotEmpty(),
+            msSinceStylus = SystemClock.uptimeMillis() - lastStylusMs,
+            palmRejectMs = PALM_REJECT_MS,
+            touchMajorPx = e.getTouchMajor(0),
+            viewHeightPx = surfaceView.height,
+            touchMajorFrac = PALM_TOUCH_MAJOR_FRAC,
+        )
     }
 
     /**
@@ -2816,7 +2830,12 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val PASTE_OFFSET = 0.03f // normalized offset so a paste lands just beside the source.
         const val FINGER_LONG_PRESS_MS = 500L // finger held ~still this long on a word → look it up.
         const val FINGER_MOVE_SLOP_PX = 24f // finger travel beyond this = a swipe, not a tap/hold.
-        const val PALM_TOUCH_MAJOR_FRAC = 0.12f // contact major ≥ 12% of view height ⇒ a palm.
+        // Contact major ≥ this fraction of the panel height ⇒ a palm. Lowered from 0.12 to 0.06
+        // (≈154px on a 2560px panel) per on-device PALMDIAG capture: resting palms reported
+        // touch-major ≈ 140–240px, well under the old 307px gate, so the very first palm leaked
+        // before any pen event primed the timing window. 0.06 catches those by size at the outset;
+        // a fingertip tap reads well below it. Tunable.
+        const val PALM_TOUCH_MAJOR_FRAC = 0.06f
 
         // Launch extras from HomeActivity.
         const val EXTRA_PICK = "inkread.pick" // open the file picker on launch.

--- a/app/src/test/java/dev/jraghavan/inkread/PalmFilterTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/PalmFilterTest.kt
@@ -1,0 +1,92 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for [PalmFilter] (RR19 palm rejection). Inputs use the real contact metrics
+ * captured on a Supernote Nomad via the temporary PALMDIAG logging: a 2560px panel, resting palms
+ * reporting touch-major ≈ 95–240px (most 140–240), pressure 0.5–0.93. No emulator can reproduce the
+ * EMR pen, so this pure logic is the deterministic guard against palm-rejection regressions.
+ */
+class PalmFilterTest {
+
+    // Production constants (kept in sync with ReaderActivity).
+    private val rejectMs = 1000L
+    private val frac = 0.06f
+    private val panel = 2560
+
+    private fun palm(
+        stylus: Boolean = false,
+        pointers: Int = 1,
+        hovering: Boolean = false,
+        stroke: Boolean = false,
+        sinceStylus: Long = 10_000L, // long ago by default (no recent pen)
+        majorPx: Float = 0f,
+        viewH: Int = panel,
+    ) = PalmFilter.isPalm(
+        isStylusTool = stylus,
+        pointerCount = pointers,
+        penHovering = hovering,
+        strokeInProgress = stroke,
+        msSinceStylus = sinceStylus,
+        palmRejectMs = rejectMs,
+        touchMajorPx = majorPx,
+        viewHeightPx = viewH,
+        touchMajorFrac = frac,
+    )
+
+    @Test fun stylusIsNeverPalm() {
+        assertFalse(palm(stylus = true, majorPx = 240f, pointers = 2))
+    }
+
+    @Test fun secondPointerWhileWritingIsPalm() {
+        assertTrue(palm(pointers = 2))
+    }
+
+    @Test fun fingerWhilePenHoveringIsPalm() {
+        // The "at the outset" case: pen in proximity, no touch yet, small contact — must still reject.
+        assertTrue(palm(hovering = true, majorPx = 90f, sinceStylus = 10_000L))
+    }
+
+    @Test fun fingerWithinPenWindowIsPalm() {
+        assertTrue(palm(sinceStylus = 500L))
+    }
+
+    @Test fun fingerMidStrokeIsPalm() {
+        assertTrue(palm(stroke = true))
+    }
+
+    /** The core regression: a large resting palm at the OUTSET (no pen event, not hovering) is now
+     *  rejected by size, where the old 0.12 (307px) gate let it through. */
+    @Test fun largePalmAtOutsetIsRejectedBySize() {
+        // Observed palm majors on device — all should be palms with the 0.06 gate (154px).
+        for (major in listOf(159f, 175f, 221f, 237f, 240f)) {
+            assertTrue("major=$major should be a palm", palm(majorPx = major))
+        }
+    }
+
+    @Test fun oldThresholdWouldHaveLeakedThesePalms() {
+        // Documents the fix: with the OLD 0.12 gate these device palms were NOT rejected by size.
+        for (major in listOf(159f, 175f, 237f)) {
+            val rejectedOld = PalmFilter.isPalm(
+                isStylusTool = false, pointerCount = 1, penHovering = false, strokeInProgress = false,
+                msSinceStylus = 10_000L, palmRejectMs = rejectMs, touchMajorPx = major,
+                viewHeightPx = panel, touchMajorFrac = 0.12f,
+            )
+            assertFalse("major=$major was leaked by the old 0.12 gate", rejectedOld)
+        }
+    }
+
+    @Test fun genuineFingertipTapIsAllowed() {
+        // A real fingertip tap: small contact, no pen nearby, not hovering ⇒ NOT a palm (navigation
+        // and lookups must still work).
+        assertFalse(palm(majorPx = 60f, sinceStylus = 10_000L))
+    }
+
+    @Test fun unknownViewHeightSkipsSizeTest() {
+        // Before the surface is sized, the size test must not fire on a huge major (no false palm).
+        assertFalse(palm(majorPx = 9999f, viewH = 0, sinceStylus = 10_000L))
+    }
+}


### PR DESCRIPTION
## What's in this PR

Two changes:

### 1. Palm rejection — reject the first palm at the start of writing (+ host tests)
Palm rejection only engaged **after** the pen had touched/hovered: `isPalmTouch` was bootstrapped solely by recent stylus activity (`lastStylusMs`), so the **first** palm — which lands before the pen engages — leaked through and fired a page flip / word lookup. On-device `PALMDIAG` capture showed the panel reports `touchMajor` ≈ 140–240 px for a resting palm, well under the old `0.12` (307 px) size gate.

- Track EMR pen **proximity** (hover enter/exit) and reject a finger that lands while the pen hovers.
- Lower `PALM_TOUCH_MAJOR_FRAC` `0.12 → 0.06` (~154 px) so a large palm is rejected by size at the outset.
- Extract the decision into a pure, Android-free **`PalmFilter`** and cover it with **9 host JVM unit tests** driven by the real captured metrics.
- New CI job **`android-unit-tests`** runs `:app:testDebugUnitTest` (host JVM — no emulator/NDK/device; an emulator can't simulate the Supernote EMR pen).

### 2. Home tagline → quiet footer
`"Super Reader for a Super You"` was a large dark bold script headline; now 12sp / muted grey / regular weight, matching the version line.

## ⚠️ Verification status — read before merging

- **Font change:** built + installed on the Nomad; visually confirmed by the maintainer.
- **Palm fix:** **NOT device-verified.** The unit tests prove the logic is internally consistent against captured numbers, *not* that the real-world bug is fixed. Two assumptions are unconfirmed:
  1. that stylus **hover events actually reach the app** (this firmware consumes the pen stream to paint ink — if it swallows hover too, the proximity gating is inert), and
  2. that a **genuine fingertip tap is smaller than ~154 px** on this digitizer (if not, the lowered threshold could reject legitimate finger taps and break navigation).
- A small (~95 px) palm landing before any pen signal still leaks.

**Recommendation:** before relying on the palm change, instrument hover + fingertip metrics on-device and confirm: hover arrives, the first palm is rejected, and finger navigation still works. Consider merging the font change and holding the palm change until verified, or merge behind that on-device check.

## Tests
- `:app:testDebugUnitTest` — 9 PalmFilter cases, 0 failures (local).
- `:app:assembleRelease` — green.
