### PR TITLE
fix(reader): suppress pinch-zoom while the pen is active

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/PalmFilter.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/PalmFilter.kt
@@ -44,9 +44,24 @@ object PalmFilter {
     ): Boolean {
         if (isStylusTool) return false
         if (pointerCount > 1) return true
-        if (penHovering) return true
-        if (msSinceStylus <= palmRejectMs) return true
-        if (strokeInProgress) return true
+        if (isPenActive(penHovering, strokeInProgress, msSinceStylus, palmRejectMs)) return true
         return viewHeightPx > 0 && touchMajorPx >= viewHeightPx * touchMajorFrac
     }
+
+    /**
+     * The EMR pen is **active** — hovering over the glass, mid-stroke, or lifted within
+     * [palmRejectMs] — so any concurrent finger contact is the writing hand, not deliberate
+     * navigation. Used to suppress **pinch-zoom while writing**: the resting palm otherwise reads as
+     * a two-finger pinch and zooms the page out from under the pen.
+     *
+     * This is the pen-proximity subset of [isPalm], deliberately WITHOUT the multi-pointer test — a
+     * pinch is intrinsically multi-pointer, so pointer count can't discriminate a palm pinch from a
+     * real one. Pen proximity is what tells them apart.
+     */
+    fun isPenActive(
+        penHovering: Boolean,
+        strokeInProgress: Boolean,
+        msSinceStylus: Long,
+        palmRejectMs: Long,
+    ): Boolean = penHovering || strokeInProgress || msSinceStylus <= palmRejectMs
 }

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -376,23 +376,46 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                     else -> captureStylus(event) // PEN (Highlighter is still P2)
                 }
             } else if (toolType == MotionEvent.TOOL_TYPE_FINGER) {
-                scaleDetector.onTouchEvent(event)
-                // A second finger means a pinch-zoom, not a tap/long-press. The single-finger DOWN
-                // armed the word-lookup timer; cancel it the instant a 2nd pointer appears (or the
-                // scale gesture engages) and neutralise this gesture, so a held pinch never triggers
-                // a Dict lookup. (onFingerMove/Up can't do this — they're gated to pointerCount==1.)
-                if (event.pointerCount > 1 || scaleDetector.isInProgress) {
-                    mainHandler.removeCallbacks(fingerLongPress)
+                // Pinch-zoom must not fire while writing: the resting hand/palm registers as a
+                // 2-finger contact and the ScaleGestureDetector would zoom the page out from under
+                // the pen. Gate the detector with the same palm rule used for taps/pan (PalmFilter)
+                // — feed it ONLY when the pen is idle. While the pen is active these contacts are
+                // the writing hand, not a deliberate pinch (RR19 palm rejection / ADR-INKREAD-0010).
+                if (penActiveForPinch()) {
+                    // A real pinch already in flight when the pen engaged: neutralise the accumulated
+                    // scale and cancel so onScaleEnd reverts to the committed zoom (no half-scaled
+                    // preview lingers, and the detector doesn't stay stuck in-progress).
+                    if (scaleDetector.isInProgress) {
+                        liveScale = 1f
+                        val cancel = MotionEvent.obtain(event).apply { action = MotionEvent.ACTION_CANCEL }
+                        scaleDetector.onTouchEvent(cancel)
+                        cancel.recycle()
+                    }
+                    // Likewise drop any in-flight minimap interaction: its latches are reset ONLY
+                    // inside handleMinimapTouch's UP path, which we bypass here — leaving them stuck
+                    // would make handleMinimapTouch swallow the next finger gesture once the pen idles.
+                    minimapActive = false; minimapThumbDrag = false
+                    mainHandler.removeCallbacks(fingerLongPress) // the writing hand, not a tap
                     fingerMoved = true
-                }
-                // While a pinch is in progress (2 fingers), don't run tap/pan/long-press logic.
-                if (!scaleDetector.isInProgress && event.pointerCount == 1) {
-                    // The zoom minimap (when shown) is an interactive navigator + zoom control;
-                    // it claims touches over its panel before the page gesture logic runs.
-                    if (!handleMinimapTouch(event)) when (event.actionMasked) {
-                        MotionEvent.ACTION_DOWN -> onFingerDown(event)
-                        MotionEvent.ACTION_MOVE -> onFingerMove(event)
-                        MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> onFingerUp(event)
+                } else {
+                    scaleDetector.onTouchEvent(event)
+                    // A second finger means a pinch-zoom, not a tap/long-press. The single-finger DOWN
+                    // armed the word-lookup timer; cancel it the instant a 2nd pointer appears (or the
+                    // scale gesture engages) and neutralise this gesture, so a held pinch never triggers
+                    // a Dict lookup. (onFingerMove/Up can't do this — they're gated to pointerCount==1.)
+                    if (event.pointerCount > 1 || scaleDetector.isInProgress) {
+                        mainHandler.removeCallbacks(fingerLongPress)
+                        fingerMoved = true
+                    }
+                    // While a pinch is in progress (2 fingers), don't run tap/pan/long-press logic.
+                    if (!scaleDetector.isInProgress && event.pointerCount == 1) {
+                        // The zoom minimap (when shown) is an interactive navigator + zoom control;
+                        // it claims touches over its panel before the page gesture logic runs.
+                        if (!handleMinimapTouch(event)) when (event.actionMasked) {
+                            MotionEvent.ACTION_DOWN -> onFingerDown(event)
+                            MotionEvent.ACTION_MOVE -> onFingerMove(event)
+                            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> onFingerUp(event)
+                        }
                     }
                 }
             }
@@ -1124,6 +1147,20 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             touchMajorFrac = PALM_TOUCH_MAJOR_FRAC,
         )
     }
+
+    /**
+     * True while the pen is active (hovering, mid-stroke, or lifted within [PALM_REJECT_MS]) — so a
+     * concurrent finger contact is the writing hand. Gates the pinch-zoom detector: the resting palm
+     * during writing otherwise reads as a two-finger pinch and zooms the page out from under the pen
+     * (RR19 palm rejection extended to the pincher). Mirrors [isPalmTouch]'s pen-proximity test,
+     * minus the multi-pointer check (a pinch IS multi-pointer; pen proximity is the discriminator).
+     */
+    private fun penActiveForPinch(): Boolean = PalmFilter.isPenActive(
+        penHovering = penHovering,
+        strokeInProgress = strokeBuf.isNotEmpty(),
+        msSinceStylus = SystemClock.uptimeMillis() - lastStylusMs,
+        palmRejectMs = PALM_REJECT_MS,
+    )
 
     /**
      * Wrap a chrome view (bottom bar, sheets) so a resting palm can't press its controls — the

--- a/app/src/test/java/dev/jraghavan/inkread/PalmFilterTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/PalmFilterTest.kt
@@ -89,4 +89,56 @@ class PalmFilterTest {
         // Before the surface is sized, the size test must not fire on a huge major (no false palm).
         assertFalse(palm(majorPx = 9999f, viewH = 0, sinceStylus = 10_000L))
     }
+
+    // ---- isPenActive: the pinch-zoom gate (suppress pinch while the writing hand rests). ----
+
+    private fun penActive(
+        hovering: Boolean = false,
+        stroke: Boolean = false,
+        sinceStylus: Long = 10_000L,
+    ) = PalmFilter.isPenActive(
+        penHovering = hovering,
+        strokeInProgress = stroke,
+        msSinceStylus = sinceStylus,
+        palmRejectMs = rejectMs,
+    )
+
+    @Test fun pinchSuppressedWhilePenHovering() {
+        assertTrue(penActive(hovering = true))
+    }
+
+    @Test fun pinchSuppressedMidStroke() {
+        assertTrue(penActive(stroke = true))
+    }
+
+    @Test fun pinchSuppressedWithinPenWindow() {
+        // Palm landing right after a pen event (the resting hand during writing) ⇒ pen is active.
+        assertTrue(penActive(sinceStylus = 500L))
+    }
+
+    @Test fun deliberatePinchAllowedWhenPenIdle() {
+        // Pen lifted away and quiet past the reject window ⇒ a two-finger pinch is intentional zoom.
+        assertFalse(penActive(sinceStylus = 10_000L))
+    }
+
+    @Test fun penActiveAtExactRejectBoundaryIsActive() {
+        // The `<=` boundary: a finger landing exactly PALM_REJECT_MS after the pen is still the
+        // writing hand (pinch stays suppressed). Pins the off-by-one edge.
+        assertTrue(penActive(sinceStylus = rejectMs))
+    }
+
+    @Test fun penIdleOneMsPastRejectBoundary() {
+        // One ms beyond the window with no hover/stroke ⇒ pen idle, pinch allowed.
+        assertFalse(penActive(sinceStylus = rejectMs + 1))
+    }
+
+    /** Refactor guard: extracting [PalmFilter.isPenActive] out of [PalmFilter.isPalm] must not drift
+     *  the truth table — a small single-pointer finger within any pen-active window is still a palm. */
+    @Test fun isPalmUnchangedByPenActiveExtraction() {
+        assertTrue(palm(sinceStylus = 500L, majorPx = 60f))
+        assertTrue(palm(hovering = true, majorPx = 60f))
+        assertTrue(palm(stroke = true, majorPx = 60f))
+        // Complement: no pen signals ⇒ a fingertip is NOT a palm (navigation still works).
+        assertFalse(palm(sinceStylus = rejectMs + 1, majorPx = 60f))
+    }
 }


### PR DESCRIPTION
## Problem
While annotating, the hand resting on the glass registered as a two-finger contact and the `ScaleGestureDetector` zoomed the page out from under the pen. The pinch detector was fed **every** finger touch with no palm gate, even though taps/pan/long-press were already palm-filtered via `PalmFilter`. (Reproduced from a device screen-capture: writing on a PDF with the Pen tool, the page scales/jumps under the hand.)

## Root cause
`scaleDetector.onTouchEvent(event)` in the `SurfaceView` touch listener ran unconditionally for every finger event. `PalmFilter.isPalm` already encodes the right rule (reject a finger while the pen hovers / within `PALM_REJECT_MS` of pen activity / mid-stroke), but it was only consulted inside `onFingerDown` — *after*, and bypassing, the scale detector.

## Fix
- Gate the scale detector with the same palm rule: feed it **only when the pen is idle**.
- Extract the pen-proximity test into `PalmFilter.isPenActive(...)`, reused by `isPalm` so the rule has one host-testable source of truth (DRY). It deliberately omits the multi-pointer test — a pinch *is* multi-pointer, so pen proximity is the discriminator.
- A pinch already in flight when the pen engages is cancelled cleanly (reverts to the committed zoom, no smeared preview).
- Any in-flight minimap latch is dropped in the same branch, so a pen-interrupted minimap drag doesn't swallow the next finger gesture.
- A deliberate two-finger pinch still zooms once the pen is lifted away (past the 1 s palm window).

No Rust core change; Kotlin-only. The core stays host-green.

## Tests
- New host-JVM tests for `isPenActive` (hover / mid-stroke / exact reject-window boundary `<=` / one-ms-past / idle).
- Regression guard that the `isPalm` refactor is behaviour-preserving (truth table unchanged).
- Full `PalmFilterTest`: **16/16 pass**.

## Review
Three independent review passes (correctness/concurrency, behavioural regression, design/DRY/tests) over two rounds — **unanimous SHIP**. The synthetic-`ACTION_CANCEL` revert path was verified against AOSP `ScaleGestureDetector`; the minimap-latch fix was verified safe (pan is committed synchronously in `navigateMinimap`, so the omitted final `applyZoom` is harmless).

## Manual test on device (Supernote Nomad)
- Write with the hand resting on the glass → page stays put (no zoom).
- Lift pen, pinch → zooms normally.
- Minimap drag / +- when zoomed, including right after writing → behaves; no swallowed gesture.