### PR TITLE
feat: font-size presets + document font/rotation discoverability (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Two surfaces drive everything: a **bottom control bar** (tap the centre of the p
 | Jump to a page | Centre-tap → drag the **slider**, or tap the page number to type one |
 | Table of contents | Centre-tap → **Contents** → tap an entry to jump |
 | Bookmark a page | Tap the **top-right corner** (dog-ear); list them via **Marks** |
-| Zoom & pan | **Pinch** to zoom; a minimap (top-right) shows your viewport. Fit/zoom presets live under **Adjust → Zoom** |
+| Zoom & pan | **Pinch** — or **double-tap the centre** — to zoom toward a point; **double-tap again** to restore fit. A minimap (top-right) shows your viewport; while zoomed, edge taps still turn pages. Fit/zoom presets also under **Adjust → Zoom** |
 
 ### Search & dictionary
 
@@ -190,9 +190,16 @@ Ink is saved to a sidecar next to your document and re-loaded next time.
 
 ### Display & layout
 
-Centre-tap → **Adjust** opens a tabbed sheet: **Rotate** (portrait/landscape), **Crop**
-(auto-crop + margin), **Zoom** (fit mode + level), **Page** (text scale), **Font** (line
-spacing, alignment — EPUB), and **Display** (contrast). Settings are remembered per book.
+Centre-tap → **Adjust** opens a tabbed sheet, remembered per book:
+
+| Tab | Controls |
+|---|---|
+| **Rotate** | Screen orientation — **0° / 90° / 180° / 270°** (portrait, landscape, and both flips) |
+| **Font** | **Text size** — A− / A+ steppers plus **100%** (default) and **XL** presets, 60%–250% (reflowable books) |
+| **Page** | Line spacing + alignment (reflowable books) |
+| **Zoom** | Fit mode + zoom level |
+| **Crop** | Auto-crop white margins + margin size |
+| **Display** | Contrast / display enhancement |
 
 > **On the roadmap:** EPUB reflow controls, Lua plugins, and cross-document search are in the
 > core or specified but not yet exposed in the shipped app — see [Status](#status).

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -115,6 +115,31 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     /** Whether PDF reflow mode is on (ADR-INKREAD-0011). Session-scoped: defaults off on each open
      *  (the fixed page is the faithful view; reflow is an opt-in toggle on the Page tab). */
     @Volatile private var reflowOn = false
+    /** True while a reflow toggle's full-document repagination is running (guards re-toggle + drives
+     *  the "Reflowing…" notice). Large PDFs take seconds (#55). */
+    @Volatile private var reflowInProgress = false
+    private var reflowProgressDialog: Dialog? = null
+    /** Shows the "Reflowing…" notice — posted with a short delay so a fast reflow never flashes it. */
+    private val showReflowProgress = Runnable {
+        if (isFinishing || docHandle == 0L) return@Runnable
+        val d = resources.displayMetrics.density
+        fun px(v: Int) = (v * d).toInt()
+        val msg = TextView(this).apply {
+            text = "Reflowing…"
+            textSize = 16f
+            setTextColor(Ink.ink) // black text on the white card below
+            setPadding(px(28), px(22), px(28), px(22))
+        }
+        reflowProgressDialog = Dialog(this).apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setCancelable(false)
+            setContentView(msg)
+            // Without an explicit light window background the dialog renders as a black box on this
+            // e-ink theme; use the app's white card (matches the other sheets) (#55).
+            window?.setBackgroundDrawable(Ink.cardBg())
+            runCatching { show() }
+        }
+    }
 
     // ---- dictionary (RR12 / D4) — owns the corpus handle + lookup/define/manage UI (SRP) ----
     private val dict = DictController(object : DictController.Host {
@@ -550,6 +575,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         mainHandler.removeCallbacks(fingerLongPress) // drop any pending finger gesture on leaving
         mainHandler.removeCallbacks(longPress)
         mainHandler.removeCallbacks(pendingCentreMenu) // don't pop the bar on a paused/finishing activity (#54)
+        dismissReflowProgress() // don't leak the "Reflowing…" dialog if backgrounded mid-reflow (#55)
         mainHandler.removeCallbacks(inkFlush) // the explicit flush below supersedes the debounce
         ink.teardown() // release the firmware ink claim + clear the overlay
         // Persist the reading position + flush ink when backgrounded (RR27/RR20) — engine thread.
@@ -2744,6 +2770,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
      *  reflowed PDF respects the user's font size / spacing / alignment; the page count and position
      *  change across the toggle, so refresh both. A `-1` means no text layer (scanned PDF). */
     private fun setReflowMode(on: Boolean) {
+        if (reflowInProgress) return // ignore a re-toggle while a reflow build is running
+        reflowInProgress = true
+        // Enabling reflow on a PDF re-extracts the text layer and repaginates the WHOLE document — on
+        // a large book that's several seconds. Show a "Reflowing…" notice if it doesn't finish
+        // quickly so the toggle doesn't look frozen; the delay means a small/fast doc never flashes
+        // the dialog (#55). The work itself is already off the UI thread (engine).
+        mainHandler.postDelayed(showReflowProgress, REFLOW_PROGRESS_DELAY_MS)
         engine.execute {
             val np = try { NativeBridge.nativeSetReflow(docHandle, on) } catch (e: RuntimeException) { -1 }
             if (np >= 0) {
@@ -2764,7 +2797,16 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             } else {
                 runOnUiThread { Toast.makeText(this, "This PDF has no text layer to reflow", Toast.LENGTH_SHORT).show() }
             }
+            runOnUiThread { dismissReflowProgress() }
         }
+    }
+
+    /** Dismiss the reflow "Reflowing…" notice (and cancel a not-yet-shown one); clears the guard. */
+    private fun dismissReflowProgress() {
+        mainHandler.removeCallbacks(showReflowProgress)
+        reflowProgressDialog?.let { runCatching { it.dismiss() } }
+        reflowProgressDialog = null
+        reflowInProgress = false
     }
 
     private fun lineSpacingPref(): Int =
@@ -2966,6 +3008,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val DOUBLE_TAP_ZOOM = 2.0f // zoom level a double-tap jumps to from fit (#54).
         const val DOUBLE_TAP_MS = 280L // max gap between the two taps of a double-tap (#54).
         const val DOUBLE_TAP_SLOP_PX = 60f // max distance between the two taps to count as a double-tap.
+        const val REFLOW_PROGRESS_DELAY_MS = 250L // show "Reflowing…" only if the build outlasts this (#55).
         const val SELECTION_HANDLE_PX = 8f // half-size of the square corner handles on the selection box.
         const val MULTILINE_DRAG_FRAC = 0.045f // drag vertical span (frac of height) above which it's a multi-line → line-span select.
         const val OPEN_DRAG_FRAC = 0.08f // lasso: start-to-lift distance (normalized) above which the gesture is an open drag (vs a closed loop).

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -2870,6 +2870,12 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 val m = dp(10); setMargins(m, 0, m, 0)
             })
             addView(pill("A+") { if (idx < TEXT_SCALES.size - 1) { idx++; apply() } })
+            // Quick presets next to the steppers: jump straight to default / largest (#55).
+            fun preset(p: View) = addView(p, LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
+            ).apply { leftMargin = dp(8) })
+            preset(pill("100%") { idx = nearestScaleIndex(1.0f); apply() })
+            preset(pill("XL") { idx = TEXT_SCALES.size - 1; apply() })
         }
         return settingRow("Font Size", control)
     }


### PR DESCRIPTION
Closes #55. r/Supernote_beta P2: font size and rotation already work but users didn't know they exist — surface them; plus a reflow-toggle UX fix found while testing.

## What changed
- **Font panel** (`Adjust → Font`): added **100%** (jump to default) and **XL** (jump to max) quick presets beside the A−/A+ steppers. Range unchanged (60%–250%, reflowable books).
- **Reflow toggle** (`Adjust → Page → Reflow`): enabling reflow on a large PDF repaginates the whole document (seconds on a big book) and previously gave no feedback — it looked frozen. Now shows a **"Reflowing…"** notice, delayed 250ms so a fast doc never flashes it, dismissed when the build finishes; re-entrancy guarded and torn down on pause. (UX only — reflow speed is unchanged.)
- **README** (Display & layout): rewrote as a tab table that explicitly calls out **Rotate** (0/90/180/270) and **Font size** (60–250% with presets); fixed a swapped Font/Page label; documented the double-tap-to-zoom and zoomed-page-turn gestures.

Rotation already lives as the first Adjust tab, so it needed only the README.

## Testing
App compiles (`JAVA_HOME` → Temurin 21). Device-validated on a Supernote Nomad: font presets work; the "Reflowing…" notice shows as a white card during a 1098-page PDF reflow and dismisses on completion.
