### PR TITLE
test(core): host-test + rustdoc hardening (#38, #40, #41, #42)

### DIFF
--- a/inkread-ink/src/model.rs
+++ b/inkread-ink/src/model.rs
@@ -701,6 +701,39 @@ mod tests {
     }
 
     #[test]
+    fn point_validation_covers_every_boundary() {
+        // A non-finite x, y, OR pressure is rejected (NaN and infinity, all three coordinates).
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert!(
+                InkPoint::new(bad, 0.0, 1.0, None, None, 0).is_err(),
+                "x={bad}"
+            );
+            assert!(
+                InkPoint::new(0.0, bad, 1.0, None, None, 0).is_err(),
+                "y={bad}"
+            );
+            assert!(
+                InkPoint::new(0.0, 0.0, bad, None, None, 0).is_err(),
+                "pressure={bad}"
+            );
+        }
+        // Exact-boundary values pass through unclamped.
+        let edge = InkPoint::new(0.0, 1.0, 0.5, None, None, 0).unwrap();
+        assert_eq!((edge.x, edge.y, edge.pressure), (0.0, 1.0, 0.5));
+        // A finite tilt is preserved on both axes; a non-finite tilt is dropped per-axis.
+        let p = InkPoint::new(0.3, 0.4, 0.6, Some(0.2), Some(f32::NAN), 0).unwrap();
+        assert_eq!(p.tilt_x, Some(0.2), "finite tilt_x kept");
+        assert_eq!(p.tilt_y, None, "NaN tilt_y dropped");
+        // Tilt is NOT clamped to [0,1] — it's an angle, any finite value is valid.
+        assert_eq!(
+            InkPoint::new(0.0, 0.0, 1.0, Some(-3.0), Some(42.0), 0)
+                .unwrap()
+                .tilt_x,
+            Some(-3.0)
+        );
+    }
+
+    #[test]
     fn tool_codes_round_trip() {
         for t in [Tool::Pen, Tool::Highlighter, Tool::Eraser] {
             assert_eq!(Tool::from_code(t.code()), Some(t));

--- a/inkread-ink/src/model.rs
+++ b/inkread-ink/src/model.rs
@@ -717,9 +717,16 @@ mod tests {
                 "pressure={bad}"
             );
         }
-        // Exact-boundary values pass through unclamped.
+        // Exact-boundary values pass through unchanged; out-of-range x/y/pressure each clamp to the
+        // nearest edge of [0,1] (independently per axis).
         let edge = InkPoint::new(0.0, 1.0, 0.5, None, None, 0).unwrap();
         assert_eq!((edge.x, edge.y, edge.pressure), (0.0, 1.0, 0.5));
+        let clamped = InkPoint::new(3.0, -1.0, 5.0, None, None, 0).unwrap();
+        assert_eq!(
+            (clamped.x, clamped.y, clamped.pressure),
+            (1.0, 0.0, 1.0),
+            "each clamps to its edge"
+        );
         // A finite tilt is preserved on both axes; a non-finite tilt is dropped per-axis.
         let p = InkPoint::new(0.3, 0.4, 0.6, Some(0.2), Some(f32::NAN), 0).unwrap();
         assert_eq!(p.tilt_x, Some(0.2), "finite tilt_x kept");

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -282,8 +282,9 @@ pub fn encode_search_wire(matches: &[SearchMatch]) -> Vec<u8> {
 ///   friends must reject anything else with `PageOutOfRange`.
 /// - **Render fills the whole buffer as opaque RGBA.** White-fill first, then rasterize, so no
 ///   pixel is left uninitialized and alpha is `0xFF` (RR4-FR3 / Amendment 3).
-/// - **`&self`, not `&mut self`.** Repagination/caches use interior mutability (e.g. `RefCell`)
-///   so the render path stays shared — mirror the existing backends rather than taking `&mut`.
+/// - **The render/repagination path is `&self`.** Repagination and caches use interior mutability
+///   (e.g. `RefCell`) so rendering stays shared — mirror the existing backends rather than taking
+///   `&mut self` (only an explicit mutation like `export_pdf` is `&mut self`).
 /// - **Defaults model a fixed-layout, non-reflowable page.** Reflow/zoom/crop/anchor hooks default
 ///   to the no-op/`None` behavior; a reflowable backend (EPUB) overrides them. Only override what
 ///   your format actually supports — see [`Self::is_magnifiable`], [`Self::supports_reflow`],

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -271,6 +271,48 @@ pub fn encode_search_wire(matches: &[SearchMatch]) -> Vec<u8> {
 /// Render targets a borrowed [`PixelBuffer`] (Fork 4); the backend white-fills before
 /// rasterizing (RR4-FR3) and resolves the channel order so the buffer ends up RGBA
 /// (Amendment 3).
+///
+/// # Invariants every implementation must uphold
+///
+/// - **Never panic across the boundary (RR21-FR3).** Every fallible method returns a typed
+///   [`CoreError`](crate::error::CoreError); a bad page index is
+///   [`PageOutOfRange`](crate::error::CoreError::PageOutOfRange), not a panic or an out-of-bounds
+///   access. Validate arguments at the seam.
+/// - **`page_count` is authoritative.** A valid index is `0..page_count()`; `render_page` and
+///   friends must reject anything else with `PageOutOfRange`.
+/// - **Render fills the whole buffer as opaque RGBA.** White-fill first, then rasterize, so no
+///   pixel is left uninitialized and alpha is `0xFF` (RR4-FR3 / Amendment 3).
+/// - **`&self`, not `&mut self`.** Repagination/caches use interior mutability (e.g. `RefCell`)
+///   so the render path stays shared — mirror the existing backends rather than taking `&mut`.
+/// - **Defaults model a fixed-layout, non-reflowable page.** Reflow/zoom/crop/anchor hooks default
+///   to the no-op/`None` behavior; a reflowable backend (EPUB) overrides them. Only override what
+///   your format actually supports — see [`Self::is_magnifiable`], [`Self::supports_reflow`],
+///   [`Self::selection_pins`].
+///
+/// # Minimal implementation
+///
+/// A blank one-page backend — the smallest thing that satisfies the trait (all other methods take
+/// their fixed-layout defaults):
+///
+/// ```ignore
+/// use reader_core::document::{Document, DocumentMetadata};
+/// use reader_core::render::PixelBuffer;
+/// use reader_core::error::{CoreError, CoreResult};
+///
+/// struct BlankDoc;
+///
+/// impl Document for BlankDoc {
+///     fn page_count(&self) -> usize { 1 }
+///     fn metadata(&self) -> DocumentMetadata { DocumentMetadata::default() }
+///     fn render_page(&self, index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+///         if index >= self.page_count() {
+///             return Err(CoreError::PageOutOfRange { requested: index, available: self.page_count() });
+///         }
+///         buf.fill_white(); // opaque RGBA, whole buffer — no partial render
+///         Ok(())
+///     }
+/// }
+/// ```
 pub trait Document {
     /// Total page count (fixed-layout: a trivial integer model — RR5-FR2).
     fn page_count(&self) -> usize;

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -540,6 +540,49 @@ mod tests {
             .collect()
     }
 
+    fn rect(x0: f32, y0: f32, x1: f32, y1: f32) -> NormRect {
+        NormRect { x0, y0, x1, y1 }
+    }
+
+    #[test]
+    fn norm_rect_contains_is_inclusive_on_the_edge() {
+        let r = rect(0.2, 0.2, 0.8, 0.8);
+        assert!(r.contains(0.5, 0.5), "interior point");
+        assert!(r.contains(0.2, 0.2), "top-left corner is inclusive");
+        assert!(r.contains(0.8, 0.8), "bottom-right corner is inclusive");
+        assert!(r.contains(0.2, 0.5), "left edge is inclusive");
+        assert!(!r.contains(0.19, 0.5), "just left of the rect");
+        assert!(!r.contains(0.5, 0.81), "just below the rect");
+    }
+
+    #[test]
+    fn norm_rect_intersects_counts_a_touching_edge_and_excludes_a_gap() {
+        let a = rect(0.0, 0.0, 0.5, 0.5);
+        assert!(a.intersects(&rect(0.4, 0.4, 0.9, 0.9)), "overlapping area");
+        assert!(
+            a.intersects(&rect(0.5, 0.0, 0.9, 0.5)),
+            "edges touching counts (shared x=0.5)"
+        );
+        assert!(!a.intersects(&rect(0.6, 0.0, 0.9, 0.5)), "x gap → disjoint");
+        assert!(!a.intersects(&rect(0.0, 0.6, 0.5, 0.9)), "y gap → disjoint");
+        // Symmetric: a∩b == b∩a.
+        let b = rect(0.4, 0.4, 0.9, 0.9);
+        assert_eq!(a.intersects(&b), b.intersects(&a));
+    }
+
+    #[test]
+    fn norm_rect_union_is_the_smallest_covering_rect() {
+        let a = rect(0.1, 0.2, 0.4, 0.5);
+        let b = rect(0.3, 0.0, 0.9, 0.6);
+        assert_eq!(a.union(&b), rect(0.1, 0.0, 0.9, 0.6));
+        // Union with self is identity; union is commutative.
+        assert_eq!(a.union(&a), a);
+        assert_eq!(a.union(&b), b.union(&a));
+        // The union covers both operands' corners.
+        let u = a.union(&b);
+        assert!(u.contains(a.x0, a.y0) && u.contains(b.x1, b.y1));
+    }
+
     /// A single-row line whose glyphs carry consecutive chapter-relative anchors in `block`.
     fn anchored_line(s: &str, block: usize, start_off: usize) -> Vec<CharBox> {
         line(s, 0.0, 0.8, 0.10, 0.03)

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -563,11 +563,23 @@ mod tests {
             a.intersects(&rect(0.5, 0.0, 0.9, 0.5)),
             "edges touching counts (shared x=0.5)"
         );
-        assert!(!a.intersects(&rect(0.6, 0.0, 0.9, 0.5)), "x gap → disjoint");
+        let gap = rect(0.6, 0.0, 0.9, 0.5);
+        assert!(!a.intersects(&gap), "x gap → disjoint");
         assert!(!a.intersects(&rect(0.0, 0.6, 0.5, 0.9)), "y gap → disjoint");
-        // Symmetric: a∩b == b∩a.
+        // Symmetric for both the overlapping AND the disjoint case: a∩b == b∩a.
         let b = rect(0.4, 0.4, 0.9, 0.9);
-        assert_eq!(a.intersects(&b), b.intersects(&a));
+        assert_eq!(a.intersects(&b), b.intersects(&a), "overlap is symmetric");
+        assert_eq!(
+            a.intersects(&gap),
+            gap.intersects(&a),
+            "disjoint is symmetric"
+        );
+        // A zero-area rect (a point) still intersects a rect that covers it.
+        let point = rect(0.25, 0.25, 0.25, 0.25);
+        assert!(
+            a.intersects(&point) && point.intersects(&a),
+            "degenerate point inside"
+        );
     }
 
     #[test]

--- a/reader-core/src/error.rs
+++ b/reader-core/src/error.rs
@@ -135,4 +135,58 @@ mod tests {
             "this file is protected and can't be opened"
         );
     }
+
+    // The status code AND the message prefix of every variant are part of the JNI contract (the
+    // Kotlin side switches on the code and surfaces the message). Pin both exactly so a future
+    // refactor that renumbers a variant or rewords a message breaks the build, not the device.
+    #[test]
+    fn status_codes_and_messages_are_pinned() {
+        let cases: [(CoreError, StatusCode, &str); 10] = [
+            (
+                CoreError::InvalidArgument("x".into()),
+                1,
+                "invalid argument: x",
+            ),
+            (
+                CoreError::UnsupportedFormat("x".into()),
+                2,
+                "unsupported file type: x",
+            ),
+            (
+                CoreError::CorruptDocument("x".into()),
+                3,
+                "this file appears damaged: x",
+            ),
+            (
+                CoreError::DrmProtected,
+                4,
+                "this file is protected and can't be opened",
+            ),
+            (
+                CoreError::PageOutOfRange {
+                    requested: 7,
+                    available: 3,
+                },
+                5,
+                "page 7 out of range (have 3)",
+            ),
+            (
+                CoreError::BufferMismatch("x".into()),
+                6,
+                "pixel buffer mismatch: x",
+            ),
+            (CoreError::RenderBackend("x".into()), 7, "render failed: x"),
+            (
+                CoreError::BackendUnavailable("x".into()),
+                8,
+                "render backend unavailable: x",
+            ),
+            (CoreError::InternalPanic("x".into()), 9, "internal error: x"),
+            (CoreError::Persistence("x".into()), 10, "storage error: x"),
+        ];
+        for (err, code, msg) in &cases {
+            assert_eq!(err.status_code(), *code, "code for {err:?}");
+            assert_eq!(&err.to_string(), msg, "message for {err:?}");
+        }
+    }
 }


### PR DESCRIPTION
Knocks out the host-only good-first-issue hardening cluster. Test/doc only — no production logic changes, core stays host-only.

## What changed

- **#38** — `point_validation_covers_every_boundary` (`inkread-ink`): sweeps NaN/±∞ across all three coordinates, asserts out-of-range x/y/pressure clamp to their edge, exact-boundary pass-through, finite-tilt preserved / non-finite-tilt dropped per axis, and that tilt is *not* clamped.
- **#40** — direct `NormRect` tests for `contains` / `intersects` / `union`: edge-inclusivity, touching-edge intersection, disjoint gaps (+ symmetry), a zero-area point, and union identity/commutativity/cover.
- **#41** — `status_codes_and_messages_are_pinned`: pins every `CoreError` variant's exact status code (1–10) **and** Display message — the JNI contract — so a future renumber/reword breaks the build, not the device.
- **#42** — `Document` trait rustdoc: the invariants every backend must uphold (no panic across JNI, page-count authority, opaque-RGBA whole-buffer render, `&self` render path, fixed-layout defaults) plus a minimal example impl.

## Not included

- **#39** (`.inkbin` round-trip + malformed-input tests) is **already covered** by the existing `inkread-ink/src/codec.rs` suite (round-trip, bad magic, version, truncation, unknown tool, non-finite width, trailing bytes, duplicate id, DoS-guard absurd counts). No new tests were warranted (REUSE-FIRST); left open for a maintainer to close.

## Testing

- `cargo fmt --all` / `cargo clippy -p reader-core -p inkread-ink --all-targets -D warnings` / tests — 268 reader-core + ink suite pass, clippy clean. No device build (test/doc only, no JNI change).