### PR TITLE
fix(app): gate all zoom entry points on a magnifiable view

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -184,6 +184,11 @@ object NativeBridge {
      *  enable/disable the Reflow control (false for scanned PDFs and for EPUB, already reflowable). */
     external fun nativeSupportsReflow(handle: Long): Boolean
 
+    /** Whether the CURRENT view honors zoom — a fixed-layout page that is not reflowed (RR25-FR3).
+     *  Gate every zoom entry point (pinch / +− / double-tap) on this so a gesture on a reflowable
+     *  view (EPUB, or a reflowed PDF) can't strand the shell's zoom factor and skew tap hit-testing. */
+    external fun nativeIsMagnifiable(handle: Long): Boolean
+
     /** Toggle reflow mode on a text-layer PDF (ADR-INKREAD-0011): reconstructs the page text and flows
      *  it like a book so font/spacing/alignment take effect; off restores the fixed page. Returns the
      *  new current page index (page count changes across the toggle), or -1 if reflow is unavailable.

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -115,6 +115,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     /** Whether PDF reflow mode is on (ADR-INKREAD-0011). Session-scoped: defaults off on each open
      *  (the fixed page is the faithful view; reflow is an opt-in toggle on the Page tab). */
     @Volatile private var reflowOn = false
+    /** Whether the current view honors zoom — a fixed-layout page that is not reflowed (#61, mirrors
+     *  the core's `is_magnifiable`). Gates every zoom entry point so a pinch/double-tap on a
+     *  reflowable view (EPUB, or a reflowed PDF) can't strand the shell's zoom. Refreshed on open and
+     *  on a reflow toggle. */
+    @Volatile private var magnifiable = false
     /** True while a reflow toggle's full-document repagination is running (guards re-toggle + drives
      *  the "Reflowing…" notice). Large PDFs take seconds (#55). */
     @Volatile private var reflowInProgress = false
@@ -758,6 +763,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             bookmarks = Bookmarks(File(filesDir, "bookmarks/${bookId.hashCode()}.json")).also { it.load() }
             currentBookId = bookId
             reflowOn = false // a fresh document opens in fixed-layout view (ADR-INKREAD-0011)
+            // A fixed-layout PDF magnifies; EPUB (always reflowed) does not (#61, RR25-FR3).
+            magnifiable = try { NativeBridge.nativeIsMagnifiable(docHandle) } catch (e: RuntimeException) { false }
             // Re-apply the saved reflow text scale (EPUB); a no-op (-1) on fixed-layout PDF.
             val savedScale = textScalePref()
             if (savedScale != 1.0f) {
@@ -1873,6 +1880,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     /** Multiply the zoom (clamped); snap back to fit at ~1. Used by the +/- buttons and pinch-end. */
     private fun zoomBy(factor: Float) {
+        if (!magnifiable) return // a reflowed view ignores zoom; don't strand the shell factor (#61)
         val next = (zoom * factor).coerceIn(1f, MAX_ZOOM_UI)
         if (zoom <= 1f && next > 1f) captureFitThumb() // grab the fit thumb before leaving fit
         zoom = next
@@ -1886,6 +1894,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
      * double-tap restores fit. `(fx, fy)` is the tap in view pixels.
      */
     private fun doubleTapZoom(fx: Float, fy: Float) {
+        if (!magnifiable) return // reflowable view: a double-tap can't magnify (#61)
         if (zoom > 1f) {
             zoom = 1f; panX = 0f; panY = 0f
             applyZoom()
@@ -1940,6 +1949,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private val scaleDetector by lazy {
         android.view.ScaleGestureDetector(this, object : android.view.ScaleGestureDetector.SimpleOnScaleGestureListener() {
             override fun onScaleBegin(d: android.view.ScaleGestureDetector): Boolean {
+                if (!magnifiable) return false // a reflowed view ignores pinch-zoom (#61, RR25-FR3)
                 gestureStartZoom = zoom; liveScale = 1f; focusX = d.focusX; focusY = d.focusY
                 return true
             }
@@ -2790,6 +2800,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             val np = try { NativeBridge.nativeSetReflow(docHandle, on) } catch (e: RuntimeException) { -1 }
             if (np >= 0) {
                 reflowOn = on
+                // The reflow toggle changes magnifiability; the core resets its zoom on reflow-on, so
+                // drop any stranded shell zoom/pan to match and re-fit (#61).
+                magnifiable = try { NativeBridge.nativeIsMagnifiable(docHandle) } catch (e: RuntimeException) { !on }
+                if (!magnifiable && zoom != 1f) { zoom = 1f; panX = 0f; panY = 0f }
                 if (on) {
                     if (textScalePref() != 1.0f) {
                         try { NativeBridge.nativeSetTextScale(docHandle, textScalePref()) } catch (e: RuntimeException) {}

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -847,6 +847,12 @@ impl Document for PdfBackend {
         self.has_text_layer()
     }
 
+    fn is_magnifiable(&self) -> bool {
+        // A fixed PDF page magnifies; a reflowed one is laid out like text and ignores zoom
+        // (mirrors `render_zoom` and `set_reflow`'s zoom=1 reset, RR25-FR3).
+        !self.reflow_on()
+    }
+
     fn set_reflow(&self, on: bool, current_page: usize) -> Option<usize> {
         if on {
             // Already on → no-op jump. No text layer → can't reflow (scanned PDF needs OCR).

--- a/reader-core/src/document/fixed/pdf_tests.rs
+++ b/reader-core/src/document/fixed/pdf_tests.rs
@@ -623,6 +623,36 @@ fn pdf_reflow_toggles_and_reflows_text() {
     assert!(doc.set_text_scale(1.0, 0).is_none(), "setters inert again");
 }
 
+#[test]
+fn pdf_is_magnifiable_until_reflowed() {
+    let _s = pdfium_serial();
+    if !host_pdfium_available() {
+        eprintln!("SKIP pdf_is_magnifiable_until_reflowed: host libpdfium UNVERIFIED");
+        return;
+    }
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/minimal.pdf"
+    ))
+    .expect("fixture present");
+    let doc = PdfBackend::open(bytes).expect("open fixture");
+
+    // A fixed-layout page honors zoom (#61, RR25-FR3).
+    assert!(doc.is_magnifiable(), "fixed PDF page magnifies");
+
+    // Record the viewport, then reflow → the view is laid out like text and no longer magnifies.
+    let (w, h) = (300u32, 400u32);
+    let mut warm = vec![0u8; (w * h * 4) as usize];
+    doc.render_page(0, &mut PixelBuffer::from_rgba(&mut warm, w, h).unwrap())
+        .expect("fixed render");
+    let target = doc.set_reflow(true, 0).expect("reflow enables");
+    assert!(!doc.is_magnifiable(), "reflowed PDF ignores zoom");
+
+    // Toggling reflow back off restores magnifiability.
+    doc.set_reflow(false, target).expect("reflow disables");
+    assert!(doc.is_magnifiable(), "fixed page magnifies again");
+}
+
 /// Visual gate (ADR-INKREAD-0011): render the first reflowed pages of a real text PDF to BMPs for
 /// human inspection — the black-screencap Supernote can't self-verify, so we eyeball on the host.
 /// Run on demand: `INKREAD_REFLOW_PDF=/path/book.pdf cargo test -p reader-core

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -300,6 +300,14 @@ pub trait Document {
         self.render_page(index, buf)
     }
 
+    /// Whether the **current** view honors pinch/zoom — true only when [`Self::render_zoom`] actually
+    /// magnifies (a fixed-layout page that is not reflowed, RR25-FR3). The shell gates every zoom
+    /// entry point on this so a pinch/double-tap on a reflowable view can't strand its zoom factor.
+    /// Default: `false` (the default `render_zoom` ignores zoom — reflowable backends, EPUB).
+    fn is_magnifiable(&self) -> bool {
+        false
+    }
+
     /// Render page `index` fit to `buf` per [`FitMode`], preserving the page aspect ratio (RR4).
     /// `pan_x`/`pan_y` are normalized `[0,1]` scroll positions used only when a mode overflows the
     /// viewport (e.g. `Width` on a tall page); centered when the page fits. Default: ignores fit and

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -553,6 +553,14 @@ mod tests {
     }
 
     #[test]
+    fn epub_is_never_magnifiable() {
+        // EPUB is always reflowed (font size, not zoom), so the shell must never magnify it (#61,
+        // RR25-FR3) — the trait default for a reflowable backend.
+        let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+        assert!(!b.is_magnifiable());
+    }
+
+    #[test]
     fn text_line_span_selects_reflowed_lines() {
         // Regression (#46 device finding): EpubBackend didn't override text_line_span, so a multi-line
         // drag on a reflowed page hit the Document trait's empty default and selected nothing — the

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -718,6 +718,22 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSupportsRef
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeIsMagnifiable(handle) : boolean — whether the CURRENT view honors zoom (a fixed-layout page
+// that is not reflowed, RR25-FR3). The shell gates every zoom entry point on this so a pinch /
+// double-tap on a reflowable view can't strand its zoom factor and skew tap hit-testing.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeIsMagnifiable<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) -> jboolean {
+    env.with_env(|env| -> jni::errors::Result<jboolean> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        Ok(session.is_magnifiable())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetReflow(handle, on) : int — toggle reflow mode on a text-layer PDF (ADR-INKREAD-0011):
 // reconstruct the page text and flow it like a book so font/spacing/alignment take effect; off
 // restores the fixed page. Returns the new current page index (page count changes across the

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -716,6 +716,14 @@ impl ReaderSession {
         self.document.supports_reflow()
     }
 
+    /// Whether the **current** view honors zoom (a fixed-layout page that is not reflowed, RR25-FR3).
+    /// The shell gates its zoom entry points (pinch / +−buttons / double-tap) on this so a gesture on
+    /// a reflowable view can't strand the shell's zoom factor and skew tap hit-testing.
+    #[must_use]
+    pub fn is_magnifiable(&self) -> bool {
+        self.document.is_magnifiable()
+    }
+
     /// Toggle **reflow mode** on the open PDF (ADR-INKREAD-0011): reconstructs the text and flows it
     /// like a book so the font-size/line-spacing/alignment controls take effect; toggling off
     /// restores the fixed page. Preserves the reading position across the changing page count and


### PR DESCRIPTION
Closes #61.

On a reflowed view (EPUB, or a PDF with reflow on) zoom doesn't apply — the core's `render_zoom` is a no-op for reflowable backends and `set_reflow` resets `zoom=1` (RR25-FR3). But the shell fed every zoom entry point unconditionally, so a pinch / double-tap on an EPUB stranded the shell at `zoom>1` while the page rendered at fit. While stranded, `vToNx`/`vToNy` mis-mapped taps (link / word-lookup hit-testing was wrong) and the next centre tap was read as the second of a double-tap, silently restoring fit instead of opening the menu.

## What changed

**`reader-core`:** add `Document::is_magnifiable` (default `false`; `PdfBackend` returns `!reflow_on()`), exposed via `ReaderSession::is_magnifiable` and `nativeIsMagnifiable`. It reports exactly when `render_zoom` actually magnifies, in one place — `supports_reflow` (capability) can't express it, since a text-layer PDF supports reflow in both the fixed and reflowed states.

**Shell (`ReaderActivity`):** track a `magnifiable` flag, refreshed on open and on a reflow toggle (dropping any stranded zoom/pan when it goes false, matching the core's own reset), and gate the three zoom entry points on it together — pinch (`onScaleBegin`), the +/− zoom buttons / minimap (`zoomBy`, the shared sink for both), and double-tap (`doubleTapZoom`).

## Testing

- `cargo fmt` / `cargo clippy -p reader-core --all-targets -D warnings` / `cargo test -p reader-core` — 264 pass, fmt + clippy clean, core stays host-only. New tests: `pdf_is_magnifiable_until_reflowed` (full fixed→reflow→fixed lifecycle) and `epub_is_never_magnifiable`.
- Built `libreader.so` + APK and installed to the Nomad.