### PR TITLE
feat(core): add plain-text (.txt) reader backend (closes #35)

### DIFF
--- a/reader-core/src/document/format.rs
+++ b/reader-core/src/document/format.rs
@@ -10,13 +10,16 @@
 use std::path::Path;
 
 /// The backends the open path can dispatch to. `Pdf` is the fixed-layout backend
-/// ([`super::fixed::PdfBackend`]); `Epub` is the reflowable backend ([`super::reflow`]).
+/// ([`super::fixed::PdfBackend`]); `Epub` ([`super::reflow`]) and `Text` ([`super::plain`]) are the
+/// reflowable backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DocFormat {
     /// Fixed-layout PDF.
     Pdf,
     /// Reflowable EPUB (a ZIP container).
     Epub,
+    /// Plain text (`.txt`/`.text`). Has no magic signature — identified by extension only.
+    Text,
 }
 
 /// PDF header marker (ISO 32000): a conforming file begins with `%PDF-`.
@@ -30,7 +33,8 @@ impl DocFormat {
     /// This is the authoritative signal: a positive match here is trusted over the extension, so a
     /// mislabeled file still opens with the right backend. A ZIP container is reported as [`Self::Epub`]
     /// (the only ZIP-based backend today). PDFs that carry leading junk before `%PDF-` (tolerated by
-    /// the spec) won't match here and fall back to the extension in [`Self::resolve`].
+    /// the spec) won't match here and fall back to the extension in [`Self::resolve`]. Plain text has
+    /// no reliable signature, so [`Self::Text`] is never sniffed — it is identified by extension only.
     pub(crate) fn sniff(bytes: &[u8]) -> Option<DocFormat> {
         if bytes.starts_with(PDF_MAGIC) {
             Some(DocFormat::Pdf)
@@ -49,6 +53,8 @@ impl DocFormat {
             Some(DocFormat::Pdf)
         } else if ext.eq_ignore_ascii_case("epub") {
             Some(DocFormat::Epub)
+        } else if ext.eq_ignore_ascii_case("txt") || ext.eq_ignore_ascii_case("text") {
+            Some(DocFormat::Text)
         } else {
             None
         }
@@ -159,6 +165,34 @@ mod tests {
     fn resolve_defaults_to_pdf_when_nothing_matches() {
         assert_eq!(
             DocFormat::resolve("mystery", b"unrecognized bytes"),
+            DocFormat::Pdf
+        );
+    }
+
+    #[test]
+    fn from_extension_identifies_plain_text() {
+        assert_eq!(
+            DocFormat::from_extension("notes.txt"),
+            Some(DocFormat::Text)
+        );
+        assert_eq!(
+            DocFormat::from_extension("README.TXT"),
+            Some(DocFormat::Text)
+        );
+        assert_eq!(DocFormat::from_extension("a/b.text"), Some(DocFormat::Text));
+    }
+
+    #[test]
+    fn resolve_uses_extension_for_text_which_has_no_magic() {
+        // Plain text has no signature, so resolution is by extension.
+        assert_eq!(DocFormat::sniff(b"hello world"), None);
+        assert_eq!(
+            DocFormat::resolve("notes.txt", b"hello world"),
+            DocFormat::Text
+        );
+        // Magic still wins over a `.txt` name (a PDF saved as .txt opens as PDF).
+        assert_eq!(
+            DocFormat::resolve("mislabeled.txt", &pdf_bytes()),
             DocFormat::Pdf
         );
     }

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod fixed;
 pub mod format;
+pub mod plain;
 pub mod reflow;
 pub(crate) mod reflow_view;
 pub mod text_select;

--- a/reader-core/src/document/plain.rs
+++ b/reader-core/src/document/plain.rs
@@ -1,0 +1,277 @@
+//! Plain-text (`.txt`) backend behind the [`Document`] trait (RR2-FR5).
+//!
+//! Plain text has no layout of its own, so this backend does the cheapest possible thing: split the
+//! file into paragraphs and hand them to the **existing reflow engine** ([`ReflowView`]) as a single
+//! reflowable unit. Pagination, font-size / line-spacing / alignment, text selection, and search all
+//! come from the shared `inkread-epub` layout pipeline verbatim — there is **no new layout code**
+//! here (REUSE-FIRST). The only plain-text-specific logic is the paragraph splitter.
+//!
+//! Blank lines separate paragraphs; a single newline inside a paragraph is a soft wrap (joined with a
+//! space and re-wrapped to the viewport), matching how a reader expects flowed prose to behave.
+
+use inkread_epub::{Block, Inline, TextRun};
+
+use crate::document::reflow_view::ReflowView;
+use crate::document::text_select::{self, NormRect, TextSelection};
+use crate::document::{Document, DocumentMetadata, SearchMatch};
+use crate::error::{CoreError, CoreResult};
+use crate::render::{PixelBuffer, Viewport};
+
+/// The plain-text backend: a reflow view over the file's paragraphs. Title/author are unknown for a
+/// bare `.txt`, so the metadata is empty.
+pub struct PlainBackend {
+    view: ReflowView,
+    meta: DocumentMetadata,
+}
+
+impl PlainBackend {
+    /// Decode `bytes` as UTF-8, split into paragraphs, and build a reflowable view for `viewport`.
+    /// Invalid UTF-8 is rejected at the boundary with a typed error — never a panic (RR21-FR3).
+    pub fn open(bytes: Vec<u8>, viewport: Viewport) -> CoreResult<Self> {
+        let text = String::from_utf8(bytes)
+            .map_err(|_| CoreError::InvalidArgument("text file is not valid UTF-8".into()))?;
+        let blocks = paragraphs_to_blocks(&text);
+        // One reflowable unit = the whole file; the engine paginates it to the viewport.
+        let view = ReflowView::new(vec![blocks], viewport.width, viewport.height);
+        Ok(Self {
+            view,
+            meta: DocumentMetadata::default(),
+        })
+    }
+}
+
+impl Document for PlainBackend {
+    fn page_count(&self) -> usize {
+        self.view.page_count()
+    }
+
+    fn metadata(&self) -> DocumentMetadata {
+        self.meta.clone()
+    }
+
+    fn render_page(&self, index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+        self.view.render(index, buf)
+    }
+
+    fn word_at(&self, page: usize, x: f32, y: f32) -> Option<TextSelection> {
+        text_select::word_at(&self.view.page_chars(page), x, y)
+    }
+
+    fn text_in_rect(&self, page: usize, rect: NormRect) -> TextSelection {
+        text_select::text_in_rect(&self.view.page_chars(page), rect)
+    }
+
+    fn search_page(&self, page: usize, query: &str) -> Vec<SearchMatch> {
+        text_select::find_matches(&self.view.page_chars(page), query)
+    }
+
+    fn set_text_scale(&self, scale: f32, current_page: usize) -> Option<usize> {
+        Some(self.view.set_scale(scale, current_page))
+    }
+
+    fn set_line_spacing(&self, mult: f32, current_page: usize) -> Option<usize> {
+        Some(self.view.set_line_spacing(mult, current_page))
+    }
+
+    fn set_alignment(&self, align_code: i32, current_page: usize) -> Option<usize> {
+        Some(self.view.set_alignment(align_code, current_page))
+    }
+}
+
+/// Split plain text into paragraph [`Block`]s. A blank line ends a paragraph; the lines within a
+/// paragraph are joined with a space (soft wrap). Whitespace-only input yields no blocks — the
+/// reflow engine still renders a single blank page (no panic).
+///
+/// Iterating with [`str::lines`] keeps peak memory at ~1× the input (it borrows slices and strips a
+/// trailing `\r`, so both `\n` and `\r\n` endings work) rather than allocating normalized copies of
+/// an up-to-2 GiB file. Trade-off: a classic-Mac file with bare-`\r` line endings (extinct since
+/// ~2001) is treated as a single line. Per-line [`str::trim`] also normalizes away leading
+/// indentation and Unicode-space-only lines — acceptable for flowed prose, lossy for ASCII art /
+/// code listings (out of scope for a `.txt` reader).
+fn paragraphs_to_blocks(text: &str) -> Vec<Block> {
+    let mut blocks = Vec::new();
+    let mut para = String::new();
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            push_paragraph(&mut blocks, &mut para);
+        } else {
+            if !para.is_empty() {
+                para.push(' ');
+            }
+            para.push_str(line.trim());
+        }
+    }
+    push_paragraph(&mut blocks, &mut para);
+    blocks
+}
+
+/// Flush the accumulated paragraph text into a [`Block::Paragraph`] (dropping an empty one) and reset
+/// the buffer.
+fn push_paragraph(blocks: &mut Vec<Block>, para: &mut String) {
+    let text = para.trim();
+    if !text.is_empty() {
+        blocks.push(Block::Paragraph {
+            content: vec![Inline::Run(TextRun {
+                text: text.to_string(),
+                bold: false,
+                italic: false,
+                href: None,
+            })],
+        });
+    }
+    para.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn viewport() -> Viewport {
+        Viewport {
+            width: 1404,
+            height: 1872,
+            dpi: 226,
+        }
+    }
+
+    /// Concatenate a paragraph block's text runs (test helper).
+    fn block_text(b: &Block) -> String {
+        match b {
+            Block::Paragraph { content } => content
+                .iter()
+                .filter_map(|i| match i {
+                    Inline::Run(r) => Some(r.text.as_str()),
+                    _ => None,
+                })
+                .collect(),
+            _ => String::new(),
+        }
+    }
+
+    #[test]
+    fn paragraphs_split_on_blank_lines() {
+        let blocks = paragraphs_to_blocks("First para.\n\nSecond para.");
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(block_text(&blocks[0]), "First para.");
+        assert_eq!(block_text(&blocks[1]), "Second para.");
+    }
+
+    #[test]
+    fn single_newline_is_a_soft_wrap() {
+        let blocks = paragraphs_to_blocks("line one\nline two");
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(block_text(&blocks[0]), "line one line two");
+    }
+
+    #[test]
+    fn crlf_and_multiple_blank_lines_collapse() {
+        assert_eq!(paragraphs_to_blocks("a\r\n\r\nb").len(), 2);
+        assert_eq!(paragraphs_to_blocks("a\n\n\n\nb").len(), 2);
+    }
+
+    #[test]
+    fn leading_and_trailing_blank_lines_make_no_empty_paragraphs() {
+        let blocks = paragraphs_to_blocks("\n\nbody\n\n");
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(block_text(&blocks[0]), "body");
+    }
+
+    #[test]
+    fn a_whitespace_only_line_separates_paragraphs() {
+        // A line that is only spaces/tabs acts as a blank-line separator.
+        let blocks = paragraphs_to_blocks("a\n   \nb");
+        assert_eq!(blocks.len(), 2);
+    }
+
+    #[test]
+    fn bare_cr_is_treated_as_a_single_line() {
+        // `str::lines()` does not split on a classic-Mac bare `\r`; documented trade-off.
+        let blocks = paragraphs_to_blocks("one\rtwo");
+        assert_eq!(blocks.len(), 1);
+    }
+
+    #[test]
+    fn whitespace_only_yields_no_blocks() {
+        assert!(paragraphs_to_blocks("   \n  \n\t").is_empty());
+        assert!(paragraphs_to_blocks("").is_empty());
+    }
+
+    #[test]
+    fn open_rejects_non_utf8() {
+        // `matches!` (not `unwrap_err`) so the test needs no `Debug` on the backend.
+        assert!(matches!(
+            PlainBackend::open(vec![0xff, 0xfe, 0x00], viewport()),
+            Err(CoreError::InvalidArgument(_))
+        ));
+    }
+
+    #[test]
+    fn open_empty_file_is_one_blank_page() {
+        let doc = PlainBackend::open(Vec::new(), viewport()).unwrap();
+        assert_eq!(doc.page_count(), 1);
+        assert_eq!(doc.metadata(), DocumentMetadata::default());
+        // Render must succeed (blank page), and an out-of-range page is a typed error, not a panic.
+        let mut bytes = vec![0u8; 1404 * 1872 * 4];
+        let mut buf = PixelBuffer::from_rgba(&mut bytes, 1404, 1872).unwrap();
+        assert!(doc.render_page(0, &mut buf).is_ok());
+        assert!(doc.render_page(99, &mut buf).is_err());
+    }
+
+    #[test]
+    fn metadata_is_empty_for_bare_txt() {
+        let doc = PlainBackend::open(b"hello".to_vec(), viewport()).unwrap();
+        assert_eq!(doc.metadata().title, None);
+        assert_eq!(doc.metadata().author, None);
+    }
+
+    #[test]
+    fn reflow_controls_are_supported() {
+        let doc = PlainBackend::open(b"some flowing text".to_vec(), viewport()).unwrap();
+        // Reflowable backend: each control returns a preserved-position page (Some), not None.
+        assert!(doc.set_text_scale(1.5, 0).is_some());
+        assert!(doc.set_line_spacing(1.7, 0).is_some());
+        assert!(doc.set_alignment(1, 0).is_some());
+    }
+
+    #[test]
+    fn search_finds_text_through_the_reused_pipeline() {
+        let doc = PlainBackend::open(b"the quick brown fox jumps".to_vec(), viewport()).unwrap();
+        assert!(
+            !doc.search_page(0, "brown").is_empty(),
+            "a present word should be found via the shared search path"
+        );
+        assert!(
+            doc.search_page(0, "zebra").is_empty(),
+            "an absent word should yield no matches"
+        );
+    }
+
+    #[test]
+    fn text_in_rect_selects_the_page_body() {
+        let doc = PlainBackend::open(b"alpha beta gamma".to_vec(), viewport()).unwrap();
+        let whole_page = NormRect {
+            x0: 0.0,
+            y0: 0.0,
+            x1: 1.0,
+            y1: 1.0,
+        };
+        let sel = doc.text_in_rect(0, whole_page);
+        assert!(
+            sel.text.contains("alpha") && sel.text.contains("gamma"),
+            "a full-page rect should select the body text, got {:?}",
+            sel.text
+        );
+    }
+
+    #[test]
+    fn word_at_returns_the_word_under_a_glyph() {
+        let doc = PlainBackend::open(b"hello world".to_vec(), viewport()).unwrap();
+        // Aim at the centre of the first glyph (the `view` field is reachable from the same module).
+        let chars = doc.view.page_chars(0);
+        let first = chars.first().expect("laid-out text has glyphs");
+        let cx = (first.rect.x0 + first.rect.x1) / 2.0;
+        let cy = (first.rect.y0 + first.rect.y1) / 2.0;
+        let sel = doc.word_at(0, cx, cy).expect("a glyph centre hits a word");
+        assert!(!sel.text.is_empty());
+    }
+}

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -146,6 +146,7 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeOpenDocumen
 
         let opened = match DocFormat::resolve(&path, &bytes) {
             DocFormat::Epub => ReaderSession::open_epub(bytes, caps, viewport),
+            DocFormat::Text => ReaderSession::open_txt(bytes, caps, viewport),
             DocFormat::Pdf => ReaderSession::open_pdf(bytes, caps, viewport),
         };
         match opened {
@@ -222,6 +223,9 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeOpenDocumen
         let opened = match DocFormat::resolve(&path, &bytes) {
             DocFormat::Epub => {
                 ReaderSession::open_epub_with_store(bytes, caps, viewport, store, book)
+            }
+            DocFormat::Text => {
+                ReaderSession::open_txt_with_store(bytes, caps, viewport, store, book)
             }
             DocFormat::Pdf => {
                 ReaderSession::open_pdf_with_store(bytes, caps, viewport, store, book)

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -200,6 +200,39 @@ impl ReaderSession {
         Ok(session)
     }
 
+    /// Open a plain-text file from bytes and build a session (RR2-FR5). Reflowable like EPUB: the
+    /// paragraphs are paginated to the viewport and repaginate if it (or the font size) changes.
+    pub fn open_txt(
+        bytes: Vec<u8>,
+        caps: DeviceCapabilities,
+        viewport: Viewport,
+    ) -> CoreResult<Self> {
+        let fingerprint = crate::persistence::identity::fingerprint(&bytes);
+        let size = bytes.len() as u64;
+        let document = crate::document::plain::PlainBackend::open(bytes, viewport)?;
+        let meta = document.metadata();
+        let identity = Some(DocIdentity {
+            fingerprint,
+            size,
+            title: meta.title,
+            author: meta.author,
+        });
+        Ok(Self::assemble(Box::new(document), caps, viewport, identity))
+    }
+
+    /// Open a plain-text file and attach a persistence store, resuming the saved position for `book`.
+    pub fn open_txt_with_store(
+        bytes: Vec<u8>,
+        caps: DeviceCapabilities,
+        viewport: Viewport,
+        store: Arc<dyn ReaderStore>,
+        book: BookId,
+    ) -> CoreResult<Self> {
+        let mut session = Self::open_txt(bytes, caps, viewport)?;
+        session.attach_store(store, book)?;
+        Ok(session)
+    }
+
     /// The single session constructor — every `open_*`/`with_document` path routes through this so
     /// the field initialization lives in one place (initial page 0; policy sized to the viewport).
     fn assemble(


### PR DESCRIPTION
Closes #35.

> **Stacked on #43** (`feat/format-detection`). Base is `feat/format-detection`, not `master`, so the diff shows only the `.txt` work. Will retarget to `master` once #43 merges.

## What

Adds a plain-text (`.txt` / `.text`) reader backend. It reuses the existing reflow engine end-to-end — **no new layout code**:

- `PlainBackend` (`reader-core/src/document/plain.rs`) splits the file into paragraphs and feeds them to `ReflowView` (the engine extracted for PDF reflow) as one reflowable unit. Pagination, font-size / line-spacing / alignment, text selection, and search all come from the shared `inkread-epub` pipeline.
- Paragraph rules: a blank line ends a paragraph; a single newline is a soft wrap. Invalid UTF-8 is rejected at the boundary with a typed error (never a panic); an empty file renders one blank page.
- `DocFormat` gains a `Text` variant — **extension-only** (plain text has no magic signature, so `sniff` never returns it; a PDF/EPUB mislabeled `.txt` still opens with the correct backend because magic wins). Both JNI open paths dispatch the new variant through the exhaustive `match`, and `session.rs` gains `open_txt` / `open_txt_with_store` mirroring the EPUB paths.

## Three-reviewer audit (correctness / security / quality)

Reviewed by three independent agents. Verdicts: quality **SHIP**; correctness & security **SHIP-WITH-NITS**. All findings folded in:

- **[security, MAJOR — fixed]** The original splitter used `text.replace("\r\n","\n").replace('\r',"\n")`, which `str::replace` allocates unconditionally → ~3× transient memory on every `.txt` (~6 GiB at the 2 GiB open cap → realistic OOM on RK3566). Rewrote `paragraphs_to_blocks` to iterate `str::lines()` (~1× memory, still handles LF/CRLF). **Trade-off:** classic-Mac bare-`\r` files (extinct since ~2001) are treated as a single line — documented, with a test pinning it.
- **[correctness, minor — fixed]** Documented that per-line `trim` normalizes away indentation / Unicode-space-only lines (acceptable for prose, lossy for ASCII art). Added splitter tests: leading/trailing blank lines, whitespace-line separator, bare-`\r`.
- **[quality]** Clean — "minimal surface, genuine reuse, honest tests."

## Known limitation (follow-up)

UTF-16 / Latin-1 `.txt` files are rejected as "not valid UTF-8" rather than rendered. Reasonable to file as a follow-up (BOM sniff + transcode) if desired — out of scope here.

## Gates

- `cargo fmt` ✓ · `cargo clippy --all -- -D warnings` ✓ (host **and** `--features jni-bridge`) · `cargo test --workspace` ✓ (227 passed)
- `cargo llvm-cov`: `plain.rs` 100% function / ~97% line (the few misses are defensive arms in a test-only helper).
