### PR TITLE
fix(core): preserve in-progress strokes/erases on page turn (#50)

### DIFF
--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -1030,6 +1030,18 @@ impl ReaderSession {
         Ok(())
     }
 
+    /// Flush the outgoing page's ink on a page turn, retrying a bounded number of times so a single
+    /// transient IO hiccup (EINTR, a momentary lock) doesn't cost the user their ink — then giving
+    /// up so navigation never blocks on a hard failure (ENOSPC). Degrade-safely, RR20 / #50.
+    fn flush_ink_retrying(&mut self) {
+        const ATTEMPTS: u32 = 3;
+        for _ in 0..ATTEMPTS {
+            if self.flush_ink().is_ok() {
+                return;
+            }
+        }
+    }
+
     /// Persist the current page's layer to the store (RR20-FR2). No-op without a store.
     fn autosave_ink(&self) -> CoreResult<()> {
         if let Some(store) = &self.ink {
@@ -1169,13 +1181,14 @@ impl ReaderSession {
     /// Swap the in-memory layer to the current page's stored ink on a page change. Any pending
     /// stroke is dropped; the load degrades safely (see [`Self::load_layer_for_page`]).
     fn load_ink_for_current_page(&mut self) {
-        // In deferred mode the outgoing page may hold unsaved edits — flush before the layer is
-        // swapped out, or they'd be lost on the page turn. Best-effort, matching this module's
-        // degrade-safely stance: a transient write error must not block navigation.
-        if self.ink_dirty {
-            let _ = self.flush_ink(); // saves under `layer_page` (the outgoing page), not the new one
+        // A page turn must not silently drop an in-progress stroke (#50 — "disappearing strokes"):
+        // COMMIT it to the outgoing page instead of cancelling. Then persist the outgoing page
+        // before the layer is swapped — a just-committed stroke, or (deferred mode) pending edits.
+        // The flush saves under `layer_page` (the outgoing page), not the new one.
+        let committed = self.layer.finish_stroke().is_some();
+        if committed || self.ink_dirty {
+            self.flush_ink_retrying();
         }
-        self.layer.cancel_stroke();
         self.layer = self.load_layer_for_page(self.page);
         self.layer_page = self.page;
         // A page turn resets the view to fit (RR5-FR3): the old pan/zoom is meaningless on a new page.

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -968,6 +968,9 @@ impl ReaderSession {
         } else {
             self.erase_changed
         };
+        // Consume the erase flag: once the gesture ends it's been persisted (or marked dirty), so a
+        // lingering `erase_changed` must not later read as an *in-progress* erase on a page turn (#50).
+        self.erase_changed = false;
         if changed {
             self.persist_after_edit()?;
         }
@@ -1030,9 +1033,11 @@ impl ReaderSession {
         Ok(())
     }
 
-    /// Flush the outgoing page's ink on a page turn, retrying a bounded number of times so a single
-    /// transient IO hiccup (EINTR, a momentary lock) doesn't cost the user their ink — then giving
-    /// up so navigation never blocks on a hard failure (ENOSPC). Degrade-safely, RR20 / #50.
+    /// Flush the outgoing page's ink on a page turn, re-issuing the write a few times so a transient
+    /// failure that clears immediately (e.g. an `EINTR`-interrupted syscall) doesn't cost the user
+    /// their ink. The retry is immediate (no backoff), so it does NOT help a sustained condition
+    /// (`ENOSPC`, a held lock) — after a bounded number of attempts it gives up so navigation never
+    /// blocks on a hard failure. Degrade-safely, RR20 / #50.
     fn flush_ink_retrying(&mut self) {
         const ATTEMPTS: u32 = 3;
         for _ in 0..ATTEMPTS {
@@ -1178,17 +1183,24 @@ impl ReaderSession {
         self.document.export_pdf(out_path, &pages, mode)
     }
 
-    /// Swap the in-memory layer to the current page's stored ink on a page change. Any pending
-    /// stroke is dropped; the load degrades safely (see [`Self::load_layer_for_page`]).
+    /// Swap the in-memory layer to the current page's stored ink on a page change, persisting any
+    /// in-progress edit to the outgoing page first; the load degrades safely (see
+    /// [`Self::load_layer_for_page`]).
     fn load_ink_for_current_page(&mut self) {
-        // A page turn must not silently drop an in-progress stroke (#50 — "disappearing strokes"):
-        // COMMIT it to the outgoing page instead of cancelling. Then persist the outgoing page
-        // before the layer is swapped — a just-committed stroke, or (deferred mode) pending edits.
+        // A page turn must not silently drop an in-progress edit (#50 — "disappearing strokes"):
+        //  - a pending pen/highlighter stroke is COMMITTED to the outgoing page (not cancelled);
+        //  - an in-progress eraser gesture has already mutated the layer (`erase_changed`) but isn't
+        //    persisted until `ink_end_stroke` — the symmetric case — so it's flushed too;
+        //  - deferred mode's pending edits (`ink_dirty`) are flushed, as before.
         // The flush saves under `layer_page` (the outgoing page), not the new one.
         let committed = self.layer.finish_stroke().is_some();
-        if committed || self.ink_dirty {
+        if committed || self.erase_changed || self.ink_dirty {
             self.flush_ink_retrying();
         }
+        // The outgoing layer (and its edit state) is about to be discarded: clear the per-page edit
+        // flags so a flush that exhausted its retries can't leak a stale dirty bit onto the new page.
+        self.erase_changed = false;
+        self.ink_dirty = false;
         self.layer = self.load_layer_for_page(self.page);
         self.layer_page = self.page;
         // A page turn resets the view to fit (RR5-FR3): the old pan/zoom is meaningless on a new page.

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -470,14 +470,20 @@ fn fs_ink(doc: &std::path::Path) -> Arc<dyn InkStore> {
 /// [`MemInkStore`] — exercises the bounded page-turn flush retry (#50).
 struct FlakyStore {
     remaining_failures: AtomicU64,
+    save_attempts: AtomicU64,
     inner: MemInkStore,
 }
 impl FlakyStore {
     fn new(fail_n: u64) -> Self {
         Self {
             remaining_failures: AtomicU64::new(fail_n),
+            save_attempts: AtomicU64::new(0),
             inner: MemInkStore::new(),
         }
+    }
+    /// Total `save_page` calls seen (failed + succeeded) — for the no-spurious-save guard.
+    fn save_attempts(&self) -> u64 {
+        self.save_attempts.load(Ordering::Relaxed)
     }
 }
 impl InkStore for FlakyStore {
@@ -485,6 +491,7 @@ impl InkStore for FlakyStore {
         self.inner.load_page(page)
     }
     fn save_page(&self, page: usize, layer: &InkLayer) -> CoreResult<()> {
+        self.save_attempts.fetch_add(1, Ordering::Relaxed);
         if self.remaining_failures.load(Ordering::Relaxed) > 0 {
             self.remaining_failures.fetch_sub(1, Ordering::Relaxed);
             return Err(CoreError::Persistence("transient IO".into()));
@@ -602,6 +609,145 @@ fn page_turn_commits_an_in_progress_stroke() {
         s.ink_strokes().len(),
         1,
         "the once-pending stroke reloads on return — not lost"
+    );
+    assert_eq!(
+        s.ink_strokes()[0].points.len(),
+        2,
+        "the committed stroke kept its points, not just its existence"
+    );
+}
+
+#[test]
+fn page_turn_commits_an_in_progress_erase() {
+    // #50 (eraser parity): an erase applied but not yet ended (ink_end_stroke) is the symmetric
+    // "disappearing edit" — a page turn must persist it, not let the erased stroke reappear.
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    draw(&mut s, &[(0.10, 0.10), (0.20, 0.10)]); // page 0: a committed stroke
+    assert_eq!(store.pages_with_ink().unwrap(), vec![0]);
+
+    // Begin an eraser gesture over the stroke but DON'T end it (pen still down).
+    s.ink_begin_stroke(Tool::Eraser, InkColor::BLACK, 0.05, 0)
+        .unwrap();
+    s.ink_add_point(0.15, 0.10, 1.0, None, None, 0).unwrap();
+    assert_eq!(
+        s.ink_strokes().len(),
+        0,
+        "erase removed the stroke in-memory"
+    );
+
+    s.on_gesture(Gesture::NextPage); // turn mid-erase
+    assert!(
+        store.pages_with_ink().unwrap().is_empty(),
+        "the in-progress erase was persisted to the outgoing page (file removed)"
+    );
+    s.on_gesture(Gesture::PrevPage);
+    assert_eq!(
+        s.ink_strokes().len(),
+        0,
+        "the erased stroke stays gone on return — the erase wasn't lost"
+    );
+}
+
+#[test]
+fn page_turn_proceeds_when_flush_exhausts_its_retries() {
+    // #50 / RR20 degrade-safely: if every retry fails (e.g. ENOSPC), navigation must still proceed
+    // — never block, never panic — even though the outgoing page's ink is lost.
+    let store = Arc::new(FlakyStore::new(u64::MAX)); // never succeeds
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store) as Arc<dyn InkStore>)
+        .unwrap();
+
+    begin_pending(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    s.on_gesture(Gesture::NextPage); // must not panic / must not hang
+    assert_eq!(
+        s.current_page(),
+        1,
+        "navigation proceeded despite a hard write failure"
+    );
+    assert!(
+        store.pages_with_ink().unwrap().is_empty(),
+        "nothing persisted on a hard failure — but we degraded safely"
+    );
+}
+
+#[test]
+fn deferred_mode_page_turn_flush_retries_transient_io() {
+    // AC#3: in DEFERRED mode the outgoing page's pending edits are flushed on the turn, riding out
+    // transient IO with the retry (the immediate-mode retry is covered separately).
+    let store = Arc::new(FlakyStore::new(2)); // first 2 saves fail, 3rd (in budget) succeeds
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store) as Arc<dyn InkStore>)
+        .unwrap();
+    s.set_autosave_deferred(true).unwrap();
+
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]); // page 0, held in memory (ink_dirty), not yet saved
+    assert!(store.pages_with_ink().unwrap().is_empty());
+
+    s.on_gesture(Gesture::NextPage); // flush-with-retry over the 2 transient failures
+    assert_eq!(
+        store.pages_with_ink().unwrap(),
+        vec![0],
+        "deferred page-0 edits persisted via the page-turn flush retry"
+    );
+}
+
+#[test]
+fn clean_page_turn_does_not_resave_immediate_mode() {
+    // A page turn with no pending stroke and no in-progress erase must not rewrite the outgoing page
+    // (immediate mode already saved it per stroke-end) — avoids a needless e-ink-relevant write.
+    let store = Arc::new(FlakyStore::new(0)); // never fails; counts save_page calls
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store) as Arc<dyn InkStore>)
+        .unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]); // exactly one save (immediate stroke-end)
+    let before = store.save_attempts();
+
+    s.on_gesture(Gesture::NextPage); // clean turn: nothing to persist
+    assert_eq!(
+        store.save_attempts(),
+        before,
+        "a clean page turn did not re-save the outgoing page"
+    );
+}
+
+#[test]
+fn page_turn_commits_an_in_progress_highlighter_stroke() {
+    // Highlighter is_ink()==true, so it shares the pen commit-on-turn path — pin it explicitly.
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    s.ink_begin_stroke(Tool::Highlighter, InkColor::BLACK, 0.03, 0)
+        .unwrap();
+    s.ink_add_point(0.1, 0.1, 1.0, None, None, 0).unwrap();
+    s.ink_add_point(0.3, 0.1, 1.0, None, None, 0).unwrap();
+
+    s.on_gesture(Gesture::NextPage);
+    s.on_gesture(Gesture::PrevPage);
+    assert_eq!(
+        s.ink_strokes().len(),
+        1,
+        "an in-progress highlighter stroke survives a page turn too"
+    );
+}
+
+#[test]
+fn page_turn_preserves_committed_strokes_plus_the_pending_one() {
+    // A page with several committed strokes AND a pending one must reload ALL of them.
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    draw(&mut s, &[(0.3, 0.3), (0.4, 0.4)]);
+    begin_pending(&mut s, &[(0.5, 0.5), (0.6, 0.6)]); // 3rd, not finished
+
+    s.on_gesture(Gesture::NextPage);
+    s.on_gesture(Gesture::PrevPage);
+    assert_eq!(
+        s.ink_strokes().len(),
+        3,
+        "two committed + one once-pending stroke all reload"
     );
 }
 

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -466,6 +466,52 @@ fn fs_ink(doc: &std::path::Path) -> Arc<dyn InkStore> {
     Arc::new(FsInkStore::new(SidecarPaths::for_document(doc)))
 }
 
+/// An `InkStore` that fails its first `fail_n` saves (transient IO), then delegates to an inner
+/// [`MemInkStore`] — exercises the bounded page-turn flush retry (#50).
+struct FlakyStore {
+    remaining_failures: AtomicU64,
+    inner: MemInkStore,
+}
+impl FlakyStore {
+    fn new(fail_n: u64) -> Self {
+        Self {
+            remaining_failures: AtomicU64::new(fail_n),
+            inner: MemInkStore::new(),
+        }
+    }
+}
+impl InkStore for FlakyStore {
+    fn load_page(&self, page: usize) -> CoreResult<InkLayer> {
+        self.inner.load_page(page)
+    }
+    fn save_page(&self, page: usize, layer: &InkLayer) -> CoreResult<()> {
+        if self.remaining_failures.load(Ordering::Relaxed) > 0 {
+            self.remaining_failures.fetch_sub(1, Ordering::Relaxed);
+            return Err(CoreError::Persistence("transient IO".into()));
+        }
+        self.inner.save_page(page, layer)
+    }
+    fn pages_with_ink(&self) -> CoreResult<Vec<usize>> {
+        self.inner.pages_with_ink()
+    }
+    fn load_metadata(&self) -> CoreResult<Option<SidecarMetadata>> {
+        self.inner.load_metadata()
+    }
+    fn save_metadata(&self, meta: &SidecarMetadata) -> CoreResult<()> {
+        self.inner.save_metadata(meta)
+    }
+}
+
+/// Begin a pen stroke and add points but DON'T finish it — leaves a pending (in-progress) stroke,
+/// the mid-stroke state a page turn must not drop (#50).
+fn begin_pending(s: &mut ReaderSession, pts: &[(f32, f32)]) {
+    s.ink_begin_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0)
+        .unwrap();
+    for &(x, y) in pts {
+        s.ink_add_point(x, y, 1.0, None, None, 0).unwrap();
+    }
+}
+
 /// Draw and commit one pen stroke through the public session API.
 fn draw(s: &mut ReaderSession, pts: &[(f32, f32)]) {
     s.ink_begin_stroke(Tool::Pen, InkColor::BLACK, 0.01, 0)
@@ -527,6 +573,77 @@ fn page_turn_loads_each_pages_own_ink() {
     assert_eq!(s.ink_strokes().len(), 1, "page 0 ink reloaded on return");
     s.on_gesture(Gesture::NextPage); // page 1 again
     assert_eq!(s.ink_strokes().len(), 1, "page 1 ink intact");
+}
+
+#[test]
+fn page_turn_commits_an_in_progress_stroke() {
+    // #50: a page turn taken mid-stroke (pen still down) used to drop the pending stroke. It must
+    // instead be committed to the OUTGOING page and persisted, then reload on return.
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store)).unwrap();
+
+    begin_pending(&mut s, &[(0.1, 0.1), (0.2, 0.2)]); // pen down on page 0, not finished
+    assert_eq!(
+        s.ink_strokes().len(),
+        0,
+        "pending stroke isn't committed yet"
+    );
+
+    s.on_gesture(Gesture::NextPage); // turn the page mid-stroke
+    assert_eq!(
+        store.pages_with_ink().unwrap(),
+        vec![0],
+        "the in-progress stroke was committed + persisted to the outgoing page"
+    );
+
+    s.on_gesture(Gesture::PrevPage); // back to page 0
+    assert_eq!(
+        s.ink_strokes().len(),
+        1,
+        "the once-pending stroke reloads on return — not lost"
+    );
+}
+
+#[test]
+fn committed_stroke_survives_a_simulated_crash() {
+    // #50: in immediate mode a finished stroke is atomically written (fsync + rename) on stroke-end,
+    // so a hard kill with no graceful close still recovers it. Use a real FS sidecar; "crash" =
+    // open a fresh store over the same files without any save/close on the first session.
+    let tmp = TempDir::new();
+    let doc = tmp.path.join("book.pdf");
+
+    let mut s = session(1, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(fs_ink(&doc)).unwrap();
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]);
+    drop(s); // ReaderSession has no Drop/flush, so this is exactly a hard kill: nothing flushed here
+
+    let mut reopened = session(1, DeviceCapabilities::supernote_full());
+    reopened.attach_ink_store(fs_ink(&doc)).unwrap();
+    assert_eq!(
+        reopened.ink_strokes().len(),
+        1,
+        "the committed stroke was durable on disk before the crash"
+    );
+}
+
+#[test]
+fn page_turn_flush_retries_transient_io() {
+    // #50: the outgoing-page flush retries a transient IO error so a momentary hiccup doesn't drop
+    // the stroke. FlakyStore fails the first 2 saves; the 3rd (within the retry budget) persists.
+    let store = Arc::new(FlakyStore::new(2));
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(Arc::clone(&store) as Arc<dyn InkStore>)
+        .unwrap();
+
+    begin_pending(&mut s, &[(0.1, 0.1), (0.2, 0.2)]); // page 0, pen down
+    s.on_gesture(Gesture::NextPage); // commit + flush with retry over the 2 transient failures
+
+    assert_eq!(
+        store.pages_with_ink().unwrap(),
+        vec![0],
+        "the retry rode out the transient failures and persisted the stroke"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #50. Fixes the r/Supernote_beta P0 **"disappearing strokes"** — ink lost when a page turned mid-edit.

## What changed
- **Pending stroke dropped on page turn.** `load_ink_for_current_page` called `cancel_stroke()` on every turn, silently discarding an in-progress pen/highlighter stroke. It now **commits** the stroke to the outgoing page (`finish_stroke`) and persists before the layer is swapped.
- **In-progress eraser parity.** An erase applied but not yet ended was the symmetric case — a mid-erase page turn discarded the erasure and the erased stroke reappeared. The page-turn flush now also covers `erase_changed` (reset in `ink_end_stroke` so it only marks an in-progress gesture).
- **Bounded flush retry.** Persisting on the turn re-issues the write a few times so a transient hiccup (e.g. `EINTR`) doesn't cost the outgoing page's ink; after the bound it gives up so navigation never blocks on a hard failure (`ENOSPC`). The per-page edit flags are cleared afterward so an exhausted retry can't leak a stale dirty bit onto the new page.

Vector 2 (finish→persist durability) was already covered: `FsInkStore.save_page` writes a flushed `*.tmp`, atomically renames, and fsyncs the parent dir — so an immediate-mode stroke is on disk before `ink_end_stroke` returns. A test now proves it survives a no-graceful-close "crash".

3-agent reviewed (correctness/data-loss, persistence/durability, test coverage); all findings addressed.

## Testing
- **250 reader-core tests green** (host, no device); clippy + fmt clean. New: pending pen stroke commits + reloads on a page turn (with point fidelity); in-progress erase committed on turn; committed stroke survives a simulated crash (FsInkStore reopen); flush rides out transient IO; exhausted-retry proceeds without panic and persists nothing; deferred-mode flush-with-retry; clean turn doesn't re-save; highlighter + multi-stroke variants.
- Run with `JAVA_HOME` unset for Rust; use the rustup toolchain (Homebrew rustc 1.85 shadows it — bypass via PATH).
