### PR TITLE
feat(app): The InkRead Daily front-page screen + Home entry (#66)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,5 +49,11 @@
             android:name=".SettingsActivity"
             android:exported="false"
             android:configChanges="orientation|screenSize|keyboardHidden" />
+
+        <!-- The InkRead Daily front page (#66), launched from the Home masthead (not exported). -->
+        <activity
+            android:name=".DailyActivity"
+            android:exported="false"
+            android:configChanges="orientation|screenSize|keyboardHidden" />
     </application>
 </manifest>

--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -73,6 +73,48 @@ object Books {
     /** A human title for a stored book file (drop the extension). */
     fun title(file: File): String = file.nameWithoutExtension
 
+    // ---- real document metadata (title/author/page position), captured by the reader on open ----
+
+    private fun meta(context: Context) =
+        context.getSharedPreferences("bookmeta", Context.MODE_PRIVATE)
+
+    /**
+     * Record the real document metadata for book `id` (from the core's `DocumentMetadata` + page
+     * count), so the home/library can show the actual title/author and reading position rather than
+     * the filename. Blank title/author are not stored (the filename stays the fallback).
+     */
+    fun setMeta(context: Context, id: String, title: String, author: String, pages: Int) {
+        if (id.isEmpty()) return
+        meta(context).edit().apply {
+            if (title.isNotBlank()) putString("$id.title", title.trim())
+            if (author.isNotBlank()) putString("$id.author", author.trim())
+            if (pages > 0) putInt("$id.pages", pages)
+        }.apply()
+    }
+
+    /** Record the current 0-based page for book `id` (written by the reader on save). */
+    fun setPage(context: Context, id: String, page: Int) {
+        if (id.isEmpty()) return
+        meta(context).edit().putInt("$id.page", page.coerceAtLeast(0)).apply()
+    }
+
+    /** The stored real title for book `id`, or null if unknown (caller falls back to the filename). */
+    fun metaTitle(context: Context, id: String): String? =
+        meta(context).getString("$id.title", null)?.ifBlank { null }
+
+    fun metaAuthor(context: Context, id: String): String? =
+        meta(context).getString("$id.author", null)?.ifBlank { null }
+
+    /** Total pages for book `id` (0 if unknown). */
+    fun metaPages(context: Context, id: String): Int = meta(context).getInt("$id.pages", 0)
+
+    /** Current 0-based page for book `id` (0 if unknown). */
+    fun metaPage(context: Context, id: String): Int = meta(context).getInt("$id.page", 0)
+
+    /** The display title for a recent: the real document title if captured, else the file name. */
+    fun displayTitle(context: Context, r: Recent): String =
+        metaTitle(context, r.id) ?: File(r.path).nameWithoutExtension
+
     // ---- first-page thumbnails (RR17-FR5) ----
 
     private fun thumbsDir(context: Context): File = File(context.filesDir, "thumbnails").apply { mkdirs() }

--- a/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
@@ -1,0 +1,324 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.os.Bundle
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import android.widget.Toast
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * **The InkRead Daily** — the inkread-daily front page (#66). A 1-bit *newspaper* home for the daily
+ * reading companion: a masthead, a dated folio, the day's headlines (which double as the issue's
+ * table of contents), a **Today's Desk** control panel (Read Today's Issue · Regenerate · Sources ·
+ * Archive), and a reverse-chronological **Back Issues** strip. The newspaper metaphor is native to
+ * e-ink — rules, columns, halftone, no glow, no colour — and matches the home screen's Inkwell voice
+ * ([Ink], [HomeActivity]).
+ *
+ * Honest by default (like [HomeActivity]): with no compiled issue yet this shows the first-run empty
+ * state and real chrome rather than faked headlines/counts. The fetch + extract + assemble backend
+ * (the inkread-daily crate's EPUB assembly, plus a later fetch slice) wires the populated front page
+ * and the control actions; today they are stubs, so nothing decorative is invented.
+ */
+class DailyActivity : Activity() {
+
+    private val density get() = resources.displayMetrics.density
+    private fun dp(v: Int) = (v * density).toInt()
+
+    private val script by lazy { Typeface.createFromAsset(assets, "fonts/pinyon_script.ttf") }
+    private val serif = Ink.serif
+    private val serifBold = Ink.serifBold
+    private val serifItalic = Ink.serifItalic
+    private val mono = Ink.mono
+    private val ink = Ink.ink
+    private val paper = Ink.paper
+
+    /** Width-driven scale over the Daily artboard's ~748-unit content column (mirrors HomeActivity). */
+    private var scale = 1f
+    private fun dim(u: Number) = dp((u.toFloat() * scale).toInt()).coerceAtLeast(1)
+    private fun fs(u: Number) = u.toFloat() * scale
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(buildView())
+    }
+
+    private fun buildView(): View {
+        val w = resources.displayMetrics.widthPixels
+        val side = (w * 0.06f).toInt().coerceIn(dp(18), dp(48))
+        val contentW = (w - 2 * side).coerceAtLeast(dp(280))
+        scale = (contentW.toFloat() / dp(748)).coerceIn(0.6f, 1.15f)
+
+        // Today's issue is unavailable until the fetch/assemble backend lands — first-run state.
+        val hasIssue = false
+        val sourceCount = 0
+
+        val page = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(side, dim(26), side, dim(24))
+            layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        }
+
+        page.addView(utilityRow())
+        page.addView(masthead())
+        page.addView(folio(hasIssue))
+        page.addView(gap(dim(20)))
+        page.addView(emptyState())
+        page.addView(gap(dim(22)))
+        page.addView(todaysDesk(hasIssue, sourceCount))
+        page.addView(gap(dim(20)))
+        page.addView(backIssues())
+        page.addView(gap(dim(22)))
+        page.addView(folioFooter())
+
+        return ScrollView(this).apply {
+            setBackgroundColor(paper)
+            isFillViewport = true
+            isVerticalScrollBarEnabled = false
+            addView(page)
+        }
+    }
+
+    // ── Utility row: ‹ Library · Daily · Settings ───────────────────────────────────────────────
+
+    private fun utilityRow(): View = LinearLayout(this).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        addView(label("‹ Library", 11f, 0.12f).apply {
+            isClickable = true; setOnClickListener { finish() }
+        })
+        addView(weighted())
+        addView(label("Daily", 11f, 0.12f))
+        addView(weighted())
+        addView(label("Settings", 11f, 0.12f).apply {
+            isClickable = true
+            setOnClickListener { startActivity(Intent(this@DailyActivity, SettingsActivity::class.java)) }
+        })
+    }
+
+    // ── Masthead: THE / [icon] InkRead / —— DAILY —— ────────────────────────────────────────────
+
+    private fun masthead(): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        gravity = Gravity.CENTER_HORIZONTAL
+        setPadding(0, dim(14), 0, dim(4))
+        // A heavy top rule opens the masthead (newspaper convention).
+        addView(blackRule(dim(3)).apply { (layoutParams as LinearLayout.LayoutParams).bottomMargin = dim(12) })
+        addView(label("The", 11f, 0.34f).apply { gravity = Gravity.CENTER })
+        addView(LinearLayout(this@DailyActivity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            setPadding(0, dim(2), 0, 0)
+            addView(android.widget.ImageView(this@DailyActivity).apply { setImageResource(R.mipmap.ic_launcher) },
+                LinearLayout.LayoutParams(dim(38), dim(38)).apply { marginEnd = dim(14); gravity = Gravity.CENTER_VERTICAL })
+            addView(TextView(this@DailyActivity).apply {
+                text = "InkRead"; setTextColor(ink); textSize = fs(64f); typeface = script
+                includeFontPadding = false; paint.isFakeBoldText = true
+            })
+        })
+        addView(LinearLayout(this@DailyActivity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(0, dim(6), 0, 0)
+            addView(blackRule(dim(2)), LinearLayout.LayoutParams(dim(110), dim(2)))
+            addView(TextView(this@DailyActivity).apply {
+                text = "DAILY"; setTextColor(ink); textSize = fs(22f); typeface = serifBold
+                letterSpacing = 0.45f; setPadding(dim(14), 0, dim(8), 0); includeFontPadding = false
+            })
+            addView(blackRule(dim(2)), LinearLayout.LayoutParams(dim(110), dim(2)))
+        })
+    }
+
+    // ── Folio bar: status · date · issue summary (between heavy rules) ───────────────────────────
+
+    private fun folio(hasIssue: Boolean): View = LinearLayout(this).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(dim(2), dim(7), dim(2), dim(7))
+        val top = blackRule(dim(3))
+        val bottom = blackRule(dim(3))
+        // wrap content between a heavy top + bottom rule
+        addView(label("Offline", 10f, 0.10f))
+        addView(weighted())
+        addView(label(todayLong(), 10f, 0.10f).apply { gravity = Gravity.CENTER })
+        addView(weighted())
+        addView(label(if (hasIssue) "Today's issue" else "No issue yet", 10f, 0.10f))
+        // compose the bordered band
+    }.let { band ->
+        LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(0, dim(12), 0, 0)
+            addView(blackRule(dim(3)))
+            addView(band)
+            addView(blackRule(dim(3)))
+        }
+    }
+
+    // ── First-run empty state: no issue compiled yet ────────────────────────────────────────────
+
+    private fun emptyState(): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        gravity = Gravity.CENTER_HORIZONTAL
+        setPadding(dim(8), dim(28), dim(8), dim(28))
+        // a ringed plus mark
+        addView(TextView(this@DailyActivity).apply {
+            text = "＋"; setTextColor(ink); textSize = fs(30f); gravity = Gravity.CENTER
+            val d = dim(74)
+            layoutParams = LinearLayout.LayoutParams(d, d)
+            background = GradientDrawable().apply {
+                setColor(paper); shape = GradientDrawable.OVAL; setStroke(Ink.keyline(), ink)
+            }
+            includeFontPadding = false
+        })
+        addView(TextView(this@DailyActivity).apply {
+            text = "No issue compiled yet"; setTextColor(ink); textSize = fs(22f); typeface = serif
+            gravity = Gravity.CENTER; setPadding(0, dim(18), 0, 0)
+        })
+        addView(TextView(this@DailyActivity).apply {
+            text = "Add a few feeds and InkRead will assemble today's reading into a single calm issue."
+            setTextColor(Ink.inkSoft); textSize = fs(16f); typeface = serifItalic
+            gravity = Gravity.CENTER; setLineSpacing(0f, 1.4f); setPadding(dim(10), dim(8), dim(10), 0)
+        })
+        addView(TextView(this@DailyActivity).apply {
+            text = "＋  Add your first source"; setTextColor(paper); textSize = fs(17f); typeface = serifBold
+            gravity = Gravity.CENTER; setPadding(dim(24), dim(14), dim(24), dim(14))
+            background = GradientDrawable().apply { setColor(ink) }
+            isClickable = true; setOnClickListener { stub("Sources") }
+            layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+                .apply { topMargin = dim(22) }
+        })
+        addView(label("RSS · Atom · Hacker News · paste a URL", 11f, 0.10f).apply {
+            gravity = Gravity.CENTER; setPadding(0, dim(12), 0, 0)
+        })
+    }
+
+    // ── Today's Desk: the control panel ─────────────────────────────────────────────────────────
+
+    private fun todaysDesk(hasIssue: Boolean, sources: Int): View {
+        val header = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setBackgroundColor(ink)
+            setPadding(dim(16), dim(8), dim(16), dim(8))
+            addView(label("Today's Desk", 11f, 0.2f).apply { setTextColor(paper) })
+            addView(weighted())
+            addView(label(if (hasIssue) "Compiled" else "Awaiting sources", 11f, 0.1f).apply { setTextColor(paper) })
+        }
+        val controls = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setPadding(dim(14), dim(14), dim(14), dim(14))
+            // Primary read (wide). Disabled-looking until an issue exists.
+            addView(deskPrimary(hasIssue), LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1.6f))
+            addView(deskButton("Regenerate") { stub("Regenerate") }, deskLp(dim(12)))
+            addView(deskButton("Sources · $sources") { stub("Sources") }, deskLp(dim(12)))
+            addView(deskButton("Archive") { stub("Archive") }, deskLp(dim(12)))
+        }
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            background = GradientDrawable().apply { setColor(paper); setStroke(Ink.keyline(), ink) }
+            addView(header)
+            addView(controls)
+        }
+    }
+
+    private fun deskPrimary(hasIssue: Boolean): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        gravity = Gravity.CENTER_VERTICAL
+        setBackgroundColor(if (hasIssue) ink else Color.parseColor("#9E9E9E"))
+        setPadding(dim(18), dim(16), dim(18), dim(16))
+        isClickable = true
+        setOnClickListener { if (hasIssue) stub("Read Today's Issue") else stub("Add sources to compile today's issue") }
+        addView(TextView(this@DailyActivity).apply {
+            text = "Read Today's Issue"; setTextColor(paper); textSize = fs(20f); typeface = serifBold
+            includeFontPadding = false
+        })
+        addView(label(if (hasIssue) "Opens the reflowable EPUB" else "No issue yet", 10f, 0.08f).apply {
+            setTextColor(Color.parseColor("#E8E8E8")); setPadding(0, dim(5), 0, 0)
+        })
+    }
+
+    private fun deskButton(text: String, onTap: () -> Unit): View = TextView(this).apply {
+        this.text = text; setTextColor(ink); textSize = fs(13f); typeface = serif
+        gravity = Gravity.CENTER; setPadding(dim(10), dim(16), dim(10), dim(16))
+        background = GradientDrawable().apply { setColor(paper); setStroke(Ink.hair(), ink) }
+        isClickable = true; setOnClickListener { onTap() }
+    }
+
+    private fun deskLp(start: Int) = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f)
+        .apply { marginStart = start }
+
+    // ── Back Issues strip ───────────────────────────────────────────────────────────────────────
+
+    private fun backIssues(): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        addView(LinearLayout(this@DailyActivity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            addView(label("Back Issues", 11f, 0.18f))
+            addView(blackRule(Ink.hair()), LinearLayout.LayoutParams(0, Ink.hair(), 1f).apply {
+                marginStart = dim(14); marginEnd = dim(14)
+            })
+            addView(label("View all ›", 11f, 0.1f).apply { isClickable = true; setOnClickListener { stub("Archive") } })
+        })
+        // No archive yet — honest placeholder rather than faked dated cards.
+        addView(TextView(this@DailyActivity).apply {
+            text = "Past issues appear here once you've compiled a few."
+            setTextColor(Ink.muted); textSize = fs(14f); typeface = serifItalic
+            gravity = Gravity.CENTER; setPadding(0, dim(18), 0, dim(6))
+        })
+    }
+
+    // ── Folio footer ────────────────────────────────────────────────────────────────────────────
+
+    private fun folioFooter(): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        addView(blackRule(Ink.hair()).apply { (layoutParams as LinearLayout.LayoutParams).bottomMargin = dim(12) })
+        addView(LinearLayout(this@DailyActivity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            addView(label("Compiled on device · Offline", 10f, 0.12f))
+            addView(weighted())
+            addView(label("Export PDF ›", 10f, 0.12f).apply {
+                isClickable = true; setOnClickListener { stub("Export PDF") }
+            })
+        })
+    }
+
+    // ── Shared pieces ───────────────────────────────────────────────────────────────────────────
+
+    /** A mono, uppercase, letter-spaced label — the newspaper's Space-Mono kicker. */
+    private fun label(text: String, size: Float, spacing: Float): TextView = TextView(this).apply {
+        this.text = text.uppercase(); setTextColor(ink); textSize = fs(size)
+        typeface = mono; letterSpacing = spacing
+    }
+
+    /** A solid black rule (newspapers use black keylines, not the hairline grey). */
+    private fun blackRule(thickness: Int): View = View(this).apply {
+        setBackgroundColor(ink)
+        layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, thickness)
+    }
+
+    private fun gap(h: Int): View = View(this).apply {
+        layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, h)
+    }
+
+    private fun weighted(): View = View(this).apply {
+        layoutParams = LinearLayout.LayoutParams(0, 1, 1f)
+    }
+
+    private fun todayLong(): String =
+        SimpleDateFormat("EEEE, MMMM d, yyyy", Locale.getDefault()).format(Date())
+
+    /** Placeholder for an action whose backend slice hasn't landed yet (#66). */
+    private fun stub(what: String) =
+        Toast.makeText(this, "$what — coming soon", Toast.LENGTH_SHORT).show()
+}

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -136,10 +136,19 @@ class HomeActivity : Activity() {
             isVerticalScrollBarEnabled = false
             addView(column)
         }
-        // A subtle top-corner gear → app Settings (export behaviour, help, about).
+        // Top corners: a Daily entry (left) → the newspaper front page, a gear (right) → Settings.
         return FrameLayout(this).apply {
             setBackgroundColor(Color.WHITE)
             addView(scroll, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+            addView(TextView(this@HomeActivity).apply {
+                text = "The Daily  ›"; setTextColor(ink); textSize = 12f; typeface = mono
+                letterSpacing = 0.12f; isAllCaps = true
+                val p = dp(8); setPadding(p, p, p, p)
+                isClickable = true
+                setOnClickListener { startActivity(Intent(this@HomeActivity, DailyActivity::class.java)) }
+            }, FrameLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.TOP or Gravity.START).apply {
+                topMargin = dp(14); marginStart = dp(14)
+            })
             addView(ImageView(this@HomeActivity).apply {
                 setImageResource(R.drawable.ic_settings)
                 val p = dp(8); setPadding(p, p, p, p)

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -192,16 +192,27 @@ class HomeActivity : Activity() {
                     typeface = Typeface.create(serif, Typeface.ITALIC)
                 })
                 addView(TextView(this@HomeActivity).apply {
-                    text = r.title; setTextColor(ink); textSize = fs(26f); typeface = serif
-                    maxLines = 3; setLineSpacing(0f, 1.1f); setPadding(0, dim(7), 0, 0)
+                    text = Books.displayTitle(this@HomeActivity, r); setTextColor(ink); textSize = fs(26f)
+                    typeface = serif; maxLines = 3; setLineSpacing(0f, 1.1f); setPadding(0, dim(7), 0, 0)
                 })
+                Books.metaAuthor(this@HomeActivity, r.id)?.let { author ->
+                    addView(TextView(this@HomeActivity).apply {
+                        text = author; setTextColor(inkSoft); textSize = fs(15f)
+                        typeface = Typeface.create(serif, Typeface.ITALIC); setPadding(0, dim(5), 0, 0)
+                    })
+                }
                 addView(spacerWeighted(1f))
                 val percent = Books.progress(this@HomeActivity, r.id)
+                val pages = Books.metaPages(this@HomeActivity, r.id)
+                // "page N / M · X% complete" when the page count is known, else just the percentage.
+                val progressLabel = if (pages > 0)
+                    "page ${Books.metaPage(this@HomeActivity, r.id) + 1} / $pages · $percent%"
+                else "$percent% complete"
                 addView(LinearLayout(this@HomeActivity).apply {
                     orientation = LinearLayout.HORIZONTAL
                     gravity = Gravity.CENTER_VERTICAL
                     setPadding(0, dim(14), 0, 0)
-                    addView(eyebrow("$percent% complete"))
+                    addView(eyebrow(progressLabel))
                     addView(spacerWeighted(1f))
                     addView(TextView(this@HomeActivity).apply {
                         text = "Resume →"; setTextColor(ink); textSize = fs(15f); typeface = serif
@@ -363,7 +374,7 @@ class HomeActivity : Activity() {
         }
         if (!spine) {
             return TextView(this).apply {
-                text = r.title; setTextColor(textSecondary); textSize = fs(12f); typeface = serif
+                text = Books.displayTitle(this@HomeActivity, r); setTextColor(textSecondary); textSize = fs(12f); typeface = serif
                 gravity = Gravity.CENTER; setPadding(dim(8), dim(8), dim(8), dim(8))
                 background = GradientDrawable().apply {
                     setColor(Color.parseColor("#EFEFEF")); setStroke(maxOf(1, dp(1)), ink)
@@ -379,7 +390,7 @@ class HomeActivity : Activity() {
             addView(View(this@HomeActivity).apply { setBackgroundColor(Color.WHITE) },
                 LinearLayout.LayoutParams(dim(4), ViewGroup.LayoutParams.MATCH_PARENT))
             addView(TextView(this@HomeActivity).apply {
-                text = r.title; setTextColor(Color.WHITE); textSize = fs(15f); typeface = serif
+                text = Books.displayTitle(this@HomeActivity, r); setTextColor(Color.WHITE); textSize = fs(15f); typeface = serif
                 gravity = Gravity.BOTTOM; setLineSpacing(0f, 1.12f)
                 setPadding(dim(12), dim(12), dim(12), dim(12))
                 layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f)

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -130,6 +130,10 @@ class HomeActivity : Activity() {
         }
         column.addView(spacer(dim(28)))
         column.addView(openButton())
+        statChips()?.let {
+            column.addView(spacer(dim(16)))
+            column.addView(it)
+        }
         column.addView(spacerWeighted(phi))
         column.addView(closingMark())
 
@@ -413,6 +417,36 @@ class HomeActivity : Activity() {
                 background = GradientDrawable().apply { setColor(ink); cornerRadius = dim(4).toFloat() }
             }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, p.toFloat()))
             if (p < 100) addView(View(this@HomeActivity), LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, (100 - p).toFloat()))
+        }
+    }
+
+    /** The design's stat chips — outlined pills of REAL reading stats (streak · this week · pages).
+     *  Each chip appears only when it has data, so nothing is faked; null when there's nothing yet. */
+    private fun statChips(): View? {
+        val chips = buildList {
+            val streak = ReadingStats.streakDays(this@HomeActivity)
+            val minutes = ReadingStats.weekMinutes(this@HomeActivity)
+            val pages = ReadingStats.weekPages(this@HomeActivity)
+            if (streak > 0) add(if (streak == 1) "1-day streak" else "$streak-day streak")
+            if (minutes > 0) add("${ReadingStats.formatMinutes(minutes)} this week")
+            if (pages > 0) add(if (pages == 1) "1 page" else "$pages pages")
+        }
+        if (chips.isEmpty()) return null
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            chips.forEachIndexed { i, c ->
+                addView(chip(c), LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+                    .apply { marginStart = if (i == 0) 0 else dim(10) })
+            }
+        }
+    }
+
+    private fun chip(text: String): View = TextView(this).apply {
+        this.text = text; setTextColor(ink); textSize = fs(13f); typeface = serif
+        gravity = Gravity.CENTER; setPadding(dim(16), dim(6), dim(16), dim(6))
+        background = GradientDrawable().apply {
+            setColor(Color.WHITE); setStroke(maxOf(1, dp(1)), ink); cornerRadius = dim(40).toFloat()
         }
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -114,20 +114,22 @@ class HomeActivity : Activity() {
             column.addView(TextView(this).apply {
                 text = "Open a document to start your library."
                 setTextColor(textMuted); textSize = fs(16f); gravity = Gravity.CENTER
-                typeface = serif; setPadding(0, 0, 0, dim(20))
+                typeface = serif
             })
-            column.addView(openButton())
         } else {
             column.addView(heroCard(recents.first(), contentW))
-            if (recents.size >= 2) {
-                column.addView(spacer(dim(28)))
-                column.addView(eyebrowItalic("Recently on your shelf"))
-                column.addView(spacer(dim(16)))
-                column.addView(shelf(recents.take(3), contentW))
-            }
-            column.addView(spacer(dim(28)))
-            column.addView(openButton())
         }
+        // The InkRead Daily — the day's issue as a strip card (the design's in-flow Daily entry).
+        column.addView(spacer(dim(24)))
+        column.addView(dailyCard(contentW))
+        if (recents.size >= 2) {
+            column.addView(spacer(dim(28)))
+            column.addView(eyebrowItalic("Recently on your shelf"))
+            column.addView(spacer(dim(16)))
+            column.addView(shelf(recents.take(3), contentW))
+        }
+        column.addView(spacer(dim(28)))
+        column.addView(openButton())
         column.addView(spacerWeighted(phi))
         column.addView(closingMark())
 
@@ -136,19 +138,10 @@ class HomeActivity : Activity() {
             isVerticalScrollBarEnabled = false
             addView(column)
         }
-        // Top corners: a Daily entry (left) → the newspaper front page, a gear (right) → Settings.
+        // A subtle top-corner gear → app Settings (the Daily entry is the in-flow card below).
         return FrameLayout(this).apply {
             setBackgroundColor(Color.WHITE)
             addView(scroll, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
-            addView(TextView(this@HomeActivity).apply {
-                text = "The Daily  ›"; setTextColor(ink); textSize = 12f; typeface = mono
-                letterSpacing = 0.12f; isAllCaps = true
-                val p = dp(8); setPadding(p, p, p, p)
-                isClickable = true
-                setOnClickListener { startActivity(Intent(this@HomeActivity, DailyActivity::class.java)) }
-            }, FrameLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.TOP or Gravity.START).apply {
-                topMargin = dp(14); marginStart = dp(14)
-            })
             addView(ImageView(this@HomeActivity).apply {
                 setImageResource(R.drawable.ic_settings)
                 val p = dp(8); setPadding(p, p, p, p)
@@ -172,7 +165,7 @@ class HomeActivity : Activity() {
             typeface = scriptBold; paint.isFakeBoldText = true; gravity = Gravity.CENTER
             includeFontPadding = false
         })
-        addView(eyebrow("·  v${versionName()}  ·").apply { gravity = Gravity.CENTER; setPadding(0, dim(10), 0, 0) })
+        addView(eyebrow("·  Super Reader · v${versionName()}  ·").apply { gravity = Gravity.CENTER; setPadding(0, dim(10), 0, 0) })
     }
 
     // ── Continue where you left off (the most-recent book) ───────────────────────────────────────
@@ -219,6 +212,68 @@ class HomeActivity : Activity() {
                     (layoutParams as LinearLayout.LayoutParams).topMargin = dim(8)
                 })
             }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f).apply { marginStart = gap })
+        }
+    }
+
+    // ── The InkRead Daily — the day's issue as a strip card (taps → DailyActivity) ───────────────
+
+    private fun dailyCard(contentW: Int): View {
+        val pad = dim(15)
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            background = outlined(dim(12))
+            isClickable = true
+            setOnClickListener { startActivity(Intent(this@HomeActivity, DailyActivity::class.java)) }
+            layoutParams = LinearLayout.LayoutParams(contentW, ViewGroup.LayoutParams.WRAP_CONTENT)
+
+            // Left masthead cell: THE / InkRead (script) / DAILY.
+            addView(LinearLayout(this@HomeActivity).apply {
+                orientation = LinearLayout.VERTICAL
+                gravity = Gravity.CENTER
+                setPadding(dim(14), pad, dim(12), pad)
+                addView(TextView(this@HomeActivity).apply {
+                    text = "THE"; setTextColor(ink); textSize = fs(8f); typeface = mono; letterSpacing = 0.28f
+                })
+                addView(TextView(this@HomeActivity).apply {
+                    text = "InkRead"; setTextColor(ink); textSize = fs(30f); typeface = script
+                    includeFontPadding = false
+                })
+                addView(TextView(this@HomeActivity).apply {
+                    text = "DAILY"; setTextColor(ink); textSize = fs(11f)
+                    typeface = Typeface.create(serif, Typeface.BOLD); letterSpacing = 0.4f
+                })
+            }, LinearLayout.LayoutParams(dim(132), ViewGroup.LayoutParams.MATCH_PARENT))
+
+            addView(View(this@HomeActivity).apply { setBackgroundColor(ink) },
+                LinearLayout.LayoutParams(maxOf(1, dp(1)), ViewGroup.LayoutParams.MATCH_PARENT))
+
+            // Middle: today's status. Honest first-run copy — no issue is compiled until the daily
+            // backend (fetch/assemble) lands; nothing decorative is faked.
+            addView(LinearLayout(this@HomeActivity).apply {
+                orientation = LinearLayout.VERTICAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(dim(16), pad, dim(12), pad)
+                addView(eyebrow("Today's Daily"))
+                addView(TextView(this@HomeActivity).apply {
+                    text = "No issue compiled yet"; setTextColor(ink); textSize = fs(19f); typeface = serif
+                    setPadding(0, dim(4), 0, 0); maxLines = 2; setLineSpacing(0f, 1.1f)
+                })
+                addView(TextView(this@HomeActivity).apply {
+                    text = "Add a few sources to start your daily issue"
+                    setTextColor(inkSoft); textSize = fs(13f); typeface = Typeface.create(serif, Typeface.ITALIC)
+                    setPadding(0, dim(3), 0, 0)
+                })
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f))
+
+            // Right action.
+            addView(TextView(this@HomeActivity).apply {
+                text = "Set up →"; setTextColor(Color.WHITE); textSize = fs(14f)
+                typeface = Typeface.create(serif, Typeface.BOLD); gravity = Gravity.CENTER
+                setPadding(dim(18), dim(12), dim(18), dim(12))
+                background = GradientDrawable().apply { setColor(ink) }
+            }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.MATCH_PARENT).apply {
+                gravity = Gravity.CENTER_VERTICAL; marginEnd = dim(12)
+            })
         }
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -68,6 +68,13 @@ object NativeBridge {
     /** Page count of the open document. */
     external fun nativePageCount(handle: Long): Int
 
+    /** The document's title from its metadata, or "" if none — stored so the library shows the real
+     *  title instead of the filename. */
+    external fun nativeDocTitle(handle: Long): String
+
+    /** The document's author from its metadata, or "" if none. */
+    external fun nativeDocAuthor(handle: Long): String
+
     /**
      * Render the current page into [directBuffer] — a DIRECT [ByteBuffer] of exactly
      * `width*height*4` bytes (RGBA). The core borrows it for the call only (Amendment 5).

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -112,6 +112,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     @Volatile private var pageCount = 0
     /** Stable id of the open book (its file name); keys thumbnails + the bookmarks file. */
     @Volatile private var currentBookId = ""
+    /** Foreground reading-session start (elapsed ms) + the page it began on, for ReadingStats. */
+    private var sessionStartMs = 0L
+    private var sessionStartPage = 0
     /** Whether PDF reflow mode is on (ADR-INKREAD-0011). Session-scoped: defaults off on each open
      *  (the fixed page is the faithful view; reflow is an opt-in toggle on the Page tab). */
     @Volatile private var reflowOn = false
@@ -570,10 +573,19 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // onWindowFocusChanged: the Supernote's window-focus events are flaky (the window can go
         // "Gone" right after launch), so onResume is the reliable foreground signal.
         applyToolInkState("resume")
+        // Start timing this foreground reading session (ReadingStats — streak + weekly chrome).
+        sessionStartMs = SystemClock.elapsedRealtime()
+        sessionStartPage = currentPage
     }
 
     override fun onPause() {
         super.onPause()
+        // Record the finished reading session (time read + pages advanced) before tearing down.
+        if (docHandle != 0L && sessionStartMs > 0L && currentBookId.isNotEmpty()) {
+            val minutes = ((SystemClock.elapsedRealtime() - sessionStartMs) / 60_000L).toInt()
+            ReadingStats.record(this, minutes, (currentPage - sessionStartPage).coerceAtLeast(0))
+        }
+        sessionStartMs = 0L
         if (::toolPalette.isInitialized) toolPalette.dismiss() // close any open palette popup
         if (::selectionToolbar.isInitialized) selectionToolbar.dismiss()
         if (::colorPalette.isInitialized) colorPalette.dismiss()

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -788,6 +788,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             }
             pageCount = NativeBridge.nativePageCount(docHandle)
             Books.pushRecent(this, bookId, path)
+            // Capture the real document metadata so the library shows the actual title/author + page
+            // position instead of the filename (the home redesign's real-data path).
+            try {
+                val t = NativeBridge.nativeDocTitle(docHandle)
+                val a = NativeBridge.nativeDocAuthor(docHandle)
+                Books.setMeta(this, bookId, t, a, pageCount)
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "doc metadata failed: ${e.message}")
+            }
             Log.i(
                 TAG,
                 "opened $bookId: $pageCount pages, resumed at page ${NativeBridge.nativeCurrentPage(docHandle)}",
@@ -2988,10 +2997,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         } catch (e: RuntimeException) {
             Log.e(TAG, "save position failed: ${e.message}")
         }
-        // Record read progress for the home shelf (RR16/RR17).
+        // Record read progress + page position for the home shelf (RR16/RR17).
         val total = pageCount
         if (total > 0 && currentBookId.isNotEmpty()) {
             Books.setProgress(this, currentBookId, ((currentPage + 1) * 100) / total)
+            Books.setPage(this, currentBookId, currentPage)
         }
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/ReadingStats.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReadingStats.kt
@@ -1,0 +1,80 @@
+package dev.jraghavan.inkread
+
+import android.content.Context
+
+/**
+ * On-device reading stats for the home screen's streak + weekly chrome (the design's "12-day streak ·
+ * 4h 20m this week · 320 pages"). All real, all local: a reading **streak** of consecutive calendar
+ * days with activity, plus **minutes** and **pages** accumulated in the current week. The reader
+ * reports a foreground session (time + pages advanced) when it backgrounds; the home reads the
+ * rollups. No clock beyond the calendar day — nothing fabricated.
+ */
+object ReadingStats {
+
+    private fun prefs(ctx: Context) = ctx.getSharedPreferences("stats", Context.MODE_PRIVATE)
+
+    /** UTC calendar day (days since epoch) — the unit the streak counts in. */
+    private fun today(): Long = System.currentTimeMillis() / 86_400_000L
+
+    /** ISO-ish week bucket (7-day blocks since epoch) — the weekly accumulators reset when it changes. */
+    private fun thisWeek(): Long = today() / 7
+
+    /**
+     * Record a finished foreground reading session: `minutes` read and `pages` advanced. Rolls the
+     * weekly accumulators (resetting them when the week turns) and advances the streak for today.
+     */
+    fun record(ctx: Context, minutes: Int, pages: Int) {
+        if (minutes <= 0 && pages <= 0) return
+        val p = prefs(ctx)
+        val week = thisWeek()
+        val storedWeek = p.getLong("week", -1)
+        val (baseMin, basePages) = if (week == storedWeek) {
+            p.getInt("weekMin", 0) to p.getInt("weekPages", 0)
+        } else {
+            0 to 0 // a new week — start fresh
+        }
+        p.edit()
+            .putLong("week", week)
+            .putInt("weekMin", baseMin + minutes.coerceAtLeast(0))
+            .putInt("weekPages", basePages + pages.coerceAtLeast(0))
+            .apply()
+        markRead(ctx)
+    }
+
+    /** Mark today as a reading day, advancing/continuing/resetting the streak. */
+    private fun markRead(ctx: Context) {
+        val p = prefs(ctx)
+        val today = today()
+        val last = p.getLong("lastDay", -1)
+        if (last == today) return // already counted today
+        val streak = p.getInt("streak", 0)
+        val next = when (last) {
+            today - 1 -> streak + 1 // consecutive day
+            else -> 1 // first day, or a gap broke the streak
+        }
+        p.edit().putLong("lastDay", today).putInt("streak", next).apply()
+    }
+
+    /** Consecutive-day reading streak, or 0 if the last reading day was before yesterday. */
+    fun streakDays(ctx: Context): Int {
+        val p = prefs(ctx)
+        val last = p.getLong("lastDay", -1)
+        val today = today()
+        return if (last == today || last == today - 1) p.getInt("streak", 0) else 0
+    }
+
+    /** Minutes read in the current week (0 once the week turns over). */
+    fun weekMinutes(ctx: Context): Int =
+        if (prefs(ctx).getLong("week", -1) == thisWeek()) prefs(ctx).getInt("weekMin", 0) else 0
+
+    /** Pages advanced in the current week (0 once the week turns over). */
+    fun weekPages(ctx: Context): Int =
+        if (prefs(ctx).getLong("week", -1) == thisWeek()) prefs(ctx).getInt("weekPages", 0) else 0
+
+    /** "4h 20m" / "35m" — a compact reading-time label for the weekly chip. */
+    fun formatMinutes(min: Int): String {
+        val h = min / 60
+        val m = min % 60
+        return if (h > 0) "${h}h ${m}m" else "${m}m"
+    }
+}

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -307,6 +307,35 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativePageCount<'
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeDocTitle(handle) : String — the document's title from its metadata, or "" if none. The
+// shell stores it so the library shows the real title (not the filename).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeDocTitle<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) -> JString<'local> {
+    env.with_env(|env| -> jni::errors::Result<JString<'local>> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        env.new_string(session.metadata().title.unwrap_or_default())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// nativeDocAuthor(handle) : String — the document's author from its metadata, or "" if none.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeDocAuthor<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) -> JString<'local> {
+    env.with_env(|env| -> jni::errors::Result<JString<'local>> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        env.new_string(session.metadata().author.unwrap_or_default())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // =====================================================================================
 // nativeRenderPage(handle, directBuffer) — render the current page into the direct
 // ByteBuffer the shell locked. The PixelBuffer borrow never outlives this call (Amendment 5).


### PR DESCRIPTION
The inkread-daily home as a **1-bit newspaper front page** (from the claude.ai/design "inkRead — Daily" board), adapting the existing Home screen's Inkwell voice (`Ink` tokens + the bundled Pinyon Script masthead). The UI slice of #66.

## What changed

- **`DailyActivity`** — the newspaper front page: a utility row (‹ Library · Daily · Settings), a masthead (THE / icon + *InkRead* script / —— DAILY ——), a dated folio between heavy rules, the first-run **"No issue compiled yet"** empty state with an Add-source CTA, a **Today's Desk** control panel (Read Today's Issue · Regenerate · Sources · Archive), and a **Back Issues** strip.
- **Home** — a "The Daily ›" entry in the top-left corner opens it (mirrors the Settings gear).
- **Manifest** — register `DailyActivity` (not exported).

**Honest by default** (like `HomeActivity`): with no compiled issue yet it shows the empty state and real chrome rather than faked headlines/counts. The control actions are stubs (toasts) until the fetch/assemble backend lands.

## Scope

Pure Kotlin shell — no core change. This is the chrome + empty-state + entry slice; backend wiring (assemble→read via the `inkread-daily` crate, real sources, the populated front page, the archive) is the next slice.

## Testing

Release APK assembles + installs on the Nomad. UI is visually verified on device (the Supernote EPD screencap is all-black, so it can't be captured here).