### PR TITLE
feat(core): reflow pagination — layout digest, PageRange, full-laid disk cache (RR8/RR9-FR3, ADR-0013)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,8 @@ dependencies = [
  "ego-tree",
  "rbook",
  "scraper",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -940,19 +942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
 ]
 
 [[package]]

--- a/inkread-epub/Cargo.toml
+++ b/inkread-epub/Cargo.toml
@@ -18,3 +18,10 @@ ego-tree = "0.11"
 # ab_glyph (Apache-2.0/MIT, pure Rust) — glyph advances (Metrics) + outline rasterization for the
 # reflow renderer; cross-compiles to aarch64-android with no native font lib.
 ab_glyph = "0.2"
+# serde (MIT/Apache) — derive on the laid-out page model so a whole pagination can be cached to the
+# `book.inkread/` sidecar and rehydrated on reopen (ADR-INKREAD-0013 D3).
+serde = { workspace = true }
+
+[dev-dependencies]
+# serde_json backs the page-model round-trip test (the cache itself lives in reader-core).
+serde_json = { workspace = true }

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -101,15 +101,22 @@ impl LayoutOpts {
     /// A stable hash of every layout-affecting field — the pagination-cache discriminator (RR9-FR3,
     /// `SPEC-RUST-READER.md`). Two `LayoutOpts` that paginate identically share a digest; any change
     /// that moves page boundaries (viewport, font size, line/para spacing, alignment, margin) flips
-    /// it, while a non-layout change (e.g. a colour theme) would not. f32s are hashed by bit pattern
-    /// and the hasher is seeded deterministically, so the digest is reproducible across processes —
-    /// a requirement for an on-disk cache key (ADR-INKREAD-0013 D1).
+    /// it, while a non-layout change (e.g. a colour theme — none exist in `LayoutOpts`) could not.
+    ///
+    /// Uses **FNV-1a-64**, not `std::hash::DefaultHasher`: this value names an on-disk cache file, so
+    /// it must be **stable forever across builds and toolchains** — `DefaultHasher`'s algorithm is
+    /// explicitly allowed to change between releases. (Mirrors the FNV-1a fingerprint policy in
+    /// `reader-core`'s `persistence::identity`.) f32s are folded in by bit pattern so the digest is
+    /// exact and deterministic (ADR-INKREAD-0013 D1).
     #[must_use]
     pub fn layout_digest(&self) -> u64 {
-        use std::hash::{Hash, Hasher};
-        // DefaultHasher::new() seeds with fixed keys (0, 0) — deterministic across runs, unlike
-        // RandomState. Bit patterns make the f32s hashable and exact.
-        let mut h = std::collections::hash_map::DefaultHasher::new();
+        const FNV_OFFSET_64: u64 = 0xcbf2_9ce4_8422_2325;
+        const FNV_PRIME_64: u64 = 0x0000_0100_0000_01b3;
+        let mut h = FNV_OFFSET_64;
+        let mut eat = |byte: u8| {
+            h ^= u64::from(byte);
+            h = h.wrapping_mul(FNV_PRIME_64);
+        };
         for field in [
             self.page_w,
             self.page_h,
@@ -118,10 +125,12 @@ impl LayoutOpts {
             self.line_spacing,
             self.para_gap,
         ] {
-            field.to_bits().hash(&mut h);
+            for b in field.to_bits().to_le_bytes() {
+                eat(b);
+            }
         }
-        (self.align as u8).hash(&mut h);
-        h.finish()
+        eat(self.align as u8);
+        h
     }
 }
 
@@ -846,6 +855,23 @@ mod tests {
             .layout_digest(),
             "align"
         );
+    }
+
+    #[test]
+    fn layout_digest_is_pinned_against_algorithm_drift() {
+        // The digest names on-disk cache files (ADR-INKREAD-0013); pin a known value so a future
+        // change to the FNV constants/algorithm — which would silently orphan every cached
+        // pagination — is caught here, exactly as reader-core's identity fingerprint is pinned.
+        let opts = LayoutOpts {
+            page_w: 400.0,
+            page_h: 600.0,
+            margin: 24.0,
+            font_px: 16.0,
+            line_spacing: 1.4,
+            para_gap: 11.2,
+            align: Align::Left,
+        };
+        assert_eq!(opts.layout_digest(), 17_685_407_801_978_826_572);
     }
 
     #[test]

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -95,6 +95,32 @@ impl LayoutOpts {
     fn content_h(&self) -> f32 {
         (self.page_h - 2.0 * self.margin).max(1.0)
     }
+
+    /// A stable hash of every layout-affecting field — the pagination-cache discriminator (RR9-FR3,
+    /// `SPEC-RUST-READER.md`). Two `LayoutOpts` that paginate identically share a digest; any change
+    /// that moves page boundaries (viewport, font size, line/para spacing, alignment, margin) flips
+    /// it, while a non-layout change (e.g. a colour theme) would not. f32s are hashed by bit pattern
+    /// and the hasher is seeded deterministically, so the digest is reproducible across processes —
+    /// a requirement for an on-disk cache key (ADR-INKREAD-0013 D1).
+    #[must_use]
+    pub fn layout_digest(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        // DefaultHasher::new() seeds with fixed keys (0, 0) — deterministic across runs, unlike
+        // RandomState. Bit patterns make the f32s hashable and exact.
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        for field in [
+            self.page_w,
+            self.page_h,
+            self.margin,
+            self.font_px,
+            self.line_spacing,
+            self.para_gap,
+        ] {
+            field.to_bits().hash(&mut h);
+        }
+        (self.align as u8).hash(&mut h);
+        h.finish()
+    }
 }
 
 /// A reflow-stable source anchor for a placed run/glyph (ADR-INKREAD-0012; feeds RR6 `PinPosition`).
@@ -727,6 +753,83 @@ mod tests {
             para_gap: 0.0,
             align: Align::Left,
         }
+    }
+
+    #[test]
+    fn layout_digest_is_stable_and_sensitive_to_layout_fields() {
+        let base = LayoutOpts::new(400.0, 600.0, 16.0);
+        // Deterministic: identical opts → identical digest (same process AND, by fixed seed, across
+        // processes — the on-disk cache key contract).
+        assert_eq!(
+            base.layout_digest(),
+            LayoutOpts::new(400.0, 600.0, 16.0).layout_digest()
+        );
+
+        // Every layout-affecting field flips the digest.
+        let d = base.layout_digest();
+        assert_ne!(
+            d,
+            LayoutOpts {
+                page_w: 401.0,
+                ..base
+            }
+            .layout_digest(),
+            "width"
+        );
+        assert_ne!(
+            d,
+            LayoutOpts {
+                page_h: 601.0,
+                ..base
+            }
+            .layout_digest(),
+            "height"
+        );
+        assert_ne!(
+            d,
+            LayoutOpts {
+                margin: base.margin + 1.0,
+                ..base
+            }
+            .layout_digest(),
+            "margin"
+        );
+        assert_ne!(
+            d,
+            LayoutOpts {
+                font_px: 17.0,
+                ..base
+            }
+            .layout_digest(),
+            "font"
+        );
+        assert_ne!(
+            d,
+            LayoutOpts {
+                line_spacing: 1.5,
+                ..base
+            }
+            .layout_digest(),
+            "line spacing"
+        );
+        assert_ne!(
+            d,
+            LayoutOpts {
+                para_gap: base.para_gap + 1.0,
+                ..base
+            }
+            .layout_digest(),
+            "para gap"
+        );
+        assert_ne!(
+            d,
+            LayoutOpts {
+                align: Align::Justify,
+                ..base
+            }
+            .layout_digest(),
+            "align"
+        );
     }
 
     #[test]

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -17,6 +17,8 @@
 //! font rasterizer; Phase 4 plugs a real glyph-advance implementation (skrifa/swash) and renders the
 //! [`Page`]s into a `PixelBuffer`.
 
+use serde::{Deserialize, Serialize};
+
 use crate::content::{Block, Inline};
 
 /// Glyph-advance measurement for a font (Phase 4 supplies a real implementation; tests use a
@@ -131,7 +133,7 @@ impl LayoutOpts {
 /// derived from character counts, **not pixels**, so they are invariant under a font-size / margin /
 /// alignment change — the property a highlight or Digest entry needs to re-resolve to the same text
 /// after the page reflows (golden `SPEC-INKREAD.md` RR8-FR2/AC1).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SourceAnchor {
     /// Reading-order index of the source block in the chapter.
     pub block: usize,
@@ -141,7 +143,7 @@ pub struct SourceAnchor {
 
 /// A positioned run of text on a line. `x`/`top` are relative to the page's **content origin** (the
 /// top-left after the margin); the renderer adds `opts.margin`. Baseline ≈ `top + size_px`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlacedRun {
     pub x: f32,
     pub text: String,
@@ -155,7 +157,7 @@ pub struct PlacedRun {
 
 /// One laid-out line: its `top` (content-relative), `height` (the line box), and positioned runs.
 /// A horizontal rule line carries `rule = true` and no runs.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LayoutLine {
     pub top: f32,
     pub height: f32,
@@ -164,7 +166,7 @@ pub struct LayoutLine {
 }
 
 /// A laid-out page: the lines that fall within the content box.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Page {
     pub lines: Vec<LayoutLine>,
 }
@@ -753,6 +755,20 @@ mod tests {
             para_gap: 0.0,
             align: Align::Left,
         }
+    }
+
+    #[test]
+    fn pages_round_trip_through_json() {
+        // The pagination cache (ADR-INKREAD-0013 D3) persists laid pages; serialization must be
+        // lossless so a rehydrated page renders/selects identically (anchors included).
+        let opts = LayoutOpts::new(400.0, 600.0, 16.0);
+        let blocks = parse_blocks(
+            "<html><body><h2>Title</h2><p>one two three</p><ul><li>a</li></ul></body></html>",
+        );
+        let pages = paginate(&blocks, &opts, &Mono);
+        let json = serde_json::to_string(&pages).expect("serialize");
+        let back: Vec<Page> = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, pages, "laid pages round-trip losslessly");
     }
 
     #[test]

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -19,6 +19,8 @@ use inkread_epub::{parse_blocks, Block, EpubPackage, NavPoint};
 use crate::document::text_select::{self, CharBox, NormRect, TextAnchor, TextSelection};
 use crate::document::{Document, DocumentMetadata, SearchMatch, TocEntry};
 use crate::error::{CoreError, CoreResult};
+use crate::persistence::pagination_cache::{CachedPagination, PaginationCache};
+use crate::persistence::sidecar::SidecarPaths;
 use crate::position::{PageRange, PinPosition};
 use crate::render::PixelBuffer;
 
@@ -59,11 +61,36 @@ pub struct EpubBackend {
     align: Cell<Align>,
     /// The current pagination; recomputed when the viewport or scale changes.
     laid: RefCell<Laid>,
+    /// Optional disk pagination cache (ADR-INKREAD-0013 D3): when present, a layout is loaded from /
+    /// written to `book.inkread/pagination/` keyed by `layout_digest`, so reopening at the same
+    /// viewport + style skips re-pagination. Absent ⇒ always lay out fresh.
+    cache: Option<PaginationCache>,
 }
 
 impl EpubBackend {
-    /// Parse `bytes` and paginate for the initial `viewport`. Maps parse failures to a typed error.
+    /// Parse `bytes` and paginate for the initial `viewport` (no pagination cache).
     pub fn open(bytes: Vec<u8>, viewport: crate::render::Viewport) -> CoreResult<Self> {
+        Self::open_inner(bytes, viewport, None)
+    }
+
+    /// Like [`Self::open`] but backed by the document's `book.inkread/` pagination cache
+    /// (ADR-INKREAD-0013 D3): the initial layout — and every repagination — is loaded from / written
+    /// to disk keyed by `layout_digest`, so reopening at the same viewport + style skips the layout.
+    pub fn open_with_cache(
+        bytes: Vec<u8>,
+        viewport: crate::render::Viewport,
+        paths: &SidecarPaths,
+    ) -> CoreResult<Self> {
+        Self::open_inner(bytes, viewport, Some(PaginationCache::new(paths)))
+    }
+
+    /// Parse `bytes` and paginate for `viewport`, consulting `cache` if present. Maps parse failures
+    /// to a typed error.
+    fn open_inner(
+        bytes: Vec<u8>,
+        viewport: crate::render::Viewport,
+        cache: Option<PaginationCache>,
+    ) -> CoreResult<Self> {
         let pkg = EpubPackage::open(bytes)
             .map_err(|e| CoreError::RenderBackend(format!("epub open: {e}")))?;
         let chapters: Vec<Vec<Block>> =
@@ -74,15 +101,14 @@ impl EpubBackend {
             author: pkg.author.clone(),
         };
         let font = AbFont::default_font();
-        let laid = layout_all(
-            &chapters,
-            &font,
+        let opts = opts_for(
             viewport.width,
             viewport.height,
             BASE_FONT_PX,
             1.4,
             Align::Left,
         );
+        let laid = build_laid(cache.as_ref(), &chapters, &font, opts);
         Ok(Self {
             chapters,
             chapter_keys,
@@ -93,6 +119,7 @@ impl EpubBackend {
             line_spacing: Cell::new(1.4),
             align: Cell::new(Align::Left),
             laid: RefCell::new(laid),
+            cache,
         })
     }
 
@@ -112,15 +139,8 @@ impl EpubBackend {
                 || (laid.opts.font_px - font_px).abs() > 0.01
         };
         if needs {
-            let fresh = layout_all(
-                &self.chapters,
-                &self.font,
-                w,
-                h,
-                font_px,
-                self.line_spacing.get(),
-                self.align.get(),
-            );
+            let opts = opts_for(w, h, font_px, self.line_spacing.get(), self.align.get());
+            let fresh = build_laid(self.cache.as_ref(), &self.chapters, &self.font, opts);
             *self.laid.borrow_mut() = fresh;
         }
     }
@@ -133,15 +153,14 @@ impl EpubBackend {
             let laid = self.laid.borrow();
             (laid.opts.page_w as u32, laid.opts.page_h as u32)
         };
-        let fresh = layout_all(
-            &self.chapters,
-            &self.font,
+        let opts = opts_for(
             w,
             h,
             self.font_px(),
             self.line_spacing.get(),
             self.align.get(),
         );
+        let fresh = build_laid(self.cache.as_ref(), &self.chapters, &self.font, opts);
         let target = fresh.chapter_start.get(chapter).copied().unwrap_or(0);
         *self.laid.borrow_mut() = fresh;
         Some(target)
@@ -339,18 +358,49 @@ impl Document for EpubBackend {
 }
 
 /// Paginate every chapter for `(w, h, font_px, line_spacing, align)`; each chapter starts a page.
-fn layout_all(
-    chapters: &[Vec<Block>],
-    font: &AbFont,
-    w: u32,
-    h: u32,
-    font_px: f32,
-    line_spacing: f32,
-    align: Align,
-) -> Laid {
+/// Build the [`LayoutOpts`] for a viewport + typography — the single place opts are assembled, so the
+/// `layout_digest` computed for the cache key (ADR-INKREAD-0013) always matches what `layout_all`
+/// paginates with.
+fn opts_for(w: u32, h: u32, font_px: f32, line_spacing: f32, align: Align) -> LayoutOpts {
     let mut opts = LayoutOpts::new(w as f32, h as f32, font_px);
     opts.line_spacing = line_spacing;
     opts.align = align;
+    opts
+}
+
+/// Paginate the whole book for `opts`, returning the cache-on-miss layout. Loads from `cache` (keyed
+/// by `opts.layout_digest()`) when present, else lays out and best-effort writes the result back
+/// (ADR-INKREAD-0013 D3). A cache write failure is non-fatal — the in-memory layout is still used.
+fn build_laid(
+    cache: Option<&PaginationCache>,
+    chapters: &[Vec<Block>],
+    font: &AbFont,
+    opts: LayoutOpts,
+) -> Laid {
+    let digest = opts.layout_digest();
+    if let Some(c) = cache {
+        if let Some(cached) = c.load(digest) {
+            return Laid {
+                opts,
+                pages: cached.pages,
+                chapter_start: cached.chapter_start,
+            };
+        }
+    }
+    let laid = layout_all(chapters, font, opts);
+    if let Some(c) = cache {
+        let _ = c.store(
+            digest,
+            &CachedPagination {
+                chapter_start: laid.chapter_start.clone(),
+                pages: laid.pages.clone(),
+            },
+        );
+    }
+    laid
+}
+
+fn layout_all(chapters: &[Vec<Block>], font: &AbFont, opts: LayoutOpts) -> Laid {
     let mut pages = Vec::new();
     let mut chapter_start = Vec::with_capacity(chapters.len());
     for blocks in chapters {
@@ -585,6 +635,72 @@ mod tests {
             ranges.windows(2).all(|w| w[0].start <= w[1].start),
             "page starts ascend"
         );
+    }
+
+    /// Self-cleaning temp dir for the pagination-cache wiring tests.
+    struct TempDir {
+        path: std::path::PathBuf,
+    }
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let mut path = std::env::temp_dir();
+            path.push(format!("inkread-reflowcache-{tag}-{:p}", &tag));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn open_with_cache_writes_then_reload_matches() {
+        let tmp = TempDir::new("write");
+        let paths = SidecarPaths::from_root(&tmp.path);
+        let b = EpubBackend::open_with_cache(SAMPLE.to_vec(), vp(400, 600), &paths).unwrap();
+        let n = b.page_count();
+        // The miss path wrote the layout to disk; it reloads as the same pagination.
+        let digest = opts_for(400, 600, BASE_FONT_PX, 1.4, Align::Left).layout_digest();
+        let loaded = PaginationCache::new(&paths)
+            .load(digest)
+            .expect("cache written on first open");
+        assert_eq!(
+            loaded.pages.len(),
+            n,
+            "cached page count matches the layout"
+        );
+    }
+
+    #[test]
+    fn open_with_cache_uses_a_planted_cache_instead_of_laying_out() {
+        // Definitive hit proof: plant a cache under the digest the backend will compute, then open —
+        // the backend must report the planted pagination, not a fresh SAMPLE layout.
+        let tmp = TempDir::new("hit");
+        let paths = SidecarPaths::from_root(&tmp.path);
+        let digest = opts_for(400, 600, BASE_FONT_PX, 1.4, Align::Left).layout_digest();
+        let planted = CachedPagination {
+            chapter_start: vec![0],
+            pages: vec![Page::default(), Page::default(), Page::default()],
+        };
+        PaginationCache::new(&paths)
+            .store(digest, &planted)
+            .unwrap();
+
+        let b = EpubBackend::open_with_cache(SAMPLE.to_vec(), vp(400, 600), &paths).unwrap();
+        assert_eq!(
+            b.page_count(),
+            3,
+            "used the planted cache, not a fresh layout"
+        );
+    }
+
+    #[test]
+    fn open_without_cache_is_unaffected() {
+        // The no-cache constructor still works and writes nothing.
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        assert!(b.page_count() >= 2);
     }
 
     #[test]

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -19,7 +19,7 @@ use inkread_epub::{parse_blocks, Block, EpubPackage, NavPoint};
 use crate::document::text_select::{self, CharBox, NormRect, TextAnchor, TextSelection};
 use crate::document::{Document, DocumentMetadata, SearchMatch, TocEntry};
 use crate::error::{CoreError, CoreResult};
-use crate::position::PinPosition;
+use crate::position::{PageRange, PinPosition};
 use crate::render::PixelBuffer;
 
 /// Base body font size in device pixels at scale `1.0` (Supernote-class panel). The user's text
@@ -229,6 +229,24 @@ impl EpubBackend {
         let chapter = self.chapter_of(page);
         let (start, end) = text_select::anchored_span(&self.page_chars(page), rect)?;
         Some((self.pin_at(chapter, start), self.pin_at(chapter, end)))
+    }
+
+    /// The `[start, end)` [`PageRange`] (RR6-FR2 / RR8-FR4) a global `page` spans: from its first
+    /// anchored glyph to the start of the next anchored page, host-derived. The book's last page ends
+    /// at a chapter-end sentinel. `None` for an anchorless page (rule-only / empty), which has no
+    /// text position. Anchorless interior pages are skipped when finding the exclusive end, so a
+    /// rule/blank page between two text pages doesn't truncate the range (ADR-INKREAD-0013 D2).
+    #[allow(dead_code)]
+    pub(crate) fn page_range(&self, page: usize) -> Option<PageRange> {
+        let start = self.page_pin(page)?;
+        let total = self.laid.borrow().pages.len();
+        let end = (page + 1..total)
+            .find_map(|p| self.page_pin(p))
+            .unwrap_or_else(|| PinPosition {
+                text_offset: i32::MAX,
+                ..start.clone()
+            });
+        Some(PageRange::new(start, end))
     }
 
     /// The chapter index that global `page` falls in (the last chapter whose start ≤ page).
@@ -533,6 +551,40 @@ mod tests {
         b.set_text_scale(1.7, 0).unwrap();
         assert_eq!(char_at(&b, &start), Some(sc), "start re-anchors");
         assert_eq!(char_at(&b, &end), Some(ec), "end re-anchors");
+    }
+
+    #[test]
+    fn page_ranges_are_stable_for_identical_layout() {
+        // RR8 DoD: same inputs ⇒ identical boundaries.
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        let _ = render(&b, 0, 400, 600);
+        let ranges1: Vec<PageRange> = (0..b.page_count())
+            .filter_map(|p| b.page_range(p))
+            .collect();
+        b.set_text_scale(1.0, 0).unwrap(); // identical layout → must reproduce the boundaries
+        let ranges2: Vec<PageRange> = (0..b.page_count())
+            .filter_map(|p| b.page_range(p))
+            .collect();
+        assert!(!ranges1.is_empty());
+        assert_eq!(ranges1, ranges2);
+    }
+
+    #[test]
+    fn page_range_starts_ascend_and_each_range_is_ordered() {
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        let _ = render(&b, 0, 400, 600);
+        let ranges: Vec<PageRange> = (0..b.page_count())
+            .filter_map(|p| b.page_range(p))
+            .collect();
+        assert!(ranges.len() >= 2);
+        for r in &ranges {
+            assert!(r.start <= r.end, "each range is ordered");
+        }
+        // Page starts ascend in reading order (host-derived global ordering, RR8-FR4).
+        assert!(
+            ranges.windows(2).all(|w| w[0].start <= w[1].start),
+            "page starts ascend"
+        );
     }
 
     #[test]

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -75,13 +75,25 @@ impl EpubBackend {
 
     /// Like [`Self::open`] but backed by the document's `book.inkread/` pagination cache
     /// (ADR-INKREAD-0013 D3): the initial layout — and every repagination — is loaded from / written
-    /// to disk keyed by `layout_digest`, so reopening at the same viewport + style skips the layout.
+    /// to disk keyed by the content fingerprint + `layout_digest`, so reopening at the same viewport +
+    /// style skips the layout. The fingerprint scopes the cache to the document's bytes, so a changed
+    /// file at the same sidecar can never serve a stale pagination.
+    ///
+    /// NOTE: not yet wired into [`crate::session::ReaderSession`] — `session::open_epub` still uses
+    /// the cache-less [`Self::open`], so on-device reopen is not yet fast. Wiring it requires a
+    /// `SidecarPaths` at the session layer (it currently holds only trait-object stores); tracked as
+    /// the RR8 device-integration follow-up.
     pub fn open_with_cache(
         bytes: Vec<u8>,
         viewport: crate::render::Viewport,
         paths: &SidecarPaths,
     ) -> CoreResult<Self> {
-        Self::open_inner(bytes, viewport, Some(PaginationCache::new(paths)))
+        let fingerprint = crate::persistence::identity::fingerprint(&bytes);
+        Self::open_inner(
+            bytes,
+            viewport,
+            Some(PaginationCache::new(paths, fingerprint)),
+        )
     }
 
     /// Parse `bytes` and paginate for `viewport`, consulting `cache` if present. Maps parse failures
@@ -250,15 +262,18 @@ impl EpubBackend {
         Some((self.pin_at(chapter, start), self.pin_at(chapter, end)))
     }
 
-    /// The `[start, end)` [`PageRange`] (RR6-FR2 / RR8-FR4) a global `page` spans: from its first
-    /// anchored glyph to the start of the next anchored page, host-derived. The book's last page ends
-    /// at a chapter-end sentinel. `None` for an anchorless page (rule-only / empty), which has no
-    /// text position. Anchorless interior pages are skipped when finding the exclusive end, so a
-    /// rule/blank page between two text pages doesn't truncate the range (ADR-INKREAD-0013 D2).
+    /// The `[start, end)` [`PageRange`] (RR6-FR2 / RR8-FR4, `SPEC-RUST-READER`) a global `page` spans:
+    /// from its first anchored glyph to the start of the next anchored page, host-derived. The book's
+    /// last page ends at a chapter-end sentinel. `None` for an anchorless page (rule-only / empty),
+    /// which has no text position. Anchorless interior pages are skipped when finding the exclusive
+    /// end, so a rule/blank page between two text pages doesn't truncate the range (ADR-0013 D2).
     #[allow(dead_code)]
     pub(crate) fn page_range(&self, page: usize) -> Option<PageRange> {
         let start = self.page_pin(page)?;
         let total = self.laid.borrow().pages.len();
+        // Last-page sentinel: `text_offset = i32::MAX` orders strictly after `start` within the same
+        // chapter — via `position_int` when it isn't clamped, and via the `text_offset` tie-break in
+        // `PinPosition::cmp` even if both clamp to `chapter_end` — so `[start, end)` is never empty.
         let end = (page + 1..total)
             .find_map(|p| self.page_pin(p))
             .unwrap_or_else(|| PinPosition {
@@ -368,6 +383,24 @@ fn opts_for(w: u32, h: u32, font_px: f32, line_spacing: f32, align: Align) -> La
     opts
 }
 
+/// Whether a loaded [`CachedPagination`] is internally consistent for a book of `n_chapters`: one
+/// `chapter_start` per chapter, starting at 0, strictly ascending, and every start in range of the
+/// cached pages. A well-typed but inconsistent blob (e.g. a corrupt or foreign file that still
+/// deserializes) is rejected so it can't silently mis-map TOC/anchoring (RR21-FR3 spirit).
+fn cached_pagination_is_valid(cached: &CachedPagination, n_chapters: usize) -> bool {
+    if cached.chapter_start.len() != n_chapters {
+        return false;
+    }
+    if n_chapters == 0 {
+        return true;
+    }
+    let pages = cached.pages.len();
+    pages > 0
+        && cached.chapter_start.first() == Some(&0)
+        && cached.chapter_start.windows(2).all(|w| w[0] < w[1])
+        && cached.chapter_start.iter().all(|&s| s < pages)
+}
+
 /// Paginate the whole book for `opts`, returning the cache-on-miss layout. Loads from `cache` (keyed
 /// by `opts.layout_digest()`) when present, else lays out and best-effort writes the result back
 /// (ADR-INKREAD-0013 D3). A cache write failure is non-fatal — the in-memory layout is still used.
@@ -380,11 +413,15 @@ fn build_laid(
     let digest = opts.layout_digest();
     if let Some(c) = cache {
         if let Some(cached) = c.load(digest) {
-            return Laid {
-                opts,
-                pages: cached.pages,
-                chapter_start: cached.chapter_start,
-            };
+            if cached_pagination_is_valid(&cached, chapters.len()) {
+                return Laid {
+                    opts,
+                    pages: cached.pages,
+                    chapter_start: cached.chapter_start,
+                };
+            }
+            // A well-typed-but-inconsistent blob (wrong chapter count / out-of-range starts) is
+            // treated as a miss rather than trusted — lay out fresh below.
         }
     }
     let laid = layout_all(chapters, font, opts);
@@ -655,6 +692,12 @@ mod tests {
         }
     }
 
+    /// A cache scoped to SAMPLE's content fingerprint — the same key `open_with_cache` will compute,
+    /// so a planted entry is actually addressed by the backend.
+    fn cache_for(paths: &SidecarPaths) -> PaginationCache {
+        PaginationCache::new(paths, crate::persistence::identity::fingerprint(SAMPLE))
+    }
+
     #[test]
     fn open_with_cache_writes_then_reload_matches() {
         let tmp = TempDir::new("write");
@@ -663,7 +706,7 @@ mod tests {
         let n = b.page_count();
         // The miss path wrote the layout to disk; it reloads as the same pagination.
         let digest = opts_for(400, 600, BASE_FONT_PX, 1.4, Align::Left).layout_digest();
-        let loaded = PaginationCache::new(&paths)
+        let loaded = cache_for(&paths)
             .load(digest)
             .expect("cache written on first open");
         assert_eq!(
@@ -675,18 +718,17 @@ mod tests {
 
     #[test]
     fn open_with_cache_uses_a_planted_cache_instead_of_laying_out() {
-        // Definitive hit proof: plant a cache under the digest the backend will compute, then open —
-        // the backend must report the planted pagination, not a fresh SAMPLE layout.
+        // Definitive hit proof: plant a cache under the (fingerprint, digest) the backend computes,
+        // then open — the backend must report the planted pagination, not a fresh SAMPLE layout.
         let tmp = TempDir::new("hit");
         let paths = SidecarPaths::from_root(&tmp.path);
         let digest = opts_for(400, 600, BASE_FONT_PX, 1.4, Align::Left).layout_digest();
+        // SAMPLE has two chapters, so a *valid* cache needs two ascending in-range chapter starts.
         let planted = CachedPagination {
-            chapter_start: vec![0],
+            chapter_start: vec![0, 2],
             pages: vec![Page::default(), Page::default(), Page::default()],
         };
-        PaginationCache::new(&paths)
-            .store(digest, &planted)
-            .unwrap();
+        cache_for(&paths).store(digest, &planted).unwrap();
 
         let b = EpubBackend::open_with_cache(SAMPLE.to_vec(), vp(400, 600), &paths).unwrap();
         assert_eq!(
@@ -694,6 +736,24 @@ mod tests {
             3,
             "used the planted cache, not a fresh layout"
         );
+    }
+
+    #[test]
+    fn an_inconsistent_cache_blob_is_rejected_and_relaid_out() {
+        // A well-typed but inconsistent cache (wrong chapter count for SAMPLE) must not be trusted:
+        // the backend lays out fresh rather than reporting the planted 3 pages.
+        let tmp = TempDir::new("badblob");
+        let paths = SidecarPaths::from_root(&tmp.path);
+        let digest = opts_for(400, 600, BASE_FONT_PX, 1.4, Align::Left).layout_digest();
+        let bad = CachedPagination {
+            chapter_start: vec![0], // SAMPLE has two chapters → inconsistent
+            pages: vec![Page::default(), Page::default(), Page::default()],
+        };
+        cache_for(&paths).store(digest, &bad).unwrap();
+
+        let b = EpubBackend::open_with_cache(SAMPLE.to_vec(), vp(400, 600), &paths).unwrap();
+        assert_ne!(b.page_count(), 3, "did not trust the inconsistent cache");
+        assert!(b.page_count() >= 2, "laid out fresh instead");
     }
 
     #[test]

--- a/reader-core/src/persistence/ink_store.rs
+++ b/reader-core/src/persistence/ink_store.rs
@@ -104,8 +104,9 @@ fn sync_dir(dir: &Path) {
 }
 
 /// Atomically replace `path` with `bytes`: write a flushed `*.tmp` sibling, rename over the target,
-/// then fsync the parent directory so the rename survives power loss. The parent must exist.
-fn atomic_write(path: &Path, bytes: &[u8]) -> CoreResult<()> {
+/// then fsync the parent directory so the rename survives power loss. The parent must exist. Shared
+/// with the pagination cache (ADR-INKREAD-0013) so both sidecar writers are crash-safe the same way.
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> CoreResult<()> {
     let mut tmp_name: OsString = path.as_os_str().to_owned();
     tmp_name.push(".tmp");
     let tmp = Path::new(&tmp_name);

--- a/reader-core/src/persistence/mod.rs
+++ b/reader-core/src/persistence/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod identity;
 pub mod ink_store;
+pub(crate) mod pagination_cache;
 pub mod sidecar;
 pub mod sqlite;
 

--- a/reader-core/src/persistence/pagination_cache.rs
+++ b/reader-core/src/persistence/pagination_cache.rs
@@ -34,21 +34,31 @@ pub(crate) struct CachedPagination {
     pub pages: Vec<Page>,
 }
 
-/// Reads/writes laid paginations under `book.inkread/pagination/`, keyed by `layout_digest`.
+/// Reads/writes laid paginations under `book.inkread/pagination/`, keyed by the document content
+/// fingerprint **and** the `layout_digest`. The fingerprint guards against staleness: if the file at
+/// a sidecar path is replaced with different content, its fingerprint changes, so the old
+/// pagination's file is no longer addressed and can't be served for the new bytes.
+//
+// TODO(ADR-INKREAD-0013): the `pagination/` dir grows one file per (content, viewport, style) combo
+// and is never pruned. Bound it (LRU / keep-N) once the cache is wired into a real reopen path.
 pub(crate) struct PaginationCache {
     dir: PathBuf,
+    fingerprint: u128,
 }
 
 impl PaginationCache {
-    /// The cache rooted at a document's sidecar (`<book>.inkread/pagination/`).
-    pub(crate) fn new(paths: &SidecarPaths) -> Self {
+    /// The cache rooted at a document's sidecar (`<book>.inkread/pagination/`), scoped to the
+    /// document's content `fingerprint` (see [`crate::persistence::identity::fingerprint`]).
+    pub(crate) fn new(paths: &SidecarPaths, fingerprint: u128) -> Self {
         Self {
             dir: paths.root().join("pagination"),
+            fingerprint,
         }
     }
 
     fn file(&self, digest: u64) -> PathBuf {
-        self.dir.join(format!("{digest:016x}.json"))
+        self.dir
+            .join(format!("{:032x}-{digest:016x}.json", self.fingerprint))
     }
 
     /// The cached pagination for `digest`, or `None` on miss / oversize / corrupt — in every
@@ -114,10 +124,12 @@ mod tests {
         }
     }
 
+    const FP: u128 = 0x0123_4567_89ab_cdef_0123_4567_89ab_cdef;
+
     #[test]
     fn round_trips_through_disk() {
         let tmp = TempDir::new("rt");
-        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path));
+        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path), FP);
         let cached = sample();
         cache.store(0xABCD, &cached).unwrap();
         assert_eq!(cache.load(0xABCD), Some(cached));
@@ -126,7 +138,7 @@ mod tests {
     #[test]
     fn miss_and_corrupt_degrade_to_none() {
         let tmp = TempDir::new("miss");
-        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path));
+        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path), FP);
         assert_eq!(cache.load(0x1234), None, "absent digest is a miss");
 
         // A corrupt file at the digest's path is a miss, not a panic.
@@ -138,7 +150,7 @@ mod tests {
     #[test]
     fn distinct_digests_do_not_collide() {
         let tmp = TempDir::new("keys");
-        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path));
+        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path), FP);
         let a = sample();
         let mut b = sample();
         b.chapter_start = vec![0, 1];
@@ -146,5 +158,18 @@ mod tests {
         cache.store(2, &b).unwrap();
         assert_eq!(cache.load(1), Some(a));
         assert_eq!(cache.load(2), Some(b));
+    }
+
+    #[test]
+    fn a_different_fingerprint_does_not_serve_a_stale_pagination() {
+        // Same sidecar + same digest, but the document content changed (different fingerprint): the
+        // old entry must not be served for the new bytes.
+        let tmp = TempDir::new("stale");
+        let paths = SidecarPaths::from_root(&tmp.path);
+        PaginationCache::new(&paths, FP)
+            .store(7, &sample())
+            .unwrap();
+        let other = PaginationCache::new(&paths, FP ^ 1);
+        assert_eq!(other.load(7), None, "foreign-content cache is a miss");
     }
 }

--- a/reader-core/src/persistence/pagination_cache.rs
+++ b/reader-core/src/persistence/pagination_cache.rs
@@ -1,0 +1,150 @@
+//! Disk pagination cache (ADR-INKREAD-0013 D3 / `SPEC-RUST-READER.md` RR8-FR3).
+//!
+//! Reflow pagination is deterministic for a given [`layout_digest`](inkread_epub::layout::LayoutOpts::layout_digest)
+//! but recomputing a whole book on every reopen is wasteful on a slow e-ink SoC. This caches the
+//! **full laid pagination** (the positioned [`Page`]s + per-chapter start indices) to the document's
+//! `book.inkread/pagination/` sidecar, keyed by the digest, so reopening at the same viewport + style
+//! rehydrates instead of re-laying-out (RR8-AC1).
+//!
+//! The cache is **advisory**: a miss, an oversize file, or a corrupt/foreign blob simply degrades to
+//! a fresh layout — never an error to the reader (RR21-FR3), mirroring [`super::ink_store`]'s posture.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use inkread_epub::layout::Page;
+
+use crate::error::{CoreError, CoreResult};
+use crate::persistence::ink_store::atomic_write;
+use crate::persistence::sidecar::SidecarPaths;
+
+/// Hard cap on a cache file read (RR21-FR3): a whole book's laid pages, generously bounded so a
+/// hostile/corrupt file can't trigger a huge allocation. Over the cap ⇒ treated as a miss.
+const MAX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// A persisted pagination for one `layout_digest`: the laid pages plus the per-chapter start page
+/// indices (`chapter_start`), i.e. everything [`crate::document::reflow`]'s `Laid` needs except the
+/// `LayoutOpts`, which the caller already holds (it computed the digest from them).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct CachedPagination {
+    /// Global page index where each chapter begins.
+    pub chapter_start: Vec<usize>,
+    /// Every laid page across the book, in reading order.
+    pub pages: Vec<Page>,
+}
+
+/// Reads/writes laid paginations under `book.inkread/pagination/`, keyed by `layout_digest`.
+pub(crate) struct PaginationCache {
+    dir: PathBuf,
+}
+
+impl PaginationCache {
+    /// The cache rooted at a document's sidecar (`<book>.inkread/pagination/`).
+    pub(crate) fn new(paths: &SidecarPaths) -> Self {
+        Self {
+            dir: paths.root().join("pagination"),
+        }
+    }
+
+    fn file(&self, digest: u64) -> PathBuf {
+        self.dir.join(format!("{digest:016x}.json"))
+    }
+
+    /// The cached pagination for `digest`, or `None` on miss / oversize / corrupt — in every
+    /// non-hit case the caller lays out fresh. Never panics (RR21-FR3).
+    pub(crate) fn load(&self, digest: u64) -> Option<CachedPagination> {
+        let path = self.file(digest);
+        let meta = std::fs::metadata(&path).ok()?;
+        if meta.len() > MAX_CACHE_BYTES {
+            return None;
+        }
+        let bytes = std::fs::read(&path).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
+    /// Persist `cached` for `digest` atomically (crash-safe via [`atomic_write`]). Returns an error
+    /// only on a genuine I/O/serialization failure; callers treat caching as best-effort.
+    pub(crate) fn store(&self, digest: u64, cached: &CachedPagination) -> CoreResult<()> {
+        std::fs::create_dir_all(&self.dir)
+            .map_err(|e| CoreError::Persistence(format!("pagination cache mkdir: {e}")))?;
+        let bytes = serde_json::to_vec(cached)
+            .map_err(|e| CoreError::Persistence(format!("pagination cache encode: {e}")))?;
+        atomic_write(&self.file(digest), &bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use inkread_epub::layout::{paginate, LayoutOpts, Metrics};
+    use inkread_epub::parse_blocks;
+
+    /// A self-cleaning temp directory (mirrors the `ink_store` test helper).
+    struct TempDir {
+        path: PathBuf,
+    }
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let mut path = std::env::temp_dir();
+            path.push(format!("inkread-pgcache-{tag}-{:p}", &tag));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    struct Mono;
+    impl Metrics for Mono {
+        fn advance(&self, text: &str, size_px: f32, _b: bool, _i: bool) -> f32 {
+            text.chars().count() as f32 * size_px * 0.5
+        }
+    }
+
+    fn sample() -> CachedPagination {
+        let opts = LayoutOpts::new(400.0, 600.0, 16.0);
+        let blocks = parse_blocks("<html><body><p>one two three four</p></body></html>");
+        CachedPagination {
+            chapter_start: vec![0],
+            pages: paginate(&blocks, &opts, &Mono),
+        }
+    }
+
+    #[test]
+    fn round_trips_through_disk() {
+        let tmp = TempDir::new("rt");
+        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path));
+        let cached = sample();
+        cache.store(0xABCD, &cached).unwrap();
+        assert_eq!(cache.load(0xABCD), Some(cached));
+    }
+
+    #[test]
+    fn miss_and_corrupt_degrade_to_none() {
+        let tmp = TempDir::new("miss");
+        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path));
+        assert_eq!(cache.load(0x1234), None, "absent digest is a miss");
+
+        // A corrupt file at the digest's path is a miss, not a panic.
+        std::fs::create_dir_all(&cache.dir).unwrap();
+        std::fs::write(cache.file(0x1234), b"{ not valid json").unwrap();
+        assert_eq!(cache.load(0x1234), None, "corrupt blob degrades to a miss");
+    }
+
+    #[test]
+    fn distinct_digests_do_not_collide() {
+        let tmp = TempDir::new("keys");
+        let cache = PaginationCache::new(&SidecarPaths::from_root(&tmp.path));
+        let a = sample();
+        let mut b = sample();
+        b.chapter_start = vec![0, 1];
+        cache.store(1, &a).unwrap();
+        cache.store(2, &b).unwrap();
+        assert_eq!(cache.load(1), Some(a));
+        assert_eq!(cache.load(2), Some(b));
+    }
+}


### PR DESCRIPTION
> Stacked on #47 (base `feat/epub-source-anchor`). Review/merge #47 first.

## Summary

Makes reflow pagination **deterministic, addressable, and cacheable** (`SPEC-RUST-READER` RR8 / RR9-FR3, ADR-INKREAD-0013). Builds on the `PinPosition` anchor work in #47. Host-only; vendor-neutral.

## What's in here

1. **`LayoutOpts::layout_digest()`** — a stable hash of every layout-affecting field (viewport, font size, line/para spacing, alignment, margin); the pagination-cache key (RR9-FR3). **FNV-1a-64**, not `DefaultHasher`, because it names an on-disk file and must be stable across toolchains; pinned with a regression test.
2. **`EpubBackend::page_range(page)`** — the `[start, end)` `PageRange` of `PinPosition`s a page spans (RR8-FR4), derived host-side from the anchored glyphs; anchorless interior pages (rule/blank) are skipped, the last page ends at a chapter-end sentinel.
3. **serde on the laid-page model** (`Page`/`LayoutLine`/`PlacedRun`/`SourceAnchor`) so a pagination can be persisted and rehydrated losslessly.
4. **Disk pagination cache** (`reader-core/.../pagination_cache.rs`) — stores the **full laid pagination** under `book.inkread/pagination/<content-fingerprint>-<layout_digest>.json`. `EpubBackend::open_with_cache` (and every repagination) loads on a hit and skips `layout_all`, writing on a miss. Reuses `ink_store::atomic_write` for crash-safe writes.

## Correctness / safety

- **Stable key:** the cache key includes the FNV-1a content fingerprint (`persistence::identity`), so a changed file at the same sidecar path can never serve a stale pagination.
- **Validated on load:** a `chapter_start` that's inconsistent with the chapters/pages is rejected and re-laid-out, not trusted.
- **Advisory:** a miss / oversize (>64 MiB) / corrupt / foreign blob degrades to a fresh layout — never an error or panic (RR21-FR3), mirroring `ink_store`'s posture.

## Scope / not in this PR

- **`open_with_cache` is not yet wired into `ReaderSession`** — `session::open_epub` still uses the cache-less path, so on-device reopen isn't fast yet. Wiring needs `SidecarPaths` at the session layer (it currently holds only trait-object stores); it's the immediate follow-up.
- The `pagination/` dir isn't pruned yet (one file per content×viewport×style) — bound it (LRU/keep-N) when wiring lands.
- The background fork-and-walk + abort + byte-weighted progress (RR8-FR1/FR2) are deliberately deferred to device integration (ADR-0013 D4); current pagination is synchronous and correct.

## Testing

- `cargo test --workspace` green — 251 reader-core + 31 inkread-epub tests, including: digest stability/sensitivity + pinned value; `PageRange` stability + ordering; serde round-trip; cache hit (planted), miss/corrupt/oversize, stale-fingerprint, inconsistent-blob rejection.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean. Core builds host-only.
