### PR TITLE
perf: preserve zoom across page turns + enable zoomed page-turn

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -1276,9 +1276,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             } else {
                 val w = surfaceView.width.toFloat()
                 if (w > 0f) {
+                    // Follow a tapped link first (links are zoom/pan-aware via vToNx/vToNy) so a link
+                    // in the edge zone isn't swallowed as a page turn while zoomed (#52 review).
+                    val link = currentLinks.firstOrNull { it.contains(vToNx(fingerDownX), vToNy(fingerDownY)) }
+                    if (link != null) { followLink(link); return }
+                    // The minimap thumbnail is the OLD page's; drop it so the turn doesn't leave the
+                    // wrong page on screen (it re-captures on the next return to fit) (#52 review).
                     val third = w / 3f
-                    if (fingerDownX < third) { panY = 0f; queuePageTurn(-1) }
-                    else if (fingerDownX > 2f * third) { panY = 0f; queuePageTurn(+1) }
+                    if (fingerDownX < third) { panY = 0f; fitThumb = null; queuePageTurn(-1) }
+                    else if (fingerDownX > 2f * third) { panY = 0f; fitThumb = null; queuePageTurn(+1) }
                 }
             }
             return

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -1262,13 +1262,24 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // After a pinch, a 2→1 lift leaves a stale origin: commit no pan/tap for the trailing finger
         // (a fresh DOWN clears this latch and restarts clean panning) (#49).
         if (gestureWasMultiTouch) return
-        // Zoomed in: a drag pans the page; a still tap does nothing (no page-turn while zoomed).
+        // Zoomed in: a drag pans the page; a still tap in the L/R edge zone turns the page while
+        // KEEPING the zoom (#52), so a zoomed reader advances without zooming out and back. The core
+        // preserves zoom + column and resets to the top of the new page on a turn; mirror that
+        // top-reset locally (panY = 0) so the shell's pan stays in sync (no native read-back). Center
+        // stays a no-op while zoomed (it's content, not the menu).
         if (zoom > 1f) {
             if (fingerMoved) {
                 val overX = viewW * (zoom - 1f); val overY = viewH * (zoom - 1f)
                 if (overX > 0f) panX = (panX - (e.x - fingerDownX) / overX).coerceIn(0f, 1f)
                 if (overY > 0f) panY = (panY - (e.y - fingerDownY) / overY).coerceIn(0f, 1f)
                 applyZoom()
+            } else {
+                val w = surfaceView.width.toFloat()
+                if (w > 0f) {
+                    val third = w / 3f
+                    if (fingerDownX < third) { panY = 0f; queuePageTurn(-1) }
+                    else if (fingerDownX > 2f * third) { panY = 0f; queuePageTurn(+1) }
+                }
             }
             return
         }

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -696,6 +696,13 @@ impl ReaderSession {
                 self.page = new_page.min(self.page_count().saturating_sub(1));
                 *self.crop_cache.borrow_mut() = None; // page indices change meaning across the toggle
                 self.invalidate_render_cache(); // ...so do the cached page renders
+                                                // A reflowed view is never magnified (zoom is fixed-layout only, RR25-FR3). Drop a
+                                                // zoomed fixed-layout view to fit BEFORE the load (whose page-turn preserve would
+                                                // otherwise carry zoom > 1 into reflow mode — keeping the render off the cached fit
+                                                // path on every reflowed turn) (#52 review).
+                self.zoom = 1.0;
+                self.pan_x = 0.0;
+                self.pan_y = 0.0;
                 self.load_ink_for_current_page();
                 true
             }
@@ -1221,6 +1228,12 @@ impl ReaderSession {
         // column (pan_x), but land at the TOP of the new page (pan_y = 0) so a turn starts the same
         // column afresh. A magnified view is fixed-layout only (zoom > 1 never occurs in reflowed
         // text, RR25-FR3), so reflowed pages — always at fit — still reset cleanly.
+        //
+        // pan_x is a fraction of the magnified OVERSCAN, not an absolute column — so on a uniform
+        // PDF it lands the same column, but if the next page is narrower or a different layout
+        // (a title page, the last page) the same pan_x maps elsewhere. It stays numerically in
+        // range (clamped [0,1]); only the "same column" intent is approximate across a layout
+        // change. A precise mapping would need a column model the fixed-layout backend doesn't have.
         if self.zoom <= 1.0 + 1e-3 {
             self.zoom = 1.0;
             self.pan_x = 0.0;

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -622,6 +622,18 @@ impl ReaderSession {
         self.zoom
     }
 
+    /// The current horizontal pan `[0,1]` over the magnified overscan (0 at fit).
+    #[must_use]
+    pub fn pan_x(&self) -> f32 {
+        self.pan_x
+    }
+
+    /// The current vertical pan `[0,1]` over the magnified overscan (0 at fit / top of page).
+    #[must_use]
+    pub fn pan_y(&self) -> f32 {
+        self.pan_y
+    }
+
     /// Set the reflow **text scale** (font size; `1.0` = default) for a reflowable document,
     /// repaginating and preserving the reading position by chapter (RR2-FR5). Returns `true` if the
     /// format supports reflow (EPUB); `false` for fixed-layout PDF (no change). The shell re-renders
@@ -1203,9 +1215,16 @@ impl ReaderSession {
         self.ink_dirty = false;
         self.layer = self.load_layer_for_page(self.page);
         self.layer_page = self.page;
-        // A page turn resets the view to fit (RR5-FR3): the old pan/zoom is meaningless on a new page.
-        self.zoom = 1.0;
-        self.pan_x = 0.0;
+        // Preserve the reading magnification across a page turn (#52 — PDF nav responsiveness):
+        // dropping a zoomed-in view back to full-page fit on every turn forced the user to re-zoom,
+        // costing a second render to reach their intended view. Keep the zoom and the horizontal
+        // column (pan_x), but land at the TOP of the new page (pan_y = 0) so a turn starts the same
+        // column afresh. A magnified view is fixed-layout only (zoom > 1 never occurs in reflowed
+        // text, RR25-FR3), so reflowed pages — always at fit — still reset cleanly.
+        if self.zoom <= 1.0 + 1e-3 {
+            self.zoom = 1.0;
+            self.pan_x = 0.0;
+        }
         self.pan_y = 0.0;
     }
 

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -72,6 +72,30 @@ fn next_and_prev_advance_and_clamp() {
     assert_eq!(s.current_page(), 1);
 }
 
+#[test]
+fn page_turn_preserves_zoom_and_column_when_magnified() {
+    // #52: a zoomed-in (fixed-layout) view keeps its zoom + horizontal column across a page turn,
+    // landing at the TOP of the new page — instead of snapping to fit and forcing a re-zoom.
+    let mut s = session(3, DeviceCapabilities::supernote_full());
+    s.set_zoom(2.0, 0.5, 0.7); // 2× zoom, right-ish column, scrolled down
+    s.on_gesture(Gesture::NextPage);
+    assert_eq!(s.zoom(), 2.0, "zoom preserved across the turn");
+    assert_eq!(s.pan_x(), 0.5, "horizontal column preserved");
+    assert_eq!(s.pan_y(), 0.0, "lands at the top of the new page");
+}
+
+#[test]
+fn page_turn_from_fit_resets_the_view() {
+    // The fit case (zoom 1) keeps the clean reset: a stray pan is cleared so a non-magnified turn
+    // always lands on a plain full-page fit.
+    let mut s = session(3, DeviceCapabilities::supernote_full());
+    s.set_zoom(1.0, 0.3, 0.3);
+    s.on_gesture(Gesture::NextPage);
+    assert_eq!(s.zoom(), 1.0);
+    assert_eq!(s.pan_x(), 0.0, "fit view resets pan");
+    assert_eq!(s.pan_y(), 0.0);
+}
+
 // Amendment 6 + RR3-AC1: gestures delegate to the policy so the promotion is consistent.
 #[test]
 fn gestures_drive_the_policy_promotion() {

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -96,6 +96,58 @@ fn page_turn_from_fit_resets_the_view() {
     assert_eq!(s.pan_y(), 0.0);
 }
 
+/// A stub that reports as reflow-capable and accepts the toggle — for the reflow zoom-reset test.
+struct ReflowStub {
+    pages: usize,
+}
+impl Document for ReflowStub {
+    fn page_count(&self) -> usize {
+        self.pages
+    }
+    fn metadata(&self) -> DocumentMetadata {
+        DocumentMetadata {
+            title: None,
+            author: None,
+        }
+    }
+    fn render_page(&self, index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+        if index >= self.pages {
+            return Err(CoreError::PageOutOfRange {
+                requested: index,
+                available: self.pages,
+            });
+        }
+        buf.fill_white();
+        Ok(())
+    }
+    fn toc(&self) -> Vec<TocEntry> {
+        Vec::new()
+    }
+    fn supports_reflow(&self) -> bool {
+        true
+    }
+    fn set_reflow(&self, _on: bool, current_page: usize) -> Option<usize> {
+        Some(current_page)
+    }
+}
+
+#[test]
+fn reflow_toggle_drops_a_magnified_view_to_fit() {
+    // #52 review: toggling reflow while zoomed must reset to fit — a reflowed view is never
+    // magnified (RR25-FR3), and carrying zoom > 1 in would keep every reflowed turn off the cached
+    // fit render path (the magnified branch is uncached).
+    let mut s = ReaderSession::with_document(
+        Box::new(ReflowStub { pages: 3 }),
+        DeviceCapabilities::supernote_full(),
+        Viewport::new(100, 120, 226),
+    );
+    s.set_zoom(2.0, 0.5, 0.5);
+    assert!(s.set_reflow(true), "reflow toggle applied");
+    assert_eq!(s.zoom(), 1.0, "magnified view dropped to fit on reflow");
+    assert_eq!(s.pan_x(), 0.0);
+    assert_eq!(s.pan_y(), 0.0);
+}
+
 // Amendment 6 + RR3-AC1: gestures delegate to the policy so the promotion is consistent.
 #[test]
 fn gestures_drive_the_policy_promotion() {


### PR DESCRIPTION
Closes #52. r/Supernote_beta P1: **PDF navigation responsiveness** — a zoomed reader was dropped to full-page fit on every turn.

## What changed
**Core (host-tested):** a magnified fixed-layout view keeps its zoom + horizontal column across a page turn, landing at the top of the new page (`pan_y = 0`), instead of resetting to fit and forcing a re-zoom. Reflowed text (always at fit, RR25-FR3) still resets cleanly; toggling reflow drops a zoomed view to fit. Adds `pan_x()`/`pan_y()` getters.

**Shell:** a zoomed reader can now turn pages via an L/R edge tap (page turns were blocked entirely at `zoom > 1`, so the core change would be unreachable). Links are followed before the edge-zone turn; the zoom minimap's thumbnail is dropped on a zoomed turn so it never shows the previous page.

Net effect: a zoomed reader advances in **one render** instead of the old zoom-out → turn → zoom-in **three renders**.

## Not a cache change (misdiagnosis)
The issue's "zoom churns the render-cache key" root cause doesn't hold: `render_cache_key` pins `zoom = 1.0` (the cache is consulted only on the fit path), and fit buffers already persist across turns — only reflow/repagination/resize clear them. The magnified path is intentionally uncached (RR24-FR2). So the AC's "cache hit on a pure zoom step" rests on the misdiagnosis; the AC's *spirit* (reach the intended view without an extra render) is met via single-render-while-zoomed.

## Review
3-agent reviewed (core+cache, shell gesture interplay, UX/spec). No blockers. Findings fixed: reflow zoom-leak (core), links swallowed while zoomed (shell), stale minimap thumbnail (shell); documented that preserved `pan_x` is overscan-relative (approximate "same column" across a layout change — numerically safe). Confirmed the old "resets to fit (RR5-FR3)" comment was a fabricated citation — the spec mandates no such reset.

## ⚠️ On-device validation required before merge
The core is host-verified (258 reader-core tests, +3); the **shell gesture behavior is not host-testable** and hasn't been run on-device yet. Verify on a Supernote:
1. Zoom into a column → tap right edge → page turns and **stays magnified** at the top of the same column.
2. Tap left edge while zoomed → previous page, still zoomed.
3. Drag while zoomed → pans (doesn't turn).
4. Tap a hyperlink (edge zone) while zoomed → follows the link, doesn't turn.
5. Minimap after a zoomed turn → not the previous page (hidden until return to fit — confirm acceptable).
6. Tap near the minimap card edge → doesn't accidentally turn the page.

## Testing
258 reader-core tests green; clippy + fmt clean; app compiles (`JAVA_HOME` → Temurin 21).
