### PR TITLE
fix: EPUB multi-line text drag-selection (+ single-line regression)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -2192,6 +2192,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val multiLine = (y1 - y0) > MULTILINE_DRAG_FRAC
         if (multiLine) {
             if (openDrag) presentLineSpanSelection(sx, sy, ex, ey, "No text under the selection")
+            // Closed loop: corner→corner. The last line is clipped to the loop's rightmost extent
+            // (x1), an approximation — for an irregular loop that may run a word or two past where the
+            // user closed it on the bottom line. Acceptable for circling a region; the directional
+            // open-drag path above clips precisely to the actual lift point.
             else presentLineSpanSelection(x0, y0, x1, y1, "No text under the selection")
         } else {
             // Single line → the dragged/circled span on that line (precise, horizontal).

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -2183,13 +2183,18 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             y0 = minOf(y0, poly[i + 1]); y1 = maxOf(y1, poly[i + 1])
             i += 2
         }
-        // Open drag (lift far from start) spanning multiple lines → reading-order line span; a closed
-        // loop (lift returns near the start) → the bounding box of what was circled.
+        // A MULTI-LINE text selection always reads in reading order — intermediate lines whole, the
+        // last line clipped — whether the gesture was an open drag or a closed loop (a geometric
+        // bbox across lines would catch only the columns inside the loop, leaving intermediate lines
+        // partial). Use the drag's start→lift when it's a directional open drag; for a closed loop
+        // use its top-left→bottom-right corners so the span still reads top to bottom.
         val openDrag = kotlin.math.hypot(ex - sx, ey - sy) > OPEN_DRAG_FRAC
         val multiLine = (y1 - y0) > MULTILINE_DRAG_FRAC
-        if (openDrag && multiLine) {
-            presentLineSpanSelection(sx, sy, ex, ey, "No text under the selection")
+        if (multiLine) {
+            if (openDrag) presentLineSpanSelection(sx, sy, ex, ey, "No text under the selection")
+            else presentLineSpanSelection(x0, y0, x1, y1, "No text under the selection")
         } else {
+            // Single line → the dragged/circled span on that line (precise, horizontal).
             presentTextSelection(x0, y0, x1, y1, "Nothing under the loop — circle ink or printed words")
         }
     }

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -550,11 +550,22 @@ mod tests {
         let _ = render(&b, 0, 400, 600);
         let sel = b.text_line_span(0, (0.05, 0.02), (0.60, 0.30)); // a drag down the top of page 0
         assert!(
-            !sel.text.trim().is_empty(),
-            "reflowed line-span selects text, got '{}'",
+            !sel.boxes.is_empty(),
+            "reflowed line-span produces highlight boxes"
+        );
+        // Correctness, not just wiring: the span must be REAL page text. Pull a word the page
+        // actually has and confirm the top-of-page span contains it (the first line is taken whole,
+        // so the page's opening words are in range) — a wrong-glyph override would not contain it.
+        let page_text: String = b.page_chars(0).iter().map(|c| c.ch).collect();
+        let word = page_text
+            .split_whitespace()
+            .find(|w| w.chars().all(|c| c.is_alphabetic()) && w.len() >= 4)
+            .expect("a real word on page 0");
+        assert!(
+            sel.text.contains(word),
+            "line-span selects actual page text containing {word:?}, got '{}'",
             sel.text
         );
-        assert!(!sel.boxes.is_empty(), "and produces highlight boxes");
     }
 
     #[test]

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -288,6 +288,12 @@ impl Document for EpubBackend {
         text_select::text_in_rect(&self.page_chars(page), rect)
     }
 
+    fn text_line_span(&self, page: usize, start: (f32, f32), end: (f32, f32)) -> TextSelection {
+        // EPUB needs the reading-order line span too (it was falling through to the empty trait
+        // default — a multi-line drag selected nothing on a reflowed page) (#46 device finding).
+        text_select::text_line_span(&self.page_chars(page), start, end)
+    }
+
     fn search_page(&self, page: usize, query: &str) -> Vec<SearchMatch> {
         text_select::find_matches(&self.page_chars(page), query)
     }
@@ -533,6 +539,22 @@ mod tests {
         b.set_text_scale(1.7, 0).unwrap();
         assert_eq!(char_at(&b, &start), Some(sc), "start re-anchors");
         assert_eq!(char_at(&b, &end), Some(ec), "end re-anchors");
+    }
+
+    #[test]
+    fn text_line_span_selects_reflowed_lines() {
+        // Regression (#46 device finding): EpubBackend didn't override text_line_span, so a multi-line
+        // drag on a reflowed page hit the Document trait's empty default and selected nothing — the
+        // bbox path worked, the line-span path returned ''. The override must select real text.
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        let _ = render(&b, 0, 400, 600);
+        let sel = b.text_line_span(0, (0.05, 0.02), (0.60, 0.30)); // a drag down the top of page 0
+        assert!(
+            !sel.text.trim().is_empty(),
+            "reflowed line-span selects text, got '{}'",
+            sel.text
+        );
+        assert!(!sel.boxes.is_empty(), "and produces highlight boxes");
     }
 
     #[test]

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -253,10 +253,21 @@ pub fn word_at(chars: &[CharBox], x: f32, y: f32) -> Option<TextSelection> {
 /// "inside the loop" (it keeps a glyph at least half-covered along the axis the rect edge cuts —
 /// a corner clip can be lower, which is the intended tightening). Shared by [`text_in_rect`] and
 /// [`anchored_span`] so the highlight and its stored anchors never disagree on which glyphs are in.
+///
+/// Horizontal is always strict centre-in-range (precise column boundary). Vertical accepts EITHER
+/// the centre inside the rect (the normal case) OR the glyph's box straddling the rect's mid-line —
+/// so a **thin single-line drag** (a Define swipe whose bbox is shorter than the glyphs and may not
+/// reach their centres) still selects the line it runs along, without re-admitting a neighbouring
+/// line a tall lasso bbox only grazes (its mid-line lands on the line it's centred over, not the
+/// grazed one).
 fn glyph_selected(rect: &NormRect, glyph: &NormRect) -> bool {
     let cx = (glyph.x0 + glyph.x1) * 0.5;
+    if cx < rect.x0 || cx > rect.x1 {
+        return false;
+    }
     let cy = (glyph.y0 + glyph.y1) * 0.5;
-    rect.contains(cx, cy)
+    let rect_mid_y = (rect.y0 + rect.y1) * 0.5;
+    (cy >= rect.y0 && cy <= rect.y1) || (glyph.y0 <= rect_mid_y && rect_mid_y <= glyph.y1)
 }
 
 /// The text whose glyphs fall within `rect` (drag-highlight), in reading order, with one highlight
@@ -758,6 +769,26 @@ mod tests {
             },
         );
         assert!(sel.is_empty());
+    }
+
+    #[test]
+    fn text_in_rect_selects_a_thin_horizontal_drag_on_one_line() {
+        // Regression (#51 → Define drag-select): a single-line drag is a THIN rect along the text;
+        // its y-range sits inside the glyphs but need not straddle their centres. Centre-point alone
+        // dropped it (nothing selected); a glyph whose box contains the drag's mid-line is selected.
+        let chars = line("hello world", 0.0, 0.55, 0.10, 0.03); // glyphs y[.10,.13], centres y=.115
+        let rect = NormRect {
+            x0: 0.0,
+            y0: 0.118,
+            x1: 0.30,
+            y1: 0.126,
+        }; // a swipe just below the glyph centres
+        let sel = text_in_rect(&chars, rect);
+        assert!(
+            sel.text.starts_with("hello"),
+            "thin single-line drag selects the line's words, got '{}'",
+            sel.text
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #37.

## What changed

**`reader-core` (EPUB backend):** `EpubBackend` did not override `Document::text_line_span`, so a multi-line drag on a reflowed EPUB page fell through to the trait's empty default and selected nothing — the bbox path worked, the reading-order line-span path returned `''`. Override it to delegate to `text_select::text_line_span` over the page's chars.

**`reader-core` (text_select):** restore single-line drag selection that #51's center-point predicate broke for a thin horizontal rect (a one-line drag whose rect is shorter than a glyph). `glyph_selected` now also accepts a glyph straddling the rect's mid-line.

**Shell (`ReaderActivity`):** route every multi-line selection through the line-span path (intermediate lines whole, last line clipped) for both open drags and closed loops. A geometric bbox across lines caught only the columns inside the loop, leaving intermediate lines partial. Single-line selections keep the precise bbox path.

## Testing

- `cargo fmt` / `cargo clippy -p reader-core --all-targets -D warnings` / `cargo test -p reader-core` — 260 pass, incl. new regressions `text_line_span_selects_reflowed_lines` and `text_in_rect_selects_a_thin_horizontal_drag_on_one_line`.
- Device-verified on the Nomad: multi-line EPUB pen drags now return spans (`boxes=3`) where they previously returned empty; the Define action is correctly hidden for multi-line selections; single-line drags select on one line.