### PR TITLE
feat(digest): persist a reflow-stable PinPosition anchor for EPUB digests

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/DigestController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DigestController.kt
@@ -70,7 +70,7 @@ class DigestController(private val host: Host) {
                 toast("No selectable text under the selection")
                 return@engineExecute
             }
-            val ok = insertDigest(path, page, text)
+            val ok = insertDigest(path, page, text, selectionAnchor(page, boundsNorm))
             toast(if (ok) "Added to Digest" else "Couldn't add to Digest")
         }
     }
@@ -78,8 +78,9 @@ class DigestController(private val host: Host) {
     /**
      * Save already-selected text on [page] to the Digest. Used by the printed-text lasso path, which
      * has resolved the selection itself — so no native extraction is needed, just the insert.
+     * [boundsNorm] (the selection's normalized bounding rect, or null) yields the reflow-stable anchor.
      */
-    fun addDigestText(page: Int, content: String) {
+    fun addDigestText(page: Int, content: String, boundsNorm: FloatArray?) {
         val path = host.currentDocPath
         val text = content.trim()
         if (path == null || host.docHandle == 0L || text.isEmpty()) {
@@ -87,8 +88,23 @@ class DigestController(private val host: Host) {
             return
         }
         host.engineExecute {
-            val ok = insertDigest(path, page, text)
+            val ok = insertDigest(path, page, text, boundsNorm?.let { selectionAnchor(page, it) })
             toast(if (ok) "Added to Digest" else "Couldn't add to Digest")
+        }
+    }
+
+    /**
+     * The reflow-stable `{"start":…,"end":…}` PinPosition anchor for the selection rect, or null for
+     * fixed-layout PDF / an empty selection (the core returns an empty string, #46). Engine thread.
+     */
+    private fun selectionAnchor(page: Int, boundsNorm: FloatArray): String? {
+        if (boundsNorm.size != 4) return null
+        return try {
+            NativeBridge.nativeSelectionPins(
+                host.docHandle, page, boundsNorm[0], boundsNorm[1], boundsNorm[2], boundsNorm[3],
+            ).ifEmpty { null }
+        } catch (e: RuntimeException) {
+            Log.e(TAG, "selectionPins failed: ${e.message}"); null
         }
     }
 
@@ -98,13 +114,13 @@ class DigestController(private val host: Host) {
      * nests `document_location_data` + `source_size`. `creation_time`/`last_modified_time` are left
      * for the provider to fill, exactly as the firmware does.
      */
-    private fun insertDigest(srcPath: String, page: Int, content: String): Boolean {
+    private fun insertDigest(srcPath: String, page: Int, content: String, anchorJson: String?): Boolean {
         val values = ContentValues().apply {
             put(COL_CONTENT, content)
             put(COL_SOURCE_TYPE, SOURCE_TYPE_DOCUMENT)
             put(COL_SOURCE_PATH, srcPath)
             put(COL_SOURCE_PAGE, page.toString())
-            put(COL_METADATA, buildMetadata(srcPath, page))
+            put(COL_METADATA, buildMetadata(srcPath, page, anchorJson))
         }
         return try {
             val uri = activity.contentResolver.insert(Uri.parse(INSERT_URI), values)
@@ -121,11 +137,12 @@ class DigestController(private val host: Host) {
 
     /**
      * `metadata` JSON. `document_location_data` is itself a JSON string — a `[{chapter,page,
-     * startPosition,endPosition}]` array (mupdf coordinate model). v1 emits page-only
-     * (`start=end=0`): the entry opens at [page] but doesn't restore a precise highlight span until
-     * we calibrate pdfium offsets against a real mupdf sample. `source_size` is the PDF byte size.
+     * startPosition,endPosition}]` array (mupdf coordinate model), emitted page-only (`start=end=0`):
+     * the entry opens at [page] but doesn't restore a precise PDF highlight span until we calibrate
+     * pdfium offsets against a real mupdf sample. `source_size` is the source byte size. For a
+     * reflowable doc, [anchorJson] adds an inkread-private reflow-stable PinPosition anchor (#46).
      */
-    private fun buildMetadata(srcPath: String, page: Int): String {
+    private fun buildMetadata(srcPath: String, page: Int, anchorJson: String?): String {
         val location = JSONArray().put(
             JSONObject()
                 .put("chapter", 0)
@@ -134,10 +151,16 @@ class DigestController(private val host: Host) {
                 .put("endPosition", 0),
         )
         val size = runCatching { File(srcPath).length() }.getOrDefault(0L)
-        return JSONObject()
+        val metadata = JSONObject()
             .put(KEY_DOCUMENT_LOCATION_DATA, location.toString())
             .put(KEY_SOURCE_SIZE, size)
-            .toString()
+        // Reflowable docs (EPUB / reflowed PDF) carry an inkread-private reflow-stable PinPosition
+        // anchor under our own key (#46). The stock Digest app ignores unknown keys and the vendor
+        // `document_location_data` is untouched, so fixed-layout PDF behaviour is unchanged.
+        if (anchorJson != null) {
+            metadata.put(KEY_INKREAD_ANCHOR, JSONObject(anchorJson))
+        }
+        return metadata.toString()
     }
 
     private fun toast(msg: String) =
@@ -159,5 +182,8 @@ class DigestController(private val host: Host) {
 
         const val KEY_DOCUMENT_LOCATION_DATA = "document_location_data"
         const val KEY_SOURCE_SIZE = "source_size"
+
+        // inkread-private (not a vendor key): the reflow-stable PinPosition anchor for EPUB digests.
+        const val KEY_INKREAD_ANCHOR = "inkread_anchor"
     }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/DigestController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DigestController.kt
@@ -154,11 +154,13 @@ class DigestController(private val host: Host) {
         val metadata = JSONObject()
             .put(KEY_DOCUMENT_LOCATION_DATA, location.toString())
             .put(KEY_SOURCE_SIZE, size)
-        // Reflowable docs (EPUB / reflowed PDF) carry an inkread-private reflow-stable PinPosition
-        // anchor under our own key (#46). The stock Digest app ignores unknown keys and the vendor
-        // `document_location_data` is untouched, so fixed-layout PDF behaviour is unchanged.
+        // An EPUB digest carries an inkread-private reflow-stable PinPosition anchor under our own key
+        // (#46). The stock Digest app ignores unknown keys and the vendor `document_location_data` is
+        // untouched, so fixed-layout PDF behaviour is unchanged. Parse defensively: a malformed anchor
+        // degrades to a page-only entry rather than failing the insert (RR21-FR3 — validate at the edge).
         if (anchorJson != null) {
-            metadata.put(KEY_INKREAD_ANCHOR, JSONObject(anchorJson))
+            runCatching { metadata.put(KEY_INKREAD_ANCHOR, JSONObject(anchorJson)) }
+                .onFailure { Log.e(TAG, "bad digest anchor, page-only: ${it.message}") }
         }
         return metadata.toString()
     }

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -110,8 +110,8 @@ object NativeBridge {
     external fun nativeTextLineSpan(handle: Long, page: Int, sx: Float, sy: Float, ex: Float, ey: Float): ByteArray
 
     /** The reflow-stable [start,end] PinPosition pair a selection rect covers on a reflowable page —
-     *  the Digest/highlight anchor (#46). Returns a JSON object `{"start":<pin>,"end":<pin>}`, or an
-     *  EMPTY string for fixed-layout PDF / an empty selection (caller falls back to a page anchor). */
+     *  the Digest anchor (#46). Returns a JSON object `{"start":<pin>,"end":<pin>}`, or an EMPTY
+     *  string for fixed-layout PDF / an empty selection (caller falls back to a page anchor). */
     external fun nativeSelectionPins(handle: Long, page: Int, x0: Float, y0: Float, x1: Float, y1: Float): String
 
     /**

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -109,6 +109,11 @@ object NativeBridge {
      *  [WireCodec.decodeSelection]. */
     external fun nativeTextLineSpan(handle: Long, page: Int, sx: Float, sy: Float, ex: Float, ey: Float): ByteArray
 
+    /** The reflow-stable [start,end] PinPosition pair a selection rect covers on a reflowable page —
+     *  the Digest/highlight anchor (#46). Returns a JSON object `{"start":<pin>,"end":<pin>}`, or an
+     *  EMPTY string for fixed-layout PDF / an empty selection (caller falls back to a page anchor). */
+    external fun nativeSelectionPins(handle: Long, page: Int, x0: Float, y0: Float, x1: Float, y1: Float): String
+
     /**
      * Find [query] on `page` (RR2 in-document search), case-insensitive. Returns the search wire
      * (decode with [WireCodec.decodeSearch]): one match per occurrence with a snippet + highlight
@@ -307,6 +312,16 @@ data class SelBox(val x0: Float, val y0: Float, val x1: Float, val y1: Float)
 /** A text selection: the selected string + the boxes to highlight (RR11 / D3). */
 data class Selection(val text: String, val boxes: List<SelBox>) {
     val isEmpty: Boolean get() = text.isEmpty()
+
+    /** The selection's normalized bounding rect `[x0,y0,x1,y1]` (union of all boxes), or null when
+     *  empty — the rect handed to the reflow-stable anchor lookup (#46). */
+    fun boundsNorm(): FloatArray? {
+        if (boxes.isEmpty()) return null
+        return floatArrayOf(
+            boxes.minOf { it.x0 }, boxes.minOf { it.y0 },
+            boxes.maxOf { it.x1 }, boxes.maxOf { it.y1 },
+        )
+    }
 }
 
 /** One in-document search match on a page (RR2): highlight [boxes] + a context [snippet]. */

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -2285,7 +2285,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                     "Define" -> dict.defineSelectionText(snippet)
                     "Copy" -> copyTextToClipboard(snippet)
                     "Highlight" -> engine.execute { highlightTextBoxes(sel) }
-                    "Add to Digest" -> digest.addDigestText(currentPage, sel.text)
+                    "Add to Digest" -> digest.addDigestText(currentPage, sel.text, sel.boundsNorm())
                 }
             }
             // Any dismissal (action chosen or cancelled) clears the box overlay; a Highlight redraws

--- a/reader-core/src/document/fixed/pdf_tests.rs
+++ b/reader-core/src/document/fixed/pdf_tests.rs
@@ -653,6 +653,33 @@ fn pdf_is_magnifiable_until_reflowed() {
     assert!(doc.is_magnifiable(), "fixed page magnifies again");
 }
 
+#[test]
+fn pdf_selection_pins_none_for_fixed_layout() {
+    let _s = pdfium_serial();
+    if !host_pdfium_available() {
+        eprintln!("SKIP pdf_selection_pins_none_for_fixed_layout: host libpdfium UNVERIFIED");
+        return;
+    }
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/minimal.pdf"
+    ))
+    .expect("fixture present");
+    let doc = PdfBackend::open(bytes).expect("open fixture");
+    // A fixed-layout PDF has a stable integer page, so there is no reflow-stable pin to mint — the
+    // digest keeps its page anchor (#46). selection_pins returns None regardless of the rect.
+    let whole = crate::document::text_select::NormRect {
+        x0: 0.0,
+        y0: 0.0,
+        x1: 1.0,
+        y1: 1.0,
+    };
+    assert!(
+        doc.selection_pins(0, whole).is_none(),
+        "no pin for fixed PDF"
+    );
+}
+
 /// Visual gate (ADR-INKREAD-0011): render the first reflowed pages of a real text PDF to BMPs for
 /// human inspection — the black-screencap Supernote can't self-verify, so we eyeball on the host.
 /// Run on demand: `INKREAD_REFLOW_PDF=/path/book.pdf cargo test -p reader-core

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -1247,6 +1247,40 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeTextLineSpa
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSelectionPins(handle, page, x0,y0,x1,y1) : String — the reflow-stable [start,end] PinPosition
+// pair a selection rect covers on a reflowable page (the Digest/highlight anchor, #46). Returns a
+// JSON object `{"start":<pin>,"end":<pin>}`, or an EMPTY string for fixed-layout PDF / an empty
+// selection (the caller then falls back to a page anchor). Anchors to text locations, not pixels.
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSelectionPins<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    page: jint,
+    x0: jfloat,
+    y0: jfloat,
+    x1: jfloat,
+    y1: jfloat,
+) -> JString<'local> {
+    env.with_env(|env| -> jni::errors::Result<JString<'local>> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let target = if page < 0 { 0usize } else { page as usize };
+        let json = match session.selection_pins(target, NormRect { x0, y0, x1, y1 }) {
+            Some((start, end)) => {
+                format!(
+                    "{{\"start\":{},\"end\":{}}}",
+                    start.to_json(),
+                    end.to_json()
+                )
+            }
+            None => String::new(),
+        };
+        env.new_string(json)
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 /// Find `query` on `page` (RR2 in-document search). Returns the search wire (decode:
 /// `WireCodec.decodeSearch`): the page's matches as snippet + highlight boxes. The shell calls this
 /// page-by-page so the scan stays memory-bounded.

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -1248,9 +1248,9 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeTextLineSpa
 }
 
 // nativeSelectionPins(handle, page, x0,y0,x1,y1) : String — the reflow-stable [start,end] PinPosition
-// pair a selection rect covers on a reflowable page (the Digest/highlight anchor, #46). Returns a
-// JSON object `{"start":<pin>,"end":<pin>}`, or an EMPTY string for fixed-layout PDF / an empty
-// selection (the caller then falls back to a page anchor). Anchors to text locations, not pixels.
+// pair a selection rect covers on a reflowable page (the Digest anchor, #46). Returns a JSON object
+// `{"start":<pin>,"end":<pin>}`, or an EMPTY string for fixed-layout PDF / an empty selection (the
+// caller then falls back to a page anchor). Anchors to text locations, not pixels.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSelectionPins<'local>(
@@ -1267,12 +1267,11 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSelectionPi
         let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
         let target = if page < 0 { 0usize } else { page as usize };
         let json = match session.selection_pins(target, NormRect { x0, y0, x1, y1 }) {
+            // PageRange serializes to exactly `{"start":{…},"end":{…}}` (primitive-only → infallible);
+            // reuse it rather than hand-building the JSON.
             Some((start, end)) => {
-                format!(
-                    "{{\"start\":{},\"end\":{}}}",
-                    start.to_json(),
-                    end.to_json()
-                )
+                serde_json::to_string(&crate::position::PageRange::new(start, end))
+                    .unwrap_or_default()
             }
             None => String::new(),
         };

--- a/reader-core/src/position/mod.rs
+++ b/reader-core/src/position/mod.rs
@@ -343,6 +343,21 @@ mod tests {
     }
 
     #[test]
+    fn page_range_serializes_to_the_selection_pins_wire_shape() {
+        // nativeSelectionPins reuses PageRange's JSON for the digest anchor (#46), which the shell
+        // consumes as `{"start":{…},"end":{…}}`. Pin that wire shape + a lossless round trip so the
+        // JNI contract can't drift silently.
+        let range = PageRange::new(pin(2, 100, 5, &[0, 3]), pin(2, 140, 9, &[0, 3]));
+        let json = serde_json::to_string(&range).expect("PageRange serializes");
+        assert!(
+            json.contains("\"start\"") && json.contains("\"end\""),
+            "wire shape carries start+end: {json}"
+        );
+        let back: PageRange = serde_json::from_str(&json).expect("round-trips");
+        assert_eq!(back, range, "selection-pins JSON round-trips losslessly");
+    }
+
+    #[test]
     fn page_range_contains_is_half_open() {
         // RR6-AC3: start inclusive, end exclusive; before/after excluded.
         let start = pin(0, 10, 0, &[1]);


### PR DESCRIPTION
Closes #46.

The Add-to-Digest entry was anchored page-only (`document_location_data` `start=end=0`), which drifts for a reflowable doc when font size / line-spacing / alignment repaginate. This persists the selection's reflow-stable `PinPosition` pair so the stored anchor survives a re-layout.

Scope note: the stock Supernote Digest app is PDF/mupdf-oriented and does not reopen EPUBs, and inkread has no reopen path yet — so this lands the **stable, correct anchor** (the buildable, valuable slice). End-to-end "tap the digest to reopen the EPUB" is a separate follow-up (needs an inkread-side consumer); the anchor this stores is exactly what that consumer will read.

## What changed

**`reader-core`:** expose `ReaderSession::selection_pins` over JNI as `nativeSelectionPins` — returns `{"start":<pin>,"end":<pin>}` (serialized via the existing `PageRange` type) for a reflowable page, or an empty string for fixed-layout PDF / empty selection. That empty string is the **format gate**: PDF keeps its page anchor. Anchors to text locations, not pixels (RR8-FR2).

**Shell (`DigestController`):** embeds that anchor under an inkread-private metadata key (`inkread_anchor`) when present, parsed defensively so a malformed anchor degrades to a page-only entry. The vendor `document_location_data` is untouched and the stock Digest app ignores unknown keys, so **fixed-layout PDF behaviour is unchanged** (IR-7 — the vendor schema stays confined to `DigestController`). Both digest paths derive the selection rect (`Selection.boundsNorm()`) and compute the anchor on the engine thread.

## Testing

- `cargo fmt` / `cargo clippy -p reader-core --all-targets -D warnings` / `cargo test -p reader-core` — 266 pass, core host-only. Coverage: the selection→pins→re-anchor round trip across two font sizes (`selection_pins_span_in_order_and_survive_a_font_size_change`), the format gate (`pdf_selection_pins_none_for_fixed_layout`), and the JNI wire-shape contract (`page_range_serializes_to_the_selection_pins_wire_shape`).
- Built `libreader.so` + APK, installed to the Nomad; device-verified that an EPUB Add-to-Digest still creates the entry and fixed-layout PDF is unchanged.