### PR TITLE
feat(daily): inkread-daily crate — issue model + EPUB assembly (#66, slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkread-daily"
+version = "0.1.0-m0"
+dependencies = [
+ "inkread-epub",
+ "zip 2.4.2",
+]
+
+[[package]]
 name = "inkread-dict"
 version = "0.1.0-m0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # RR1-AC3: bare `cargo test -p reader-core` builds with `jni` absent from the resolved graph.
 [workspace]
 resolver = "2"
-members = ["build-dict", "device-eink", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "inkread-pdftext", "reader-core"]
+members = ["build-dict", "device-eink", "inkread-daily", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "inkread-pdftext", "reader-core"]
 
 [workspace.package]
 version = "0.1.0-m0"
@@ -19,6 +19,7 @@ repository = "https://github.com/j-raghavan/inkread"
 [workspace.dependencies]
 # Internal crates.
 device-eink = { path = "device-eink" }
+inkread-daily = { path = "inkread-daily" }
 inkread-dict = { path = "inkread-dict" }
 inkread-epub = { path = "inkread-epub" }
 inkread-ink = { path = "inkread-ink" }

--- a/inkread-daily/Cargo.toml
+++ b/inkread-daily/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "inkread-daily"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "inkread-daily (#66): turn feed/article sources into a self-contained daily-issue EPUB the inkread reader opens. Pure, host-testable assembly — fetching lives in the Android shell (IR-7)."
+
+[dependencies]
+# Writes the issue EPUB (a ZIP container). Already a workspace dependency (CBZ). Pure Rust,
+# AGPL-compatible, cross-compiles clean.
+zip = { workspace = true }
+
+[dev-dependencies]
+# Round-trip the assembled issue through the real EPUB parser the reader uses, so a malformed
+# container fails the host gate rather than the device.
+inkread-epub = { workspace = true }

--- a/inkread-daily/src/epub.rs
+++ b/inkread-daily/src/epub.rs
@@ -1,0 +1,190 @@
+//! Assemble an [`Issue`] into a self-contained EPUB the inkread reader opens (#66).
+//!
+//! Emits the minimal OCF/EPUB-3 structure the reader's parser accepts: a stored `mimetype` first,
+//! `META-INF/container.xml`, an OPF (manifest + spine), an EPUB-3 nav doc (TOC), a title page, and
+//! one XHTML document per article. Pure + host-testable — no network, no clock (the caller stamps
+//! the date). In-memory ZIP writing to a `Vec` cannot fail, so this is infallible.
+
+use std::io::{Cursor, Write};
+
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+use crate::model::Issue;
+
+/// Build the issue EPUB as bytes. The result opens with the reader's EPUB backend and reflows like
+/// any book (honoring the shipped font-size/spacing controls + reflow-stable resume).
+#[must_use]
+pub fn assemble_epub(issue: &Issue) -> Vec<u8> {
+    let mut zw = ZipWriter::new(Cursor::new(Vec::new()));
+
+    // OCF requires the mimetype entry FIRST and STORED (uncompressed).
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    add(&mut zw, "mimetype", b"application/epub+zip", stored);
+
+    let deflate = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    add(
+        &mut zw,
+        "META-INF/container.xml",
+        CONTAINER_XML.as_bytes(),
+        deflate,
+    );
+    add(&mut zw, "OEBPS/content.opf", opf(issue).as_bytes(), deflate);
+    add(&mut zw, "OEBPS/nav.xhtml", nav(issue).as_bytes(), deflate);
+    add(
+        &mut zw,
+        "OEBPS/title.xhtml",
+        title_page(issue).as_bytes(),
+        deflate,
+    );
+    for i in 0..issue.articles.len() {
+        add(
+            &mut zw,
+            &article_path(i),
+            article_xhtml(issue, i).as_bytes(),
+            deflate,
+        );
+    }
+
+    zw.finish()
+        .expect("in-memory zip finish is infallible")
+        .into_inner()
+}
+
+/// Write one ZIP entry (in-memory writes are infallible — entry names are crate-controlled).
+fn add(zw: &mut ZipWriter<Cursor<Vec<u8>>>, name: &str, data: &[u8], opts: SimpleFileOptions) {
+    zw.start_file(name, opts).expect("valid zip entry name");
+    zw.write_all(data)
+        .expect("in-memory zip write is infallible");
+}
+
+/// The XHTML path for article `i` (zero-padded so reading order is stable in any tooling).
+fn article_path(i: usize) -> String {
+    format!("OEBPS/a{i:04}.xhtml")
+}
+
+const CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles>
+</container>"#;
+
+/// The OPF package: metadata + a manifest of (nav, title, every article) and a spine that opens on
+/// the title page then reads the articles in order.
+fn opf(issue: &Issue) -> String {
+    let mut manifest = String::from(
+        r#"    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="title" href="title.xhtml" media-type="application/xhtml+xml"/>
+"#,
+    );
+    let mut spine = String::from("    <itemref idref=\"title\"/>\n");
+    for i in 0..issue.articles.len() {
+        manifest.push_str(&format!(
+            "    <item id=\"a{i}\" href=\"a{i:04}.xhtml\" media-type=\"application/xhtml+xml\"/>\n"
+        ));
+        spine.push_str(&format!("    <itemref idref=\"a{i}\"/>\n"));
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="id">urn:inkread-daily:{date}</dc:identifier>
+    <dc:title>{title} — {date}</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+{manifest}  </manifest>
+  <spine>
+{spine}  </spine>
+</package>"#,
+        title = esc(&issue.title),
+        date = esc(&issue.date),
+    )
+}
+
+/// The EPUB-3 nav doc: a TOC linking the title page and each article (by its headline).
+fn nav(issue: &Issue) -> String {
+    let mut items = String::from("    <li><a href=\"title.xhtml\">Cover</a></li>\n");
+    for (i, art) in issue.articles.iter().enumerate() {
+        items.push_str(&format!(
+            "    <li><a href=\"a{i:04}.xhtml\">{}</a></li>\n",
+            esc(&art.title)
+        ));
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+  <head><title>Contents</title></head>
+  <body><nav epub:type="toc"><ol>
+{items}  </ol></nav></body>
+</html>"#
+    )
+}
+
+/// The cover/title page: issue title, date, and a contents list.
+fn title_page(issue: &Issue) -> String {
+    let mut toc = String::new();
+    for art in &issue.articles {
+        toc.push_str(&format!(
+            "    <li>{}<br/><span class=\"src\">{}</span></li>\n",
+            esc(&art.title),
+            esc(&art.source)
+        ));
+    }
+    xhtml(
+        &issue.title,
+        &format!(
+            "<h1>{}</h1>\n<p class=\"date\">{}</p>\n<ul>\n{toc}</ul>",
+            esc(&issue.title),
+            esc(&issue.date)
+        ),
+    )
+}
+
+/// One article document: headline, a source · date byline, then the clean article body.
+fn article_xhtml(issue: &Issue, i: usize) -> String {
+    let art = &issue.articles[i];
+    let byline = match &art.published {
+        Some(d) => format!("{} · {}", esc(&art.source), esc(d)),
+        None => esc(&art.source),
+    };
+    let body = format!(
+        "<h1>{}</h1>\n<p class=\"byline\">{byline}</p>\n{}",
+        esc(&art.title),
+        art.body_html // already clean, XHTML-compatible markup
+    );
+    xhtml(&art.title, &body)
+}
+
+/// Wrap `body` (raw XHTML markup) in a minimal, well-formed XHTML document titled `title`.
+fn xhtml(title: &str, body: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>{}</title></head>
+  <body>
+{body}
+  </body>
+</html>"#,
+        esc(title)
+    )
+}
+
+/// Escape the five XML metacharacters so user-supplied titles/sources/dates can't break the markup.
+fn esc(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "epub_tests.rs"]
+mod tests;

--- a/inkread-daily/src/epub.rs
+++ b/inkread-daily/src/epub.rs
@@ -150,7 +150,7 @@ fn article_xhtml(issue: &Issue, i: usize) -> String {
     let body = format!(
         "<h1>{}</h1>\n<p class=\"byline\">{byline}</p>\n{}",
         esc(&art.title),
-        art.body_html // already clean, XHTML-compatible markup
+        art.body_html // trusted: caller's contract is already-clean, well-formed XHTML (not escaped)
     );
     xhtml(&art.title, &body)
 }

--- a/inkread-daily/src/epub_tests.rs
+++ b/inkread-daily/src/epub_tests.rs
@@ -1,0 +1,100 @@
+//! Tests for the issue→EPUB assembler (#66). The headline guarantee: an assembled issue parses
+//! with the *real* reader EPUB backend (`inkread_epub::EpubPackage`), so a malformed container is
+//! caught on the host, not the device.
+
+use super::*;
+use crate::model::{Article, Issue};
+use inkread_epub::EpubPackage;
+
+fn article(title: &str, source: &str, body: &str, published: Option<&str>) -> Article {
+    Article {
+        title: title.to_string(),
+        source: source.to_string(),
+        url: format!("https://example.test/{title}"),
+        published: published.map(str::to_string),
+        body_html: body.to_string(),
+    }
+}
+
+fn sample_issue() -> Issue {
+    Issue {
+        title: "inkread daily".to_string(),
+        date: "24 Jun 2026".to_string(),
+        articles: vec![
+            article(
+                "Calm Computing",
+                "Hacker News",
+                "<p>Long-form reading, away from the feed.</p>",
+                Some("24 Jun 2026"),
+            ),
+            article(
+                "E-ink & You",
+                "A Blog",
+                "<p>Why grayscale is restful.</p><p>And paper-like.</p>",
+                None,
+            ),
+        ],
+    }
+}
+
+#[test]
+fn assembled_issue_parses_with_the_reader_epub_backend() {
+    let bytes = assemble_epub(&sample_issue());
+    let pkg = EpubPackage::open(bytes).expect("assembled issue is a valid EPUB");
+    // Title page + 2 articles in the spine (the reader sees each as a chapter).
+    assert_eq!(pkg.chapter_count(), 3, "title page + two articles");
+}
+
+#[test]
+fn issue_metadata_and_article_text_survive_the_round_trip() {
+    let bytes = assemble_epub(&sample_issue());
+    let pkg = EpubPackage::open(bytes).unwrap();
+    let title = pkg.title.clone().unwrap_or_default();
+    assert!(
+        title.contains("inkread daily") && title.contains("24 Jun 2026"),
+        "issue title carries the name + date: {title:?}"
+    );
+    // The article bodies reach the parsed chapters (search the concatenated chapter HTML).
+    let html: String = pkg.chapters.iter().map(|c| c.html.clone()).collect();
+    assert!(html.contains("Long-form reading"), "article 1 body present");
+    assert!(html.contains("paper-like"), "article 2 body present");
+    assert!(html.contains("Hacker News"), "byline/source present");
+}
+
+#[test]
+fn an_empty_issue_still_assembles_a_valid_epub() {
+    let issue = Issue {
+        title: "inkread daily".to_string(),
+        date: "24 Jun 2026".to_string(),
+        articles: vec![],
+    };
+    assert!(issue.is_empty());
+    let pkg = EpubPackage::open(assemble_epub(&issue)).expect("empty issue is still a valid EPUB");
+    assert_eq!(pkg.chapter_count(), 1, "just the title page");
+}
+
+#[test]
+fn xml_metacharacters_in_titles_do_not_break_the_container() {
+    // A hostile headline with &, <, >, quotes must not produce malformed XHTML/OPF.
+    let issue = Issue {
+        title: "Tom & Jerry <b>\"news\"</b>".to_string(),
+        date: "24 Jun 2026".to_string(),
+        articles: vec![article(
+            "5 < 10 & \"quotes\" > here",
+            "A & B News",
+            "<p>Body with &amp; an entity.</p>",
+            None,
+        )],
+    };
+    let pkg = EpubPackage::open(assemble_epub(&issue))
+        .expect("escaped metacharacters keep the EPUB well-formed");
+    assert_eq!(pkg.chapter_count(), 2);
+    assert!(
+        pkg.title
+            .clone()
+            .unwrap_or_default()
+            .contains("Tom & Jerry"),
+        "title decodes back: {:?}",
+        pkg.title
+    );
+}

--- a/inkread-daily/src/epub_tests.rs
+++ b/inkread-daily/src/epub_tests.rs
@@ -62,6 +62,25 @@ fn issue_metadata_and_article_text_survive_the_round_trip() {
 }
 
 #[test]
+fn malformed_body_html_is_currently_accepted_extraction_slice_must_sanitize() {
+    // KNOWN GAP (#66): body_html is injected RAW on the "already clean, well-formed XHTML" contract.
+    // The reader's parser (rbook) is lenient and accepts malformed markup today, so a bad body does
+    // NOT fail this host gate — it would reach the device, where reflow layout is the unknown. The
+    // extraction slice MUST guarantee well-formed XHTML (or this crate must sanitize) before any real
+    // fetched content is assembled. This test PINS the current leniency so a future switch to strict
+    // parsing surfaces here as a failure rather than silently — it documents the gap, not an endorsement.
+    let issue = Issue {
+        title: "t".to_string(),
+        date: "d".to_string(),
+        articles: vec![article("Bad", "Src", "<p>unclosed & a raw < here", None)],
+    };
+    assert!(
+        EpubPackage::open(assemble_epub(&issue)).is_ok(),
+        "rbook currently tolerates malformed body markup — see the #66 extraction slice"
+    );
+}
+
+#[test]
 fn an_empty_issue_still_assembles_a_valid_epub() {
     let issue = Issue {
         title: "inkread daily".to_string(),

--- a/inkread-daily/src/lib.rs
+++ b/inkread-daily/src/lib.rs
@@ -1,0 +1,15 @@
+//! `inkread-daily` (#66): turn followed feed/article sources into a self-contained **daily-issue
+//! EPUB** that the inkread reader opens like any book — calm, offline, e-ink-first reading.
+//!
+//! This crate is the *assembly* half: it takes already-extracted [`Article`]s, composes them into an
+//! [`Issue`], and serializes that to an EPUB ([`assemble_epub`]). It is **pure and host-testable** —
+//! no network and no clock. Fetching feeds and extracting readable text live at the edges (the
+//! Android shell does the network; a later slice does HTML→clean extraction), keeping the core
+//! vendor- and IO-free (RR1-AC3 / IR-7). Delivery as EPUB means the whole existing reader — reflow,
+//! font-size/spacing controls, reflow-stable resume — is reused with no new rendering code.
+
+mod epub;
+mod model;
+
+pub use epub::assemble_epub;
+pub use model::{Article, Issue, Source};

--- a/inkread-daily/src/model.rs
+++ b/inkread-daily/src/model.rs
@@ -1,0 +1,52 @@
+//! The `inkread-daily` domain model (#66): the data a daily issue is built from.
+//!
+//! Deliberately tiny and dependency-free. A [`Source`] is a feed/site the user follows; an
+//! [`Article`] is one extracted, ready-to-read piece; an [`Issue`] is the compiled set for a day.
+//! Fetching feeds and extracting readable text happen at the edges (the Android shell / a later
+//! extraction slice) and produce these values — this crate only *assembles* them into an EPUB.
+
+/// A content source the user follows (RSS/Atom feed or a site). The fetch layer owns the network;
+/// this is just the persisted identity the shell stores and the assembly attributes articles to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Source {
+    /// Human-facing name shown as the article byline (e.g. "Hacker News").
+    pub name: String,
+    /// The feed/page URL the fetch layer polls.
+    pub url: String,
+}
+
+/// One ready-to-read article in an issue: a title, the source it came from, the original URL, an
+/// optional published date (already formatted for display), and the **clean** body as simple,
+/// well-formed XHTML-compatible markup (paragraphs/headings) — the output of readability extraction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Article {
+    /// Article headline.
+    pub title: String,
+    /// Display name of the originating source (the byline).
+    pub source: String,
+    /// Canonical article URL (kept for attribution / a future "open original").
+    pub url: String,
+    /// Pre-formatted published date for display, if known (e.g. "24 Jun 2026").
+    pub published: Option<String>,
+    /// Clean article body as XHTML-compatible markup (well-formed; readability output).
+    pub body_html: String,
+}
+
+/// A compiled daily issue: a dated, titled set of articles in reading order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Issue {
+    /// Issue title (e.g. "inkread daily").
+    pub title: String,
+    /// The issue date, pre-formatted for display (the caller stamps it — this crate reads no clock).
+    pub date: String,
+    /// Articles in reading order.
+    pub articles: Vec<Article>,
+}
+
+impl Issue {
+    /// Whether the issue has no articles (the assembler still produces a valid, if empty, EPUB).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.articles.is_empty()
+    }
+}

--- a/inkread-daily/src/model.rs
+++ b/inkread-daily/src/model.rs
@@ -6,7 +6,9 @@
 //! extraction slice) and produce these values — this crate only *assembles* them into an EPUB.
 
 /// A content source the user follows (RSS/Atom feed or a site). The fetch layer owns the network;
-/// this is just the persisted identity the shell stores and the assembly attributes articles to.
+/// this is the persisted identity the shell stores. **Ahead of its consumer:** defined here as the
+/// stable model type the fetch/persistence slice will read — assembly attributes articles by the
+/// flat [`Article::source`] byline today and does not reference this struct yet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Source {
     /// Human-facing name shown as the article byline (e.g. "Hacker News").


### PR DESCRIPTION
First slice of #66 (the daily reading companion). Adds the **pure, host-testable assembly half**: takes already-extracted articles, composes them into an `Issue`, and serializes that to a self-contained EPUB the existing reader opens — so reflow, the font-size/spacing controls, and reflow-stable resume are all reused with **no new rendering code**.

Intentionally scoped to assembly. Feed fetching (Android shell), readability extraction, and the archive/calendar UI are follow-up slices — this keeps the crate vendor- and IO-free (RR1-AC3 / IR-7).

## What changed

- New `inkread-daily` crate (workspace member).
- **`model.rs`** — `Source` / `Article` / `Issue` domain types (dependency-free).
- **`epub.rs`** — `assemble_epub(&Issue) -> Vec<u8>` emitting the minimal OCF/EPUB-3 layout the reader's parser accepts: stored `mimetype` first, `container.xml`, OPF manifest+spine, EPUB-3 nav, a title page, one XHTML per article. XML metacharacters in titles/sources/dates are escaped; clean `body_html` is injected per the extraction contract. No new dependencies (reuses the workspace `zip` dep); no network, no clock (the caller stamps the date).

## Testing

- `cargo fmt` / `cargo clippy --workspace -D warnings` / `cargo test --workspace` — 5 inkread-daily tests, license gate passes (no new deps).
- The headline guarantee is a **round-trip through the real reader backend** (`inkread_epub::EpubPackage::open`): title page + articles parse, metadata + body text survive, an empty issue is still valid, and escaped metacharacters keep the EPUB well-formed.

Reviewed (correctness + arch): both APPROVE. Verified the OCF container is byte-valid (strict epubcheck signature) and the OPF/spine/nav are internally consistent. Nits folded in — a test pinning that the parser currently tolerates malformed `body_html` (so the extraction slice owns sanitization), plus comment/`Source` clarifications.

Follow-up slices: readability extraction (Rust) → feed fetch + Daily UI (Kotlin shell) → archive/calendar.