### PR TITLE
feat(core): reflow-stable PinPosition locator + EPUB source-anchor threading (RR6, ADR-0012 Phase 1)

### DIFF
--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -97,6 +97,22 @@ impl LayoutOpts {
     }
 }
 
+/// A reflow-stable source anchor for a placed run/glyph (ADR-INKREAD-0012; feeds RR6 `PinPosition`).
+///
+/// `block` is the reading-order index of the source [`Block`](crate::content::Block) in the chapter
+/// (the v1 `xpath` — stable because reflow never reorders blocks). `char_offset` is the
+/// **chapter-relative** character offset of the run's (or this glyph's) first character. Both are
+/// derived from character counts, **not pixels**, so they are invariant under a font-size / margin /
+/// alignment change — the property a highlight or Digest entry needs to re-resolve to the same text
+/// after the page reflows (golden `SPEC-INKREAD.md` RR8-FR2/AC1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SourceAnchor {
+    /// Reading-order index of the source block in the chapter.
+    pub block: usize,
+    /// Chapter-relative character offset of the first character.
+    pub char_offset: usize,
+}
+
 /// A positioned run of text on a line. `x`/`top` are relative to the page's **content origin** (the
 /// top-left after the margin); the renderer adds `opts.margin`. Baseline ≈ `top + size_px`.
 #[derive(Debug, Clone, PartialEq)]
@@ -107,6 +123,8 @@ pub struct PlacedRun {
     pub bold: bool,
     pub italic: bool,
     pub href: Option<String>,
+    /// Source anchor of this run's first character (ADR-INKREAD-0012).
+    pub anchor: SourceAnchor,
 }
 
 /// One laid-out line: its `top` (content-relative), `height` (the line box), and positioned runs.
@@ -141,15 +159,26 @@ fn heading_scale(level: u8) -> f32 {
 #[must_use]
 pub fn paginate(blocks: &[Block], opts: &LayoutOpts, m: &dyn Metrics) -> Vec<Page> {
     let mut pager = Pager::new(opts);
-    for block in blocks {
+    // Chapter-relative character cursor, advanced as source text is consumed in reading order, so
+    // every placed run/glyph carries a font-invariant offset (ADR-INKREAD-0012).
+    let mut cursor = 0usize;
+    for (block_index, block) in blocks.iter().enumerate() {
         match block {
             Block::Heading { level, content } => {
                 let size = opts.font_px * heading_scale(*level);
-                pager.add_paragraph(content, size, 0.0, true, m);
+                pager.add_paragraph(content, size, 0.0, true, block_index, &mut cursor, m);
                 pager.gap(opts.para_gap);
             }
             Block::Paragraph { content } => {
-                pager.add_paragraph(content, opts.font_px, 0.0, false, m);
+                pager.add_paragraph(
+                    content,
+                    opts.font_px,
+                    0.0,
+                    false,
+                    block_index,
+                    &mut cursor,
+                    m,
+                );
                 pager.gap(opts.para_gap);
             }
             Block::ListItem {
@@ -162,7 +191,7 @@ pub fn paginate(blocks: &[Block], opts: &LayoutOpts, m: &dyn Metrics) -> Vec<Pag
                 } else {
                     "•".to_string()
                 };
-                pager.add_list_item(&marker, content, opts.font_px, m);
+                pager.add_list_item(&marker, content, opts.font_px, block_index, &mut cursor, m);
                 pager.gap(opts.para_gap * 0.4);
             }
             Block::Image { alt, .. } => {
@@ -179,7 +208,7 @@ pub fn paginate(blocks: &[Block], opts: &LayoutOpts, m: &dyn Metrics) -> Vec<Pag
                     italic: true,
                     href: None,
                 })];
-                pager.add_paragraph(&run, opts.font_px, 0.0, false, m);
+                pager.add_paragraph(&run, opts.font_px, 0.0, false, block_index, &mut cursor, m);
                 pager.gap(opts.para_gap);
             }
             Block::Rule => pager.add_rule(opts.para_gap),
@@ -244,15 +273,28 @@ impl<'o> Pager<'o> {
     }
 
     /// Lay out a paragraph/heading: greedy-break its inlines to the content width and emit lines.
+    /// `cursor` is the chapter-relative character offset, advanced as the inlines are consumed.
+    #[allow(clippy::too_many_arguments)]
     fn add_paragraph(
         &mut self,
         inlines: &[Inline],
         size: f32,
         indent: f32,
         bold_all: bool,
+        block: usize,
+        cursor: &mut usize,
         m: &dyn Metrics,
     ) {
-        let lines = break_lines(inlines, size, indent, self.opts.content_w(), bold_all, m);
+        let lines = break_lines(
+            inlines,
+            size,
+            indent,
+            self.opts.content_w(),
+            bold_all,
+            block,
+            cursor,
+            m,
+        );
         let line_h = size * self.opts.line_spacing;
         let n = lines.len();
         for (i, mut runs) in lines.into_iter().enumerate() {
@@ -268,10 +310,33 @@ impl<'o> Pager<'o> {
     }
 
     /// Lay out a list item with a hanging marker and indented body.
-    fn add_list_item(&mut self, marker: &str, inlines: &[Inline], size: f32, m: &dyn Metrics) {
+    fn add_list_item(
+        &mut self,
+        marker: &str,
+        inlines: &[Inline],
+        size: f32,
+        block: usize,
+        cursor: &mut usize,
+        m: &dyn Metrics,
+    ) {
         let marker_w = m.advance(marker, size, false, false);
         let indent = marker_w + m.advance("  ", size, false, false);
-        let mut lines = break_lines(inlines, size, indent, self.opts.content_w(), false, m);
+        // The marker is synthetic (not source text): it shares the body's start offset and does not
+        // consume cursor budget, so body offsets still map to source characters.
+        let marker_anchor = SourceAnchor {
+            block,
+            char_offset: *cursor,
+        };
+        let mut lines = break_lines(
+            inlines,
+            size,
+            indent,
+            self.opts.content_w(),
+            false,
+            block,
+            cursor,
+            m,
+        );
         // Prepend the marker to the first line at the content origin (hanging indent).
         if let Some(first) = lines.first_mut() {
             first.insert(
@@ -283,6 +348,7 @@ impl<'o> Pager<'o> {
                     bold: false,
                     italic: false,
                     href: None,
+                    anchor: marker_anchor,
                 },
             );
         } else {
@@ -293,6 +359,7 @@ impl<'o> Pager<'o> {
                 bold: false,
                 italic: false,
                 href: None,
+                anchor: marker_anchor,
             }]);
         }
         let line_h = size * self.opts.line_spacing;
@@ -309,25 +376,37 @@ impl<'o> Pager<'o> {
     }
 }
 
-/// A line-breaking token.
+/// A line-breaking token. `Word`s carry their source [`SourceAnchor`] so it can be stamped onto the
+/// resulting [`PlacedRun`].
 enum Tok<'a> {
     Word {
         text: &'a str,
         bold: bool,
         italic: bool,
         href: Option<&'a str>,
+        anchor: SourceAnchor,
     },
     Space,
     Break,
 }
 
 /// Flatten inlines into words/spaces/breaks, preserving inter-run spacing (text is already
-/// whitespace-collapsed by Phase 2, so a single ASCII space separates words).
-fn tokenize(inlines: &[Inline], bold_all: bool) -> Vec<Tok<'_>> {
+/// whitespace-collapsed by Phase 2, so a single ASCII space separates words). `cursor` advances by
+/// the chapter-relative character count as words and the spaces/breaks between them are consumed, so
+/// each word's [`SourceAnchor`] records where its first character sits (ADR-INKREAD-0012).
+fn tokenize<'a>(
+    inlines: &'a [Inline],
+    bold_all: bool,
+    block: usize,
+    cursor: &mut usize,
+) -> Vec<Tok<'a>> {
     let mut toks = Vec::new();
     for inline in inlines {
         match inline {
-            Inline::Break => toks.push(Tok::Break),
+            Inline::Break => {
+                toks.push(Tok::Break);
+                *cursor += 1; // the <br> occupies one character position
+            }
             Inline::Image { alt, .. } => {
                 let label = if alt.is_empty() { "[img]" } else { alt };
                 toks.push(Tok::Word {
@@ -335,12 +414,18 @@ fn tokenize(inlines: &[Inline], bold_all: bool) -> Vec<Tok<'_>> {
                     bold: false,
                     italic: true,
                     href: None,
+                    anchor: SourceAnchor {
+                        block,
+                        char_offset: *cursor,
+                    },
                 });
+                *cursor += label.chars().count();
             }
             Inline::Run(r) => {
                 for (i, part) in r.text.split(' ').enumerate() {
                     if i > 0 {
                         toks.push(Tok::Space);
+                        *cursor += 1; // the single collapsed space between words
                     }
                     if !part.is_empty() {
                         toks.push(Tok::Word {
@@ -348,7 +433,12 @@ fn tokenize(inlines: &[Inline], bold_all: bool) -> Vec<Tok<'_>> {
                             bold: r.bold || bold_all,
                             italic: r.italic,
                             href: r.href.as_deref(),
+                            anchor: SourceAnchor {
+                                block,
+                                char_offset: *cursor,
+                            },
                         });
+                        *cursor += part.chars().count();
                     }
                 }
             }
@@ -400,12 +490,15 @@ fn align_line(
 /// Greedy line-break: returns each line as its positioned runs (x relative to content origin; the
 /// body is offset by `indent`). Words wider than the available width are placed on their own line
 /// (not split — hyphenation is a later refinement).
+#[allow(clippy::too_many_arguments)]
 fn break_lines(
     inlines: &[Inline],
     size: f32,
     indent: f32,
     content_w: f32,
     bold_all: bool,
+    block: usize,
+    cursor: &mut usize,
     m: &dyn Metrics,
 ) -> Vec<Vec<PlacedRun>> {
     let avail = (content_w - indent).max(1.0);
@@ -415,7 +508,7 @@ fn break_lines(
     let mut x = 0.0f32; // offset within the body column (excludes indent)
     let mut need_space = false;
 
-    for tok in tokenize(inlines, bold_all) {
+    for tok in tokenize(inlines, bold_all, block, cursor) {
         match tok {
             Tok::Break => {
                 if !cur.is_empty() {
@@ -430,6 +523,7 @@ fn break_lines(
                 bold,
                 italic,
                 href,
+                anchor,
             } => {
                 let ww = m.advance(text, size, bold, italic);
                 let place = |x: f32, cur: &mut Vec<PlacedRun>| {
@@ -440,6 +534,7 @@ fn break_lines(
                         bold,
                         italic,
                         href: href.map(str::to_string),
+                        anchor,
                     });
                 };
                 if cur.is_empty() {
@@ -610,5 +705,104 @@ mod tests {
     #[test]
     fn empty_blocks_make_no_pages() {
         assert!(paginate(&[], &LayoutOpts::new(400.0, 600.0, 16.0), &Mono).is_empty());
+    }
+
+    /// Collect every placed run as `(block, char_offset, text)` in reading order.
+    fn run_anchors(pages: &[Page]) -> Vec<(usize, usize, String)> {
+        pages
+            .iter()
+            .flat_map(|p| p.lines.iter())
+            .flat_map(|l| l.runs.iter())
+            .map(|r| (r.anchor.block, r.anchor.char_offset, r.text.clone()))
+            .collect()
+    }
+
+    fn wide(font_px: f32) -> LayoutOpts {
+        LayoutOpts {
+            page_w: 100_000.0,
+            page_h: 100_000.0,
+            margin: 0.0,
+            font_px,
+            line_spacing: 1.0,
+            para_gap: 0.0,
+            align: Align::Left,
+        }
+    }
+
+    #[test]
+    fn run_anchors_track_chapter_character_offsets() {
+        // "alpha"(5)@0, space@5, "beta"(4)@6, space@10, "gamma"@11.
+        let pages = paginate(&[para("alpha beta gamma")], &wide(10.0), &Mono);
+        assert_eq!(
+            run_anchors(&pages),
+            vec![
+                (0, 0, "alpha".into()),
+                (0, 6, "beta".into()),
+                (0, 11, "gamma".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn block_index_increments_and_offset_continues_across_blocks() {
+        // block 0 "one two": one@0, two@4 → cursor 7; block 1 "three"@7.
+        let pages = paginate(&[para("one two"), para("three")], &wide(10.0), &Mono);
+        assert_eq!(
+            run_anchors(&pages),
+            vec![
+                (0, 0, "one".into()),
+                (0, 4, "two".into()),
+                (1, 7, "three".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_marker_shares_body_offset_and_does_not_consume_budget() {
+        let pages = paginate(
+            &[
+                Block::ListItem {
+                    ordered: true,
+                    index: 1,
+                    content: vec![Inline::Run(TextRun {
+                        text: "first".into(),
+                        bold: false,
+                        italic: false,
+                        href: None,
+                    })],
+                },
+                para("after"),
+            ],
+            &LayoutOpts::new(1000.0, 1000.0, 10.0),
+            &Mono,
+        );
+        let anchors = run_anchors(&pages);
+        // Marker "1." and body "first" both anchor at offset 0 of block 0; the marker adds no budget,
+        // so "after" (block 1) starts at 5 (= len("first")), not 7.
+        assert_eq!(anchors[0], (0, 0, "1.".into()), "marker shares body start");
+        assert_eq!(anchors[1], (0, 0, "first".into()), "body at block start");
+        assert_eq!(
+            anchors[2],
+            (1, 5, "after".into()),
+            "marker consumed no offset"
+        );
+    }
+
+    #[test]
+    fn run_anchors_are_font_size_invariant() {
+        // Wrapping differs by size, but each word keeps its (block, char_offset) — the reflow-stable
+        // property a highlight/Digest anchor relies on (ADR-INKREAD-0012).
+        let blocks = [
+            para("the quick brown fox jumps over"),
+            para("the lazy dog sleeps soundly"),
+        ];
+        let narrow = |fp: f32| {
+            let opts = LayoutOpts {
+                page_w: 60.0,
+                ..wide(fp)
+            };
+            run_anchors(&paginate(&blocks, &opts, &Mono))
+        };
+        assert_eq!(narrow(10.0), narrow(20.0));
     }
 }

--- a/inkread-epub/src/render.rs
+++ b/inkread-epub/src/render.rs
@@ -16,7 +16,7 @@
 
 use ab_glyph::{point, Font, FontVec, PxScale, ScaleFont};
 
-use crate::layout::{LayoutOpts, Metrics, Page};
+use crate::layout::{LayoutOpts, Metrics, Page, SourceAnchor};
 
 /// The bundled default reading face — Spectral Regular (SIL OFL 1.1; see `fonts/OFL.txt`).
 const DEFAULT_FONT: &[u8] = include_bytes!("../fonts/Spectral-Regular.ttf");
@@ -150,6 +150,10 @@ pub struct PlacedGlyph {
     pub y0: f32,
     pub x1: f32,
     pub y1: f32,
+    /// Reflow-stable source anchor of this glyph (ADR-INKREAD-0012): the run's `block` and the
+    /// glyph's chapter-relative `char_offset`. Lets `reader-core` mint a `PinPosition` from a
+    /// selection or a page's first glyph.
+    pub anchor: SourceAnchor,
 }
 
 /// Extract a laid-out [`Page`]'s glyphs as positioned boxes (pixel space), walking runs **exactly**
@@ -166,12 +170,13 @@ pub fn page_glyphs(page: &Page, opts: &LayoutOpts, font: &AbFont) -> Vec<PlacedG
         }
         let y0 = margin + line.top;
         let y1 = y0 + line.height;
-        let mut prev_run_end: Option<f32> = None;
+        let mut prev_run_end: Option<(f32, SourceAnchor)> = None;
         for run in &line.runs {
             let sf = font.font.as_scaled(PxScale::from(run.size_px));
             let run_start = margin + run.x;
-            // Bridge the gap to the previous run on this line with a space glyph.
-            if let Some(end) = prev_run_end {
+            // Bridge the gap to the previous run on this line with a space glyph, anchored just past
+            // the previous run's last character (its char_offset + its length = the space position).
+            if let Some((end, prev_anchor)) = prev_run_end {
                 if run_start > end {
                     out.push(PlacedGlyph {
                         ch: ' ',
@@ -179,12 +184,14 @@ pub fn page_glyphs(page: &Page, opts: &LayoutOpts, font: &AbFont) -> Vec<PlacedG
                         y0,
                         x1: run_start,
                         y1,
+                        anchor: prev_anchor,
                     });
                 }
             }
             let mut pen_x = run_start;
             let mut prev = None;
-            for ch in run.text.chars() {
+            // The glyph's chapter-relative offset = the run's first-char offset + its index in the run.
+            for (i, ch) in run.text.chars().enumerate() {
                 let id = font.font.glyph_id(ch);
                 if let Some(p) = prev {
                     pen_x += sf.kern(p, id);
@@ -196,11 +203,19 @@ pub fn page_glyphs(page: &Page, opts: &LayoutOpts, font: &AbFont) -> Vec<PlacedG
                     y0,
                     x1: pen_x + adv,
                     y1,
+                    anchor: SourceAnchor {
+                        block: run.anchor.block,
+                        char_offset: run.anchor.char_offset + i,
+                    },
                 });
                 pen_x += adv;
                 prev = Some(id);
             }
-            prev_run_end = Some(pen_x);
+            let run_end_anchor = SourceAnchor {
+                block: run.anchor.block,
+                char_offset: run.anchor.char_offset + run.text.chars().count(),
+            };
+            prev_run_end = Some((pen_x, run_end_anchor));
         }
     }
     out
@@ -279,6 +294,50 @@ mod tests {
             .take_while(|g| g.ch != ' ')
             .collect::<Vec<_>>();
         assert!(first_word.windows(2).all(|w| w[0].x0 <= w[1].x0));
+    }
+
+    #[test]
+    fn glyph_anchors_index_the_chapter_text() {
+        // On one line each glyph's char_offset equals its position in the rejoined text (words +
+        // single inter-word spaces), and all sit in block 0.
+        let font = AbFont::default_font();
+        let opts = LayoutOpts::new(4000.0, 600.0, 18.0);
+        let pages = paginate(&[paragraph("Hello reflowed world")], &opts, &font);
+        let glyphs = page_glyphs(&pages[0], &opts, &font);
+        assert_eq!(glyphs.len(), "Hello reflowed world".chars().count());
+        for (i, g) in glyphs.iter().enumerate() {
+            assert_eq!(g.anchor.block, 0);
+            assert_eq!(g.anchor.char_offset, i, "glyph {:?} at {i}", g.ch);
+        }
+    }
+
+    #[test]
+    fn glyph_anchors_are_stable_across_font_size() {
+        // The headline property (RR8-AC1 / ADR-INKREAD-0012): a character keeps its
+        // (block, char_offset) when the page reflows at a different size, so a highlight/Digest
+        // re-resolves to the same text. Synthesized inter-word spaces are layout-dependent and
+        // excluded; word characters must agree exactly.
+        let font = AbFont::default_font();
+        let blocks = [
+            paragraph("The quick brown fox jumps over"),
+            paragraph("the lazy dog sleeps soundly now"),
+        ];
+        let collect = |fp: f32| -> std::collections::BTreeMap<(usize, usize), char> {
+            let opts = LayoutOpts::new(220.0, 400.0, fp);
+            paginate(&blocks, &opts, &font)
+                .iter()
+                .flat_map(|p| page_glyphs(p, &opts, &font))
+                .filter(|g| g.ch != ' ')
+                .map(|g| ((g.anchor.block, g.anchor.char_offset), g.ch))
+                .collect()
+        };
+        let small = collect(13.0);
+        let large = collect(26.0);
+        assert!(!small.is_empty());
+        assert_eq!(
+            small, large,
+            "a glyph keeps its (block, char_offset) across a font-size change"
+        );
     }
 
     #[test]

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -367,6 +367,8 @@ impl PdfBackend {
                     x1: nx0.max(nx1),
                     y1: ny_top.max(ny_bottom),
                 },
+                // Fixed-layout PDF: the page index is the anchor; no reflow anchor (ADR-0012).
+                anchor: None,
             });
         }
         out

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -13,7 +13,7 @@
 use std::cell::{Cell, RefCell};
 
 use inkread_epub::layout::{paginate, Align, LayoutOpts, Page};
-use inkread_epub::render::{page_glyphs, render_page as raster_page, AbFont, GrayCanvas};
+use inkread_epub::render::{render_page as raster_page, AbFont, GrayCanvas};
 use inkread_epub::{parse_blocks, Block, EpubPackage, NavPoint};
 
 use crate::document::text_select::{self, CharBox, NormRect, TextAnchor, TextSelection};
@@ -155,24 +155,8 @@ impl EpubBackend {
         let Some(page) = laid.pages.get(index) else {
             return Vec::new();
         };
-        let pw = laid.opts.page_w.max(1.0);
-        let ph = laid.opts.page_h.max(1.0);
-        page_glyphs(page, &laid.opts, &self.font)
-            .into_iter()
-            .map(|g| CharBox {
-                ch: g.ch,
-                rect: NormRect {
-                    x0: (g.x0 / pw).clamp(0.0, 1.0),
-                    y0: (g.y0 / ph).clamp(0.0, 1.0),
-                    x1: (g.x1 / pw).clamp(0.0, 1.0),
-                    y1: (g.y1 / ph).clamp(0.0, 1.0),
-                },
-                anchor: Some(TextAnchor {
-                    block: g.anchor.block,
-                    char_offset: g.anchor.char_offset,
-                }),
-            })
-            .collect()
+        // Shared with the PDF-reflow backend so the glyph→CharBox + anchor mapping lives once.
+        crate::document::reflow_view::page_charboxes(page, &laid.opts, &self.font)
     }
 
     /// Frame a chapter-relative [`TextAnchor`] into a full [`PinPosition`] (RR6) for `chapter`. The
@@ -209,8 +193,10 @@ impl EpubBackend {
     /// the pin's chapter, the last page whose first anchored glyph is at or before the pin's offset.
     #[allow(dead_code)]
     pub(crate) fn pin_to_page(&self, pin: &PinPosition) -> usize {
-        let chapter = pin.chapter_index.max(0) as usize;
         let laid = self.laid.borrow();
+        // Clamp a foreign/corrupt chapter index into range rather than scanning the whole book.
+        let chapter =
+            (pin.chapter_index.max(0) as usize).min(laid.chapter_start.len().saturating_sub(1));
         let start = laid.chapter_start.get(chapter).copied().unwrap_or(0);
         let end = laid
             .chapter_start
@@ -223,7 +209,10 @@ impl EpubBackend {
         for page in start..end {
             match self.page_chars(page).into_iter().find_map(|c| c.anchor) {
                 Some(a) if (a.char_offset as i32) <= target => best = page,
-                _ => break, // pages are in reading order; once we pass the target, stop
+                // A real anchor past the target → reading order says stop. An anchorless interior
+                // page (a rule-only or empty page) must NOT stop the scan: keep looking.
+                Some(_) => break,
+                None => continue,
             }
         }
         best

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -229,6 +229,19 @@ impl EpubBackend {
         best
     }
 
+    /// The `[start, end]` [`PinPosition`] pair a selection rectangle covers on `page` — the anchor a
+    /// highlight / note / Digest range stores (RR11-FR4 / RR12). `None` when nothing is selected.
+    #[allow(dead_code)]
+    pub(crate) fn selection_pins(
+        &self,
+        page: usize,
+        rect: NormRect,
+    ) -> Option<(PinPosition, PinPosition)> {
+        let chapter = self.chapter_of(page);
+        let (start, end) = text_select::anchored_span(&self.page_chars(page), rect)?;
+        Some((self.pin_at(chapter, start), self.pin_at(chapter, end)))
+    }
+
     /// The chapter index that global `page` falls in (the last chapter whose start ≤ page).
     fn chapter_of(&self, page: usize) -> usize {
         let laid = self.laid.borrow();
@@ -507,6 +520,30 @@ mod tests {
             pin.chapter_index.max(0) as usize
         );
         let _ = moved_page;
+    }
+
+    #[test]
+    fn selection_pins_span_in_order_and_survive_a_font_size_change() {
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        let _ = render(&b, 0, 400, 600);
+        // A band over the top of page 0 selects the opening lines.
+        let band = NormRect {
+            x0: 0.0,
+            y0: 0.0,
+            x1: 1.0,
+            y1: 0.5,
+        };
+        let (start, end) = b.selection_pins(0, band).expect("a selection on page 0");
+        assert!(start <= end, "start pin precedes end pin");
+        let (sc, ec) = (
+            char_at(&b, &start).expect("start char"),
+            char_at(&b, &end).expect("end char"),
+        );
+
+        // Reflow at a larger size: the same span endpoints re-resolve to the same characters.
+        b.set_text_scale(1.7, 0).unwrap();
+        assert_eq!(char_at(&b, &start), Some(sc), "start re-anchors");
+        assert_eq!(char_at(&b, &end), Some(ec), "end re-anchors");
     }
 
     #[test]

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -16,9 +16,10 @@ use inkread_epub::layout::{paginate, Align, LayoutOpts, Page};
 use inkread_epub::render::{page_glyphs, render_page as raster_page, AbFont, GrayCanvas};
 use inkread_epub::{parse_blocks, Block, EpubPackage, NavPoint};
 
-use crate::document::text_select::{self, CharBox, NormRect, TextSelection};
+use crate::document::text_select::{self, CharBox, NormRect, TextAnchor, TextSelection};
 use crate::document::{Document, DocumentMetadata, SearchMatch, TocEntry};
 use crate::error::{CoreError, CoreResult};
+use crate::position::PinPosition;
 use crate::render::PixelBuffer;
 
 /// Base body font size in device pixels at scale `1.0` (Supernote-class panel). The user's text
@@ -166,8 +167,66 @@ impl EpubBackend {
                     x1: (g.x1 / pw).clamp(0.0, 1.0),
                     y1: (g.y1 / ph).clamp(0.0, 1.0),
                 },
+                anchor: Some(TextAnchor {
+                    block: g.anchor.block,
+                    char_offset: g.anchor.char_offset,
+                }),
             })
             .collect()
+    }
+
+    /// Frame a chapter-relative [`TextAnchor`] into a full [`PinPosition`] (RR6) for `chapter`. The
+    /// backend owns the chapter identity; the offset is carried in `text_offset` so `position_int()`
+    /// orders within the chapter, and `xpath = [block]` re-anchors the source block (ADR-0012 D2).
+    //
+    // `pin_at`/`page_pin`/`pin_to_page` are the PinPosition composition foundation (ADR-0012 Phase 1,
+    // step 2). They are exercised by tests now and consumed in the follow-ups — selection→pin-pair
+    // and the RR12 reading-position resume / Digest wiring — hence `allow(dead_code)` until then.
+    #[allow(dead_code)]
+    fn pin_at(&self, chapter: usize, anchor: TextAnchor) -> PinPosition {
+        PinPosition {
+            chapter_index: chapter as i32,
+            chapter_id: self.chapter_keys.get(chapter).cloned().unwrap_or_default(),
+            chapter_start: 0,
+            chapter_end: i32::MAX,
+            node_position: 0,
+            text_offset: anchor.char_offset as i32,
+            xpath: vec![anchor.block as i32],
+        }
+    }
+
+    /// The [`PinPosition`] a global `page` starts at — its first anchored glyph (RR8/RR12 reading
+    /// position). `None` for an empty page (no glyphs to anchor).
+    #[allow(dead_code)]
+    pub(crate) fn page_pin(&self, page: usize) -> Option<PinPosition> {
+        let chapter = self.chapter_of(page);
+        let anchor = self.page_chars(page).into_iter().find_map(|c| c.anchor)?;
+        Some(self.pin_at(chapter, anchor))
+    }
+
+    /// Resolve a [`PinPosition`] back to the global page that contains it after a re-layout — the
+    /// re-anchoring that makes a highlight/Digest survive a font-size change (RR12-FR4). Picks, within
+    /// the pin's chapter, the last page whose first anchored glyph is at or before the pin's offset.
+    #[allow(dead_code)]
+    pub(crate) fn pin_to_page(&self, pin: &PinPosition) -> usize {
+        let chapter = pin.chapter_index.max(0) as usize;
+        let laid = self.laid.borrow();
+        let start = laid.chapter_start.get(chapter).copied().unwrap_or(0);
+        let end = laid
+            .chapter_start
+            .get(chapter + 1)
+            .copied()
+            .unwrap_or(laid.pages.len());
+        drop(laid);
+        let target = pin.text_offset.max(0);
+        let mut best = start;
+        for page in start..end {
+            match self.page_chars(page).into_iter().find_map(|c| c.anchor) {
+                Some(a) if (a.char_offset as i32) <= target => best = page,
+                _ => break, // pages are in reading order; once we pass the target, stop
+            }
+        }
+        best
     }
 
     /// The chapter index that global `page` falls in (the last chapter whose start ≤ page).
@@ -399,6 +458,55 @@ mod tests {
         assert_eq!(new_page, b.toc()[1].target_page.unwrap());
         // PDF-style fixed layout would return None; EPUB returns Some.
         assert!(b.set_text_scale(1.0, 0).is_some());
+    }
+
+    /// The source character a pin currently resolves to: the glyph on `pin_to_page(pin)` whose anchor
+    /// matches the pin's block + offset.
+    fn char_at(b: &EpubBackend, pin: &PinPosition) -> Option<char> {
+        let page = b.pin_to_page(pin);
+        b.page_chars(page).into_iter().find_map(|c| {
+            c.anchor.and_then(|a| {
+                (a.block as i32 == pin.xpath[0] && a.char_offset as i32 == pin.text_offset)
+                    .then_some(c.ch)
+            })
+        })
+    }
+
+    #[test]
+    fn page_pin_anchors_to_the_first_glyph_and_first_page_is_chapter_start() {
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        let _ = render(&b, 0, 400, 600);
+        let pin = b.page_pin(0).expect("page 0 has text");
+        assert_eq!(pin.chapter_index, 0, "page 0 is chapter 0");
+        // The pin resolves to the first character actually painted on page 0.
+        let first_ch = b.page_chars(0).into_iter().find(|c| c.anchor.is_some());
+        assert_eq!(char_at(&b, &pin), first_ch.map(|c| c.ch));
+    }
+
+    #[test]
+    fn pin_re_anchors_to_the_same_character_across_a_font_size_change() {
+        // The headline guarantee (golden SPEC-INKREAD.md RR8-AC1 / RR12-FR4): a pin minted at one
+        // size re-resolves to the *same source character* after the page reflows at a new size.
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        let _ = render(&b, 0, 400, 600);
+        // Mint a pin partway through chapter 2 so re-pagination genuinely moves it.
+        let ch2 = b.toc()[1].target_page.unwrap();
+        let pin = b.page_pin(ch2).or_else(|| b.page_pin(0)).expect("a pin");
+        let before = char_at(&b, &pin).expect("char before reflow");
+
+        let moved_page = b.set_text_scale(1.9, ch2).unwrap();
+        let after = char_at(&b, &pin).expect("char after reflow");
+
+        assert_eq!(
+            before, after,
+            "pin re-resolves to the same source character after reflow"
+        );
+        // Sanity: the pin still lands inside its own chapter under the new pagination.
+        assert_eq!(
+            b.chapter_of(b.pin_to_page(&pin)),
+            pin.chapter_index.max(0) as usize
+        );
+        let _ = moved_page;
     }
 
     #[test]

--- a/reader-core/src/document/reflow_view.rs
+++ b/reader-core/src/document/reflow_view.rs
@@ -17,7 +17,7 @@ use inkread_epub::layout::{paginate, Align, LayoutOpts, Page};
 use inkread_epub::render::{page_glyphs, render_page as raster_page, AbFont, GrayCanvas};
 use inkread_epub::Block;
 
-use crate::document::text_select::{CharBox, NormRect};
+use crate::document::text_select::{CharBox, NormRect, TextAnchor};
 use crate::error::{CoreError, CoreResult};
 use crate::render::PixelBuffer;
 
@@ -192,6 +192,12 @@ impl ReflowView {
                     x1: (g.x1 / pw).clamp(0.0, 1.0),
                     y1: (g.y1 / ph).clamp(0.0, 1.0),
                 },
+                // Reconstructed-PDF blocks flow through the same paginator, so the glyph carries an
+                // anchor over the *reflowed* unit (ADR-INKREAD-0012 Decision 3).
+                anchor: Some(TextAnchor {
+                    block: g.anchor.block,
+                    char_offset: g.anchor.char_offset,
+                }),
             })
             .collect()
     }

--- a/reader-core/src/document/reflow_view.rs
+++ b/reader-core/src/document/reflow_view.rs
@@ -21,6 +21,31 @@ use crate::document::text_select::{CharBox, NormRect, TextAnchor};
 use crate::error::{CoreError, CoreResult};
 use crate::render::PixelBuffer;
 
+/// Normalize a laid-out page's glyphs into selection [`CharBox`]es: pixel boxes → `[0,1]` plus the
+/// reflow-stable anchor. Shared by **both** reflowable backends ([`super::reflow::EpubBackend`] and
+/// [`ReflowView`]) so the glyph→`CharBox` mapping — including the `SourceAnchor`→[`TextAnchor`]
+/// conversion at the renderer/core boundary — lives in exactly one place (ADR-INKREAD-0012).
+pub(crate) fn page_charboxes(page: &Page, opts: &LayoutOpts, font: &AbFont) -> Vec<CharBox> {
+    let pw = opts.page_w.max(1.0);
+    let ph = opts.page_h.max(1.0);
+    page_glyphs(page, opts, font)
+        .into_iter()
+        .map(|g| CharBox {
+            ch: g.ch,
+            rect: NormRect {
+                x0: (g.x0 / pw).clamp(0.0, 1.0),
+                y0: (g.y0 / ph).clamp(0.0, 1.0),
+                x1: (g.x1 / pw).clamp(0.0, 1.0),
+                y1: (g.y1 / ph).clamp(0.0, 1.0),
+            },
+            anchor: Some(TextAnchor {
+                block: g.anchor.block,
+                char_offset: g.anchor.char_offset,
+            }),
+        })
+        .collect()
+}
+
 /// Base body font size in device pixels at scale `1.0` — matches the EPUB backend so a PDF and an
 /// EPUB read at the same nominal size (RR2-FR5 font-size control).
 const BASE_FONT_PX: f32 = 38.0;
@@ -180,26 +205,9 @@ impl ReflowView {
         let Some(page) = laid.pages.get(index) else {
             return Vec::new();
         };
-        let pw = laid.opts.page_w.max(1.0);
-        let ph = laid.opts.page_h.max(1.0);
-        page_glyphs(page, &laid.opts, &self.font)
-            .into_iter()
-            .map(|g| CharBox {
-                ch: g.ch,
-                rect: NormRect {
-                    x0: (g.x0 / pw).clamp(0.0, 1.0),
-                    y0: (g.y0 / ph).clamp(0.0, 1.0),
-                    x1: (g.x1 / pw).clamp(0.0, 1.0),
-                    y1: (g.y1 / ph).clamp(0.0, 1.0),
-                },
-                // Reconstructed-PDF blocks flow through the same paginator, so the glyph carries an
-                // anchor over the *reflowed* unit (ADR-INKREAD-0012 Decision 3).
-                anchor: Some(TextAnchor {
-                    block: g.anchor.block,
-                    char_offset: g.anchor.char_offset,
-                }),
-            })
-            .collect()
+        // Reconstructed-PDF blocks flow through the same paginator, so glyphs carry an anchor over
+        // the *reflowed* unit (ADR-INKREAD-0012 Decision 3) — shared with the EPUB backend.
+        page_charboxes(page, &laid.opts, &self.font)
     }
 
     /// Set the text scale (font size) and repaginate, returning the preserved-position page.

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -281,6 +281,19 @@ pub fn text_in_rect(chars: &[CharBox], rect: NormRect) -> TextSelection {
     }
 }
 
+/// The reflow-stable anchors of the **first and last** glyphs a rectangle selects, in reading order
+/// — the `[start, end]` pin pair for a highlight / note / Digest range (RR11-FR4 / ADR-INKREAD-0012).
+/// Uses the same selection predicate as [`text_in_rect`]. Returns `None` when the selection is empty
+/// or its glyphs carry no anchor (a fixed-layout backend), so callers fall back to a page anchor.
+#[must_use]
+pub fn anchored_span(chars: &[CharBox], rect: NormRect) -> Option<(TextAnchor, TextAnchor)> {
+    let mut selected = chars.iter().filter(|c| rect.intersects(&c.rect));
+    let start = selected.next()?.anchor?;
+    // `end` is the last selected glyph's anchor; a single-glyph selection collapses to `start`.
+    let end = selected.next_back().and_then(|c| c.anchor).unwrap_or(start);
+    Some((start, end))
+}
+
 /// Select the text a **drag** sweeps from `start` to `end` (normalized points), the reading-order
 /// multi-line selection (RR11). Mirrors how a desktop selection reads, with the project's twist:
 /// the line the drag *starts* on and every line through to the one *before* the lift are taken
@@ -495,6 +508,70 @@ mod tests {
                 anchor: None,
             })
             .collect()
+    }
+
+    /// A single-row line whose glyphs carry consecutive chapter-relative anchors in `block`.
+    fn anchored_line(s: &str, block: usize, start_off: usize) -> Vec<CharBox> {
+        line(s, 0.0, 0.8, 0.10, 0.03)
+            .into_iter()
+            .enumerate()
+            .map(|(i, mut c)| {
+                c.anchor = Some(TextAnchor {
+                    block,
+                    char_offset: start_off + i,
+                });
+                c
+            })
+            .collect()
+    }
+
+    #[test]
+    fn anchored_span_returns_first_and_last_selected_anchors() {
+        let chars = anchored_line("hello world", 2, 100);
+        // A rect covering the whole line selects every glyph.
+        let full = NormRect {
+            x0: 0.0,
+            y0: 0.0,
+            x1: 1.0,
+            y1: 1.0,
+        };
+        let (s, e) = anchored_span(&chars, full).expect("span");
+        assert_eq!(
+            s,
+            TextAnchor {
+                block: 2,
+                char_offset: 100
+            }
+        );
+        assert_eq!(
+            e,
+            TextAnchor {
+                block: 2,
+                char_offset: 100 + "hello world".chars().count() - 1,
+            }
+        );
+    }
+
+    #[test]
+    fn anchored_span_is_none_for_unanchored_or_empty() {
+        let bare = line("abc", 0.0, 0.8, 0.10, 0.03); // anchor: None
+        let full = NormRect {
+            x0: 0.0,
+            y0: 0.0,
+            x1: 1.0,
+            y1: 1.0,
+        };
+        assert!(anchored_span(&bare, full).is_none(), "unanchored → None");
+        let empty = NormRect {
+            x0: 0.0,
+            y0: 0.9,
+            x1: 0.1,
+            y1: 1.0,
+        };
+        assert!(
+            anchored_span(&anchored_line("abc", 0, 0), empty).is_none(),
+            "no glyph selected → None"
+        );
     }
 
     #[test]

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -63,8 +63,9 @@ pub struct CharBox {
 }
 
 /// A reflow-stable text anchor: the source block (reading-order index in the chapter) and the
-/// chapter-relative character offset. Mirrors `inkread_epub`'s glyph anchor but is kept local so
-/// this selection module stays dependency-free / host-testable. The backend frames it into a full
+/// chapter-relative character offset. Field-identical to `inkread_epub::layout::SourceAnchor` but
+/// kept as the core's own selection-domain type so the selection model isn't coupled to the
+/// renderer's glyph type (the backends convert at the boundary). The backend frames it into a full
 /// `PinPosition` (it owns the chapter index/id).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct TextAnchor {

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -56,6 +56,22 @@ pub struct CharBox {
     pub ch: char,
     /// Its normalized box.
     pub rect: NormRect,
+    /// Reflow-stable source anchor (ADR-INKREAD-0012), when the backend is reflowable. `None` for
+    /// fixed-layout PDF (its position *is* the page). Reflow backends fill it so a selection or a
+    /// page's first glyph can be turned into a `PinPosition` that survives a font-size change.
+    pub anchor: Option<TextAnchor>,
+}
+
+/// A reflow-stable text anchor: the source block (reading-order index in the chapter) and the
+/// chapter-relative character offset. Mirrors `inkread_epub`'s glyph anchor but is kept local so
+/// this selection module stays dependency-free / host-testable. The backend frames it into a full
+/// `PinPosition` (it owns the chapter index/id).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TextAnchor {
+    /// Reading-order index of the source block in the chapter.
+    pub block: usize,
+    /// Chapter-relative character offset.
+    pub char_offset: usize,
 }
 
 /// A resolved selection: the selected text plus the boxes a shell highlights (one per text line).
@@ -476,6 +492,7 @@ mod tests {
                     x1: x0 + (i as f32 + 1.0) * w,
                     y1: y + h,
                 },
+                anchor: None,
             })
             .collect()
     }
@@ -593,6 +610,7 @@ mod tests {
                 x1: 0.81,
                 y1: 0.13,
             },
+            anchor: None,
         });
         chars.extend(line("second line two", 0.0, 0.8, 0.16, 0.03));
         let sel = text_line_span(&chars, (0.1, 0.115), (0.9, 0.175));

--- a/reader-core/src/lib.rs
+++ b/reader-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod ink_wire;
 pub mod persistence;
 pub mod policy;
+pub mod position;
 pub mod render;
 pub mod session;
 pub mod settings;

--- a/reader-core/src/position/mod.rs
+++ b/reader-core/src/position/mod.rs
@@ -1,0 +1,337 @@
+//! `PinPosition` + `PageRange` — the reflow-stable position locator (RR6, M2).
+//!
+//! A reflowable document has no fixed page number: the same word lands on a different rendered page
+//! when the font size, margins, or viewport change. A [`PinPosition`] anchors to **content**, not
+//! pixels — a chapter plus a DOM/byte offset and an XPath — so it re-resolves to the *same words*
+//! across a re-layout (RR6-FR1; the headline re-anchoring guarantee of RR9/RR12).
+//!
+//! This module is the foundation `RR8` (pagination), `RR11` (selection/TOC), and `RR12`
+//! (annotations, reading-position resume, the EPUB Digest anchor) build on. It is **pure and
+//! dependency-free** (serde only) so it is fully host-tested without the reflow engine: the type,
+//! its **total order** (reading order), a lexicographically-comparable **compare key** for use as a
+//! cache/index key, and lossless **JSON** round-trip.
+//!
+//! Clean-room (RR18): the field set and ordering semantics mirror the documented NeoReader locator
+//! contract; no decompiled code is reused.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{CoreError, CoreResult};
+
+/// Bias that maps the full `i32` range onto a non-negative `i64` so a fixed-width zero-padded
+/// decimal encoding sorts lexicographically the same way the integer sorts numerically
+/// (`i32::MIN + BIAS == 0`, `i32::MAX + BIAS == u32::MAX`).
+const PIN_INT_BIAS: i64 = 2_147_483_648; // 2^31
+/// Width of `u32::MAX` (`4294967295`) in decimal digits — the fixed field width after biasing.
+const PIN_INT_WIDTH: usize = 10;
+
+/// Field separator in [`PinPosition::compare_key`]. `0x01` sorts below every digit and the xpath
+/// element separator, so a shorter xpath prefix sorts before a longer one (matching `Vec` order).
+const KEY_FIELD_SEP: char = '\u{1}';
+/// Separator between xpath elements in the compare key (sorts above [`KEY_FIELD_SEP`]).
+const KEY_XPATH_SEP: char = ',';
+
+/// A reflow-stable locator into a document (RR6-FR1).
+///
+/// `position_int()` (= `chapter_start + node_position + text_offset`, clamped to `chapter_end`) is
+/// the chapter-relative reading offset used for ordering and progress; `xpath` re-anchors the exact
+/// node across a re-layout. Two positions order by `(chapter_index, position_int())` first
+/// (RR6-AC2); the remaining fields are deterministic tie-breaks that make the order **total** and
+/// consistent with structural equality.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PinPosition {
+    /// Zero-based spine/chapter index — the primary ordering key.
+    pub chapter_index: i32,
+    /// Stable chapter identifier (e.g. the OPF spine id / href), preserved across re-pagination.
+    pub chapter_id: String,
+    /// Document-relative offset where this chapter begins (for `position_int`/progress).
+    pub chapter_start: i32,
+    /// Document-relative offset where this chapter ends (the upper clamp for `position_int`).
+    pub chapter_end: i32,
+    /// Offset of the anchored node within the chapter.
+    pub node_position: i32,
+    /// Character offset within the anchored node.
+    pub text_offset: i32,
+    /// DOM path (child-index chain from the chapter root) used to re-anchor across re-layouts.
+    pub xpath: Vec<i32>,
+}
+
+impl PinPosition {
+    /// The chapter-relative reading offset: `chapter_start + node_position + text_offset`, clamped
+    /// to `chapter_end` (RR6-FR1). Computed in `i64` so the sum can't overflow `i32`.
+    #[must_use]
+    pub fn position_int(&self) -> i64 {
+        let sum = i64::from(self.chapter_start)
+            + i64::from(self.node_position)
+            + i64::from(self.text_offset);
+        sum.min(i64::from(self.chapter_end))
+    }
+
+    /// The ordering tuple: `(chapter_index, position_int())` first (RR6-AC2), then every remaining
+    /// field so the order is **total** and `cmp == Equal` iff the positions are structurally equal
+    /// (the `Ord`/`Eq` contract). The compare key (RR6-FR3) encodes this same field order.
+    fn order_cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.chapter_index, self.position_int())
+            .cmp(&(other.chapter_index, other.position_int()))
+            .then_with(|| self.node_position.cmp(&other.node_position))
+            .then_with(|| self.text_offset.cmp(&other.text_offset))
+            .then_with(|| self.chapter_start.cmp(&other.chapter_start))
+            .then_with(|| self.chapter_end.cmp(&other.chapter_end))
+            .then_with(|| self.xpath.cmp(&other.xpath))
+            .then_with(|| self.chapter_id.cmp(&other.chapter_id))
+    }
+
+    /// A lexicographically-comparable string whose `str` ordering equals [`Ord`] (RR6-FR3), so
+    /// positions can be used directly as cache/index keys. Ints are biased + zero-padded to a fixed
+    /// width; the xpath uses a separator that preserves `Vec`'s prefix-is-less rule.
+    #[must_use]
+    pub fn compare_key(&self) -> String {
+        let mut key = String::new();
+        for v in [
+            self.chapter_index,
+            // position_int is i64 but always within biasing range for real documents; clamp defends
+            // against a hostile chapter_end far outside i32 (it can't, both inputs are i32).
+            self.position_int() as i32,
+            self.node_position,
+            self.text_offset,
+            self.chapter_start,
+            self.chapter_end,
+        ] {
+            key.push_str(&pad_int(v));
+            key.push(KEY_FIELD_SEP);
+        }
+        for (i, seg) in self.xpath.iter().enumerate() {
+            if i > 0 {
+                key.push(KEY_XPATH_SEP);
+            }
+            key.push_str(&pad_int(*seg));
+        }
+        key.push(KEY_FIELD_SEP);
+        key.push_str(&self.chapter_id);
+        key
+    }
+
+    /// Serialize to JSON (RR6-FR4). Infallible for this primitive-only shape.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).expect("PinPosition serializes infallibly")
+    }
+
+    /// Parse from JSON, validating at the boundary (RR21-FR3): a malformed locator blob (e.g. a
+    /// corrupt `resume_blob`) is reported as a corrupt document rather than panicking.
+    pub fn from_json(s: &str) -> CoreResult<Self> {
+        serde_json::from_str(s)
+            .map_err(|e| CoreError::CorruptDocument(format!("pin-position: {e}")))
+    }
+}
+
+impl Ord for PinPosition {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.order_cmp(other)
+    }
+}
+
+impl PartialOrd for PinPosition {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A page as a **half-open** range of positions `[start, end)` (RR6-FR2). A reflow page is defined
+/// by where it begins and where the next page begins, so the start is inclusive and the end is
+/// exclusive — adjacent pages tile the document without overlap.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PageRange {
+    /// First position on the page (inclusive).
+    pub start: PinPosition,
+    /// First position of the *next* page (exclusive).
+    pub end: PinPosition,
+}
+
+impl PageRange {
+    /// Build a range. `start` is expected to order at or before `end`; an inverted range simply
+    /// contains nothing (callers paginate in reading order so this is a defensive no-op).
+    #[must_use]
+    pub fn new(start: PinPosition, end: PinPosition) -> Self {
+        Self { start, end }
+    }
+
+    /// Whether `pos` falls on this page: `start <= pos < end` (RR6-FR2/AC3).
+    #[must_use]
+    pub fn contains(&self, pos: &PinPosition) -> bool {
+        *pos >= self.start && *pos < self.end
+    }
+}
+
+/// Bias + zero-pad an `i32` to a fixed width so decimal string order matches numeric order across
+/// the whole `i32` range (negatives included).
+fn pad_int(v: i32) -> String {
+    format!(
+        "{:0width$}",
+        i64::from(v) + PIN_INT_BIAS,
+        width = PIN_INT_WIDTH
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A terse builder so tests read as reading-order intent, not field soup.
+    fn pin(chapter: i32, node: i32, offset: i32, xpath: &[i32]) -> PinPosition {
+        PinPosition {
+            chapter_index: chapter,
+            chapter_id: format!("ch{chapter}"),
+            chapter_start: 0,
+            chapter_end: i32::MAX,
+            node_position: node,
+            text_offset: offset,
+            xpath: xpath.to_vec(),
+        }
+    }
+
+    #[test]
+    fn position_int_sums_and_clamps_to_chapter_end() {
+        let p = PinPosition {
+            chapter_start: 100,
+            node_position: 20,
+            text_offset: 5,
+            chapter_end: i32::MAX,
+            ..pin(0, 0, 0, &[])
+        };
+        assert_eq!(p.position_int(), 125);
+
+        let clamped = PinPosition {
+            chapter_end: 110,
+            ..p
+        };
+        assert_eq!(
+            clamped.position_int(),
+            110,
+            "clamped to chapter_end (RR6-FR1)"
+        );
+    }
+
+    #[test]
+    fn position_int_cannot_overflow_i32() {
+        // chapter_start + node + offset would overflow i32 if summed in i32; i64 keeps it sound.
+        let p = PinPosition {
+            chapter_start: i32::MAX,
+            node_position: i32::MAX,
+            text_offset: i32::MAX,
+            chapter_end: i32::MAX,
+            ..pin(0, 0, 0, &[])
+        };
+        assert_eq!(p.position_int(), i64::from(i32::MAX));
+    }
+
+    #[test]
+    fn orders_by_chapter_then_offset() {
+        // RR6-AC2: chapter_index dominates; within a chapter, the document offset orders.
+        let a = pin(0, 10, 0, &[1]);
+        let b = pin(0, 50, 0, &[1]);
+        let c = pin(1, 0, 0, &[1]);
+        assert!(a < b, "earlier offset, same chapter, sorts first");
+        assert!(b < c, "earlier chapter sorts first regardless of offset");
+        assert!(a < c);
+    }
+
+    #[test]
+    fn ordering_is_a_total_order() {
+        // RR6 DoD: ordering totality. A representative cross-product must satisfy trichotomy and
+        // transitivity, and cmp==Equal must coincide with structural equality.
+        let mut all = Vec::new();
+        for chapter in 0..3 {
+            for node in [0, 5, 5] {
+                for offset in [0, 3] {
+                    for xpath in [vec![1], vec![1, 2], vec![2]] {
+                        all.push(pin(chapter, node, offset, &xpath));
+                    }
+                }
+            }
+        }
+        for a in &all {
+            for b in &all {
+                let ord = a.cmp(b);
+                assert_eq!(
+                    ord == std::cmp::Ordering::Equal,
+                    a == b,
+                    "cmp Equal iff structurally equal"
+                );
+                assert_eq!(ord, b.cmp(a).reverse(), "antisymmetry");
+                for c in &all {
+                    if a <= b && b <= c {
+                        assert!(a <= c, "transitivity");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn compare_key_order_matches_cmp() {
+        // RR6-FR3: the string compare key sorts identically to the type's reading order, so it can
+        // be used as a cache/index key. Includes negative coordinates to exercise the bias.
+        let mut positions = vec![
+            pin(2, 0, 0, &[1]),
+            pin(0, 5, 0, &[1, 2]),
+            pin(0, 5, 0, &[1]),
+            pin(0, 5, 0, &[2]),
+            pin(0, 0, 0, &[1]),
+            pin(1, 0, 0, &[]),
+            PinPosition {
+                node_position: -7,
+                ..pin(0, 0, 0, &[3])
+            },
+        ];
+        let mut by_cmp = positions.clone();
+        by_cmp.sort();
+        positions.sort_by_key(PinPosition::compare_key);
+        assert_eq!(positions, by_cmp, "compare_key order must equal Ord");
+    }
+
+    #[test]
+    fn json_round_trip_is_lossless_and_equal() {
+        // RR6-AC1: serialize → deserialize is byte-identical and compares equal.
+        let p = PinPosition {
+            chapter_index: 4,
+            chapter_id: "OEBPS/ch04.xhtml".to_string(),
+            chapter_start: 12_000,
+            chapter_end: 18_500,
+            node_position: 240,
+            text_offset: 17,
+            xpath: vec![0, 3, 1, 9],
+        };
+        let json = p.to_json();
+        let back = PinPosition::from_json(&json).expect("round-trips");
+        assert_eq!(back, p);
+        assert_eq!(back.to_json(), json, "re-serialization is byte-identical");
+    }
+
+    #[test]
+    fn from_json_rejects_garbage_without_panicking() {
+        let err = PinPosition::from_json("{not json").unwrap_err();
+        assert!(matches!(err, CoreError::CorruptDocument(_)));
+    }
+
+    #[test]
+    fn page_range_contains_is_half_open() {
+        // RR6-AC3: start inclusive, end exclusive; before/after excluded.
+        let start = pin(0, 10, 0, &[1]);
+        let end = pin(0, 30, 0, &[1]);
+        let range = PageRange::new(start.clone(), end.clone());
+
+        assert!(range.contains(&start), "start is inclusive");
+        assert!(range.contains(&pin(0, 20, 0, &[1])), "interior");
+        assert!(!range.contains(&end), "end is exclusive");
+        assert!(!range.contains(&pin(0, 5, 0, &[1])), "before");
+        assert!(!range.contains(&pin(1, 0, 0, &[1])), "after (next chapter)");
+    }
+
+    #[test]
+    fn empty_range_contains_nothing() {
+        let p = pin(0, 10, 0, &[1]);
+        let range = PageRange::new(p.clone(), p.clone());
+        assert!(!range.contains(&p));
+    }
+}

--- a/reader-core/src/position/mod.rs
+++ b/reader-core/src/position/mod.rs
@@ -25,6 +25,12 @@ const PIN_INT_BIAS: i64 = 2_147_483_648; // 2^31
 /// Width of `u32::MAX` (`4294967295`) in decimal digits — the fixed field width after biasing.
 const PIN_INT_WIDTH: usize = 10;
 
+/// Bias for `position_int()`, whose floor (`chapter_start + node_position + text_offset`, each i32)
+/// can reach `3 * i32::MIN`. Adding `3 * 2^31` keeps the whole reachable range non-negative.
+const PIN_INT64_BIAS: i64 = 3 * PIN_INT_BIAS;
+/// Width of the biased `position_int()` (`i32::MAX + 3*2^31` ≈ 8.6e9 → 10 digits; 11 for headroom).
+const PIN_INT64_WIDTH: usize = 11;
+
 /// Field separator in [`PinPosition::compare_key`]. `0x01` sorts below every digit and the xpath
 /// element separator, so a shorter xpath prefix sorts before a longer one (matching `Vec` order).
 const KEY_FIELD_SEP: char = '\u{1}';
@@ -86,12 +92,15 @@ impl PinPosition {
     /// width; the xpath uses a separator that preserves `Vec`'s prefix-is-less rule.
     #[must_use]
     pub fn compare_key(&self) -> String {
+        // Field order MUST match `order_cmp` exactly so the lexicographic key order equals `Ord`.
         let mut key = String::new();
+        key.push_str(&pad_int(self.chapter_index));
+        key.push(KEY_FIELD_SEP);
+        // `position_int()` is i64 (its floor can sum below `i32::MIN` for adversarial input), so it is
+        // encoded at full i64 width — casting to i32 here would wrap and disagree with `order_cmp`.
+        key.push_str(&pad_i64(self.position_int()));
+        key.push(KEY_FIELD_SEP);
         for v in [
-            self.chapter_index,
-            // position_int is i64 but always within biasing range for real documents; clamp defends
-            // against a hostile chapter_end far outside i32 (it can't, both inputs are i32).
-            self.position_int() as i32,
             self.node_position,
             self.text_offset,
             self.chapter_start,
@@ -171,6 +180,12 @@ fn pad_int(v: i32) -> String {
         i64::from(v) + PIN_INT_BIAS,
         width = PIN_INT_WIDTH
     )
+}
+
+/// Bias + zero-pad an i64 `position_int()` so its decimal string order matches numeric order across
+/// its full reachable range (its floor can sum down to `3 * i32::MIN`).
+fn pad_i64(v: i64) -> String {
+    format!("{:0width$}", v + PIN_INT64_BIAS, width = PIN_INT64_WIDTH)
 }
 
 #[cfg(test)]
@@ -282,6 +297,19 @@ mod tests {
             PinPosition {
                 node_position: -7,
                 ..pin(0, 0, 0, &[3])
+            },
+            // Adversarial: a position_int() that underflows i32 (sum < i32::MIN). Encoded at full i64
+            // width, so its compare_key still sorts consistently with Ord (regression for the old
+            // `as i32` cast that wrapped).
+            PinPosition {
+                node_position: i32::MIN,
+                text_offset: -1,
+                ..pin(0, 0, 0, &[1])
+            },
+            PinPosition {
+                node_position: i32::MIN,
+                text_offset: -100,
+                ..pin(0, 0, 0, &[1])
             },
         ];
         let mut by_cmp = positions.clone();


### PR DESCRIPTION
## Summary

Adds the **reflow-stable position locator** and threads a **source anchor** through the EPUB pipeline so a position/selection in reflowable content survives a font-size change — the foundation for reflow-anchored reading-position resume, highlights, and the EPUB Digest (#46).

Implements **RR6** (`PinPosition`) and **Phase 1 of ADR-INKREAD-0012** (source-anchor threading). Host-only; the Rust core stays vendor-neutral.

## What's in here (5 commits, each independently gate-checked)

1. **`feat(core)`** — `PinPosition` / `PageRange` (RR6): the content-anchored locator with `position_int()`, a total reading order, a lexicographically-comparable `compare_key`, lossless JSON round-trip, and half-open `PageRange::contains`.
2. **`feat(epub)`** — a `SourceAnchor { block, char_offset }` threaded through `layout` onto every `PlacedRun`/`PlacedGlyph`. Offsets derive from **character counts, not pixels**, so they are invariant under font-size / margin / alignment changes.
3. **`feat(core)`** — `CharBox.anchor`; `EpubBackend` mints a `PinPosition` for a page and resolves one back to a page after re-layout. PDF-reflow gets anchors for free (shared paginator); fixed-layout PDF stays `None` (unchanged).
4. **`feat(core)`** — selection → `[start_pin, end_pin]` pair (`anchored_span` + `selection_pins`).
5. **`fix(core)`** — applies the three-agent review (below).

## Why anchors are stable

The headline guarantee (golden `SPEC-INKREAD.md` RR8-FR2/AC1, RR12-FR4): a pin or selection minted at one font size **re-resolves to the same source characters** after the page reflows. Tested at run, glyph, and backend levels (`set_text_scale` then re-resolve).

## Testing

- `cargo test --workspace` green — **241** reader-core + **28** inkread-epub tests (incl. ordering-totality, `compare_key == Ord` with adversarial underflow, font-size invariance, and the re-anchor tests).
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Core still builds host-only (no Android/pdfium needed for these tests).

## Three-agent review (correctness · spec-conformance · reuse/quality)

All returned SHIP-WITH-FIXES; fixes applied in commit 5:
- **Correctness**: `pin_to_page` no longer stops at an anchorless (rule/empty) interior page; foreign `chapter_index` clamped.
- **RR6 contract**: `compare_key` encodes `position_int()` at full i64 (was an i32 cast that could wrap) + a regression test.
- **Quality**: the glyph→`CharBox` normalizer is now a single shared `page_charboxes` across both reflow backends.

## Scope / follow-ups (separate PRs)

- v1 uses a block-reading-order index as `xpath` and a single cumulative `text_offset` (documented in `ADR-INKREAD-0012`'s "As shipped (v1)" notes); refine to a DOM path later.
- PDF-reflow carries anchor data but pin *composition* (`ReflowView` side) is deferred.
- Then: RR8 pagination, RR12 persistence/resume + re-anchoring, and finally **#46** (`DigestController` sends a `PinPosition`).

No issue is auto-closed; this unblocks #46.
