### PR TITLE
feat(daily): auto-compile a fresh issue each morning (#66)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,9 @@ dependencies {
     // ignores. Bump these together with compileSdk + AGP, not piecemeal.
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
+    // Background scheduler for the daily auto-compile (#66). 2.9.x is the last line that builds
+    // against compileSdk 34 (2.10+ needs SDK 35) — bump with compileSdk + AGP, not piecemeal.
+    implementation("androidx.work:work-runtime-ktx:2.9.1")
 
     // Host JVM unit tests for pure logic (e.g. PalmFilter) — run via :app:testDebugUnitTest, no
     // emulator/device needed (an emulator can't simulate the Supernote EMR pen anyway).

--- a/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
@@ -288,6 +288,13 @@ class DailyActivity : Activity() {
 
     // ── Today's Desk ──────────────────────────────────────────────────────────────────────────────
 
+    /** "Compiled 5:02 AM" from the last compile time, or just "Compiled" if the time is unknown. */
+    private fun compiledStamp(): String {
+        val at = daily.lastCompiledAt()
+        if (at <= 0L) return "Compiled"
+        return "Compiled ${SimpleDateFormat("h:mm a", Locale.getDefault()).format(Date(at))}"
+    }
+
     private fun todaysDesk(hasIssue: Boolean, sources: Int, issue: File?): View {
         val header = LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL
@@ -295,7 +302,7 @@ class DailyActivity : Activity() {
             setPadding(dim(16), dim(8), dim(16), dim(8))
             addView(label("Today's Desk", 11f, 0.2f).apply { setTextColor(paper) })
             addView(weighted())
-            addView(label(if (hasIssue) "Compiled" else "Awaiting sources", 11f, 0.1f).apply { setTextColor(paper) })
+            addView(label(if (hasIssue) compiledStamp() else "Awaiting sources", 11f, 0.1f).apply { setTextColor(paper) })
         }
         val controls = LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL

--- a/app/src/main/java/dev/jraghavan/inkread/DailyAutoCompileWorker.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyAutoCompileWorker.kt
@@ -1,0 +1,79 @@
+package dev.jraghavan.inkread
+
+import android.content.Context
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+
+/**
+ * Compiles a fresh daily issue in the background each morning (#66), so an issue is waiting when the
+ * device is picked up instead of needing a manual Regenerate. A WorkManager periodic job: it survives
+ * reboots, waits for a network, and backs off on transient failure. The first run is aligned to the
+ * next [MORNING_HOUR]; WorkManager then repeats it about once a day.
+ *
+ * The compile pipeline itself lives in [DailyController] (fetch → core extract/assemble); this worker
+ * only schedules and drives it. Idempotent: if today's issue already exists (e.g. the user compiled
+ * manually) it does nothing.
+ */
+class DailyAutoCompileWorker(context: Context, params: WorkerParameters) :
+    Worker(context, params) {
+
+    override fun doWork(): Result {
+        val daily = DailyController(applicationContext)
+        if (daily.todayIssue() != null) {
+            Log.i(TAG, "today's issue already compiled — skipping")
+            return Result.success()
+        }
+        return try {
+            // No network / no enabled sources yet → retry with backoff (WorkManager honours the
+            // network constraint, so this mainly covers a feed being briefly unreachable).
+            if (daily.compileSync()) Result.success() else Result.retry()
+        } catch (e: Exception) {
+            Log.e(TAG, "auto-compile failed", e)
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val TAG = "DailyAutoCompile"
+        private const val UNIQUE = "daily-auto-compile"
+        private const val MORNING_HOUR = 5
+
+        /** Enqueue (or keep) the daily auto-compile. Safe to call on every app start — KEEP leaves an
+         *  already-scheduled job untouched, so the morning cadence isn't reset each launch. */
+        fun schedule(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+            val request = PeriodicWorkRequestBuilder<DailyAutoCompileWorker>(1, TimeUnit.DAYS)
+                .setConstraints(constraints)
+                .setInitialDelay(delayToNextMorning(), TimeUnit.MILLISECONDS)
+                .setBackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.MINUTES)
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(UNIQUE, ExistingPeriodicWorkPolicy.KEEP, request)
+            Log.i(TAG, "scheduled daily auto-compile (first run in ${delayToNextMorning() / 60000} min)")
+        }
+
+        /** Millis from now until the next [MORNING_HOUR] o'clock, local time. */
+        private fun delayToNextMorning(): Long {
+            val now = Calendar.getInstance()
+            val next = (now.clone() as Calendar).apply {
+                set(Calendar.HOUR_OF_DAY, MORNING_HOUR)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+                if (!after(now)) add(Calendar.DAY_OF_MONTH, 1)
+            }
+            return next.timeInMillis - now.timeInMillis
+        }
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
@@ -115,6 +115,13 @@ class DailyController(private val context: Context) {
         }
     }
 
+    /** Blocking compile for the background scheduler ([DailyAutoCompileWorker]); call off the UI
+     *  thread. Returns whether an issue was produced. */
+    fun compileSync(): Boolean = compileBlocking()
+
+    /** Epoch millis of the last successful compile (0 if never). Drives the "Compiled HH:MM" stamp. */
+    fun lastCompiledAt(): Long = prefs().getLong("compiledAtMillis", 0L)
+
     private var lastStatus = ""
 
     private fun compileBlocking(): Boolean {
@@ -186,6 +193,7 @@ class DailyController(private val context: Context) {
         val file = File(dailyDir(), "inkread-daily-${todayKey()}.epub")
         file.writeBytes(bytes)
         storeIssueMeta(articles, file)
+        prefs().edit().putLong("compiledAtMillis", System.currentTimeMillis()).apply()
         Log.i(TAG, "compile OK: ${articles.length()} articles → ${file.name} (${bytes.size} bytes)")
         lastStatus = "Compiled ${articles.length()} articles"
         return true

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -75,6 +75,7 @@ class HomeActivity : Activity() {
         super.onCreate(savedInstanceState)
         setContentView(buildView())
         shelfSig = shelfSignature()
+        DailyAutoCompileWorker.schedule(this) // a fresh Daily issue compiles each morning (#66)
     }
 
     override fun onResume() {


### PR DESCRIPTION
## What

The Daily only refreshed on a manual **Regenerate**, so the issue shown was whatever was last built by hand. This adds a background scheduler so a fresh issue is waiting when the device is picked up.

## How

- **`DailyAutoCompileWorker`** — a WorkManager periodic job: survives reboot, requires a network, backs off on transient failure. First run aligns to **5 AM local**, then repeats ~daily. Idempotent — skips if today's issue already exists (e.g. you compiled manually).
- **`DailyController.compileSync()`** exposes the existing blocking compile to the worker; the last successful compile time is persisted.
- **`HomeActivity`** schedules the job on launch (`KEEP`, so the cadence isn't reset each open).
- **Today's Desk** stamps **"Compiled h:mm a"** from the last compile time.
- Adds `androidx.work:work-runtime-ktx:2.9.1` (the line that builds against compileSdk 34).

## Testing

- Verified on the Nomad: the job enqueues (logged "first run in 397 min" ≈ 5 AM) and registers with the system JobScheduler via WorkManager.
- `cargo fmt --all --check`, `cargo clippy --all -- -D warnings`, `cargo test --workspace` — all green (no Rust changed).
- APK assembles + installs.

Closes part of #66 (daily auto-compile).