### PR TITLE
feat(core): reflow-stable reading-position resume via PinPosition

### DIFF
--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -403,6 +403,33 @@ pub trait Document {
         None
     }
 
+    /// The reflow-stable [`PinPosition`](crate::position::PinPosition) a `page` starts at, for a
+    /// reflowable backend — a locator that survives a font-size / line-spacing / alignment change
+    /// (RR8/RR12). `None` for a fixed-layout format (its page index is already stable) or an empty
+    /// page. Default: none.
+    fn page_pin(&self, _page: usize) -> Option<crate::position::PinPosition> {
+        None
+    }
+
+    /// Resolve a [`PinPosition`](crate::position::PinPosition) back to the global page that contains
+    /// it under the CURRENT pagination — re-anchoring a saved location after a re-layout (RR12-FR4).
+    /// `None` for a fixed-layout format (it has no pins). Default: none.
+    fn pin_to_page(&self, _pin: &crate::position::PinPosition) -> Option<usize> {
+        None
+    }
+
+    /// The `[start, end]` [`PinPosition`](crate::position::PinPosition) pair a selection rectangle
+    /// covers on `page`, for a reflowable backend — the reflow-stable anchor a highlight / note /
+    /// Digest range stores (RR11-FR4 / RR12). `None` for a fixed-layout format or an empty
+    /// selection. Default: none.
+    fn selection_pins(
+        &self,
+        _page: usize,
+        _rect: NormRect,
+    ) -> Option<(crate::position::PinPosition, crate::position::PinPosition)> {
+        None
+    }
+
     /// Prefetch hint (RR4-FR7): the core may call this after rendering the current page so a
     /// backend can warm an internal handle for the likely-next page, making a page turn blit a
     /// ready buffer. Default: a no-op (backends opt in). Must never panic on a bad index.

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -163,10 +163,9 @@ impl EpubBackend {
     /// backend owns the chapter identity; the offset is carried in `text_offset` so `position_int()`
     /// orders within the chapter, and `xpath = [block]` re-anchors the source block (ADR-0012 D2).
     //
-    // `pin_at`/`page_pin`/`pin_to_page` are the PinPosition composition foundation (ADR-0012 Phase 1,
-    // step 2). They are exercised by tests now and consumed in the follow-ups — selection→pin-pair
-    // and the RR12 reading-position resume / Digest wiring — hence `allow(dead_code)` until then.
-    #[allow(dead_code)]
+    // `pin_at`/`page_pin`/`pin_to_page`/`selection_pins` are the PinPosition composition foundation
+    // (ADR-0012 Phase 1, step 2), now exposed through the `Document` trait for the RR12
+    // reading-position resume + Digest anchor wiring (#46).
     fn pin_at(&self, chapter: usize, anchor: TextAnchor) -> PinPosition {
         PinPosition {
             chapter_index: chapter as i32,
@@ -181,7 +180,6 @@ impl EpubBackend {
 
     /// The [`PinPosition`] a global `page` starts at — its first anchored glyph (RR8/RR12 reading
     /// position). `None` for an empty page (no glyphs to anchor).
-    #[allow(dead_code)]
     pub(crate) fn page_pin(&self, page: usize) -> Option<PinPosition> {
         let chapter = self.chapter_of(page);
         let anchor = self.page_chars(page).into_iter().find_map(|c| c.anchor)?;
@@ -191,7 +189,6 @@ impl EpubBackend {
     /// Resolve a [`PinPosition`] back to the global page that contains it after a re-layout — the
     /// re-anchoring that makes a highlight/Digest survive a font-size change (RR12-FR4). Picks, within
     /// the pin's chapter, the last page whose first anchored glyph is at or before the pin's offset.
-    #[allow(dead_code)]
     pub(crate) fn pin_to_page(&self, pin: &PinPosition) -> usize {
         let laid = self.laid.borrow();
         // Clamp a foreign/corrupt chapter index into range rather than scanning the whole book.
@@ -220,7 +217,6 @@ impl EpubBackend {
 
     /// The `[start, end]` [`PinPosition`] pair a selection rectangle covers on `page` — the anchor a
     /// highlight / note / Digest range stores (RR11-FR4 / RR12). `None` when nothing is selected.
-    #[allow(dead_code)]
     pub(crate) fn selection_pins(
         &self,
         page: usize,
@@ -317,6 +313,21 @@ impl Document for EpubBackend {
     fn set_alignment(&self, align_code: i32, current_page: usize) -> Option<usize> {
         self.align.set(Align::from_code(align_code));
         self.repaginate_keeping_chapter(current_page)
+    }
+
+    // Reflow-stable anchors (RR8/RR12, ADR-0012): expose the inherent pin machinery through the
+    // trait so the session can persist a resume/Digest locator that survives a re-layout. Fixed
+    // layout keeps the trait defaults (`None`); fully-qualified calls hit the inherent impls above.
+    fn page_pin(&self, page: usize) -> Option<PinPosition> {
+        EpubBackend::page_pin(self, page)
+    }
+
+    fn pin_to_page(&self, pin: &PinPosition) -> Option<usize> {
+        Some(EpubBackend::pin_to_page(self, pin))
+    }
+
+    fn selection_pins(&self, page: usize, rect: NormRect) -> Option<(PinPosition, PinPosition)> {
+        EpubBackend::selection_pins(self, page, rect)
     }
 }
 

--- a/reader-core/src/persistence/mod.rs
+++ b/reader-core/src/persistence/mod.rs
@@ -79,6 +79,14 @@ impl ReadingPosition {
         }
     }
 
+    /// Set the opaque resume blob (the reflow-stable `PinPosition` JSON, RR12-FR4 / #46). Chained
+    /// after [`Self::new`]; `None` leaves it page-only.
+    #[must_use]
+    pub fn with_resume_blob(mut self, blob: Option<Vec<u8>>) -> Self {
+        self.resume_blob = blob;
+        self
+    }
+
     /// Human-facing progress as `"current/total"` (1-based current), e.g. `"3/12"` (RR12-FR3).
     /// An empty document reads `"0/0"`.
     #[must_use]

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -294,7 +294,18 @@ impl ReaderSession {
         self.apply_settings(&settings, Some(&book));
         if let Some(pos) = store.load_position(&book)? {
             let last = self.page_count().saturating_sub(1);
-            self.page = pos.page_index.min(last);
+            // Prefer the reflow-stable pin (RR12-FR4 / #46): a saved EPUB position re-anchors to the
+            // right page under the CURRENT pagination, surviving a font-size change since the last
+            // open. The integer page is the fallback (fixed-layout PDF, or a position saved before
+            // pins, or a malformed blob).
+            self.page = pos
+                .resume_blob
+                .as_deref()
+                .and_then(|b| std::str::from_utf8(b).ok())
+                .and_then(|s| crate::position::PinPosition::from_json(s).ok())
+                .and_then(|pin| self.document.pin_to_page(&pin))
+                .map(|p| p.min(last))
+                .unwrap_or_else(|| pos.page_index.min(last));
         }
         self.store = Some(store);
         self.book = Some(book);
@@ -312,12 +323,32 @@ impl ReaderSession {
             .with_avoid_flashing(settings.avoid_flashing(book));
     }
 
-    /// Persist the current reading position (RR12-FR3). A store-less session is a no-op.
+    /// Persist the current reading position (RR12-FR3). For a reflowable document it also stores the
+    /// page's reflow-stable [`PinPosition`] JSON in `resume_blob` so the next open re-anchors across
+    /// a font-size change (RR12-FR4 / #46); fixed-layout PDF stores the integer page only. A
+    /// store-less session is a no-op.
     pub fn save_position(&self) -> CoreResult<()> {
         if let (Some(store), Some(book)) = (&self.store, &self.book) {
-            store.save_position(book, &ReadingPosition::new(self.page, self.page_count()))?;
+            let blob = self
+                .document
+                .page_pin(self.page)
+                .map(|pin| pin.to_json().into_bytes());
+            let pos = ReadingPosition::new(self.page, self.page_count()).with_resume_blob(blob);
+            store.save_position(book, &pos)?;
         }
         Ok(())
+    }
+
+    /// The `[start, end]` reflow-stable anchor pair a selection rectangle covers on `page`, for a
+    /// reflowable document — the Digest/highlight locator (RR11-FR4 / #46). `None` for fixed-layout
+    /// PDF or an empty selection; the caller falls back to a page anchor.
+    #[must_use]
+    pub fn selection_pins(
+        &self,
+        page: usize,
+        rect: NormRect,
+    ) -> Option<(crate::position::PinPosition, crate::position::PinPosition)> {
+        self.document.selection_pins(page, rect)
     }
 
     /// The bounded render + cover caches (RR24). [`Self::render_current`] consults/fills the render

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -274,6 +274,112 @@ fn resume_clamps_to_document_range() {
     assert_eq!(s.current_page(), 4);
 }
 
+/// A reflowable-style stub that carries reflow-stable pins. `page_pin` encodes the page in the pin's
+/// `text_offset`; `pin_to_page` simulates a re-layout that shifts every page by +1 — so a resume that
+/// uses the pin lands one page past the saved integer, proving the pin path (not the int fallback)
+/// drives the re-anchor (#46).
+struct PinStub {
+    pages: usize,
+}
+impl Document for PinStub {
+    fn page_count(&self) -> usize {
+        self.pages
+    }
+    fn metadata(&self) -> DocumentMetadata {
+        DocumentMetadata {
+            title: None,
+            author: None,
+        }
+    }
+    fn render_page(&self, index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+        if index >= self.pages {
+            return Err(CoreError::PageOutOfRange {
+                requested: index,
+                available: self.pages,
+            });
+        }
+        buf.fill_white();
+        Ok(())
+    }
+    fn toc(&self) -> Vec<TocEntry> {
+        Vec::new()
+    }
+    fn page_pin(&self, page: usize) -> Option<crate::position::PinPosition> {
+        Some(crate::position::PinPosition {
+            chapter_index: 0,
+            chapter_id: "c".into(),
+            chapter_start: 0,
+            chapter_end: i32::MAX,
+            node_position: 0,
+            text_offset: page as i32,
+            xpath: vec![],
+        })
+    }
+    fn pin_to_page(&self, pin: &crate::position::PinPosition) -> Option<usize> {
+        Some(pin.text_offset as usize + 1) // a re-layout shifted everything one page on
+    }
+}
+
+fn pin_store_session(pages: usize, store: Arc<dyn ReaderStore>, book: BookId) -> ReaderSession {
+    ReaderSession::with_document_and_store(
+        Box::new(PinStub { pages }),
+        DeviceCapabilities::supernote_full(),
+        Viewport::new(100, 120, 226),
+        store,
+        book,
+    )
+    .unwrap()
+}
+
+#[test]
+fn save_position_stores_a_pin_for_reflowable_and_resume_re_anchors_via_it() {
+    // #46/RR12-FR4: a reflowable position persists a PinPosition blob, and a later open re-anchors
+    // through it (pin_to_page) rather than trusting the stale integer page from a different layout.
+    let store: Arc<dyn ReaderStore> = Arc::new(SqliteStore::open_in_memory().unwrap());
+    let book = BookId::new("b").unwrap();
+    let mut a = pin_store_session(6, store.clone(), book.clone());
+    a.on_gesture(Gesture::NextPage);
+    a.on_gesture(Gesture::NextPage); // page 2
+    a.save_position().unwrap();
+
+    let loaded = store.load_position(&book).unwrap().unwrap();
+    assert_eq!(
+        loaded.page_index, 2,
+        "the integer page is still recorded as a fallback"
+    );
+    assert!(
+        loaded.resume_blob.is_some(),
+        "a reflowable position stores a pin blob"
+    );
+
+    let b = pin_store_session(6, store, book);
+    assert_eq!(
+        b.current_page(),
+        3,
+        "resume re-anchored via the pin (page 2 + the +1 re-layout shift), not the stale integer 2"
+    );
+}
+
+#[test]
+fn fixed_layout_position_stores_no_pin_and_resumes_by_page() {
+    // A fixed-layout doc (no pins) keeps the page-only behaviour — no blob, resume by integer page.
+    let store: Arc<dyn ReaderStore> = Arc::new(SqliteStore::open_in_memory().unwrap());
+    let book = BookId::new("b").unwrap();
+    let mut a = store_session(6, store.clone(), book.clone()); // StubDoc → no pins
+    a.on_gesture(Gesture::NextPage);
+    a.on_gesture(Gesture::NextPage); // page 2
+    a.save_position().unwrap();
+
+    let loaded = store.load_position(&book).unwrap().unwrap();
+    assert!(loaded.resume_blob.is_none(), "fixed-layout stores no pin");
+    let b = store_session(6, store, book);
+    assert_eq!(
+        b.current_page(),
+        2,
+        "fixed-layout resumes by the integer page"
+    );
+}
+
 // A store-less session: saving is a no-op (M0 path stays green).
 #[test]
 fn store_less_save_is_noop() {


### PR DESCRIPTION
Foundation for #46. Wires the previously dead-coded PinPosition machinery (ADR-0012) so a reflowable reading position survives repagination, and exposes the selection→pin pair the Digest anchor will consume.

## What changed

**`Document` trait (`mod.rs`):** promote `page_pin` / `pin_to_page` / `selection_pins` onto the trait (default `None` for fixed-layout). `EpubBackend` overrides delegate to the existing inherent impls; the `#[allow(dead_code)]` gates are dropped.

**Persistence (`persistence/mod.rs`):** new `ReadingPosition::with_resume_blob` builder.

**Session (`session.rs`):**
- `save_position` stores the page's `PinPosition` JSON in `ReadingPosition`'s reserved `resume_blob` for a reflowable doc (page-only for fixed-layout PDF).
- `attach_store` resume prefers the pin: it re-anchors to the correct page under the **current** pagination (RR12-FR4), so an EPUB position survives a font-size change since the last open. Integer page is the fallback (PDF, pre-pin, or unparseable blob).
- expose `ReaderSession::selection_pins` for the Digest anchor.

## Testing

- `cargo fmt --check` / `cargo clippy -p reader-core --all-targets -D warnings` / `cargo test -p reader-core` — 260 pass, fmt + clippy clean, core stays host-only.
- New session tests: a reflowable position persists a pin blob and resume re-anchors through it (not the stale integer page); fixed-layout stores no blob and resumes by page.