### PR TITLE
feat(daily): mark headlines read/unread on the front page (#66)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
@@ -228,10 +228,21 @@ class DailyActivity : Activity() {
             })
             addView(blackRule(maxOf(1, dp(1))).apply { (layoutParams as LinearLayout.LayoutParams).topMargin = dim(5) })
             list.forEach { h ->
-                addView(TextView(this@DailyActivity).apply {
-                    text = h.title; setTextColor(ink); textSize = fs(15f); typeface = serif
-                    setLineSpacing(0f, 1.16f); setPadding(0, dim(10), 0, 0)
-                    isClickable = true; setOnClickListener { openIssue(issue, h.index) }
+                val read = daily.isRead(h.index)
+                addView(LinearLayout(this@DailyActivity).apply {
+                    orientation = LinearLayout.HORIZONTAL
+                    setPadding(0, dim(10), 0, 0)
+                    isClickable = true
+                    setOnClickListener { daily.markRead(h.index); openIssue(issue, h.index) }
+                    // Fixed-width gutter: a filled dot for unread, blank for read — titles stay aligned.
+                    addView(TextView(this@DailyActivity).apply {
+                        text = if (read) "" else "●"; setTextColor(ink); textSize = fs(9f)
+                        typeface = serif; width = dim(16); setPadding(0, dim(5), 0, 0)
+                    })
+                    addView(TextView(this@DailyActivity).apply {
+                        text = h.title; setTextColor(if (read) Ink.muted else ink); textSize = fs(15f)
+                        typeface = serif; setLineSpacing(0f, 1.16f)
+                    }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
                 })
             }
         }

--- a/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
@@ -211,6 +211,20 @@ class DailyController(private val context: Context) {
             }
         }.getOrDefault(emptyList())
 
+    /** Whether article [index] of today's issue has been opened. Keyed by date so marks reset daily. */
+    fun isRead(index: Int): Boolean =
+        prefs().getStringSet("readArticles", emptySet())!!.contains("${todayKey()}#$index")
+
+    /** Mark article [index] of today's issue as read; prunes other days' marks so the set stays small. */
+    fun markRead(index: Int) {
+        val today = todayKey()
+        val next = prefs().getStringSet("readArticles", emptySet())!!
+            .filter { it.startsWith("$today#") } // drop stale days
+            .toMutableSet()
+            .apply { add("$today#$index") }
+        prefs().edit().putStringSet("readArticles", next).apply()
+    }
+
     /** Past issues (excluding today), most-recent first. */
     fun backIssues(): List<BackIssue> {
         val today = todayKey()


### PR DESCRIPTION
## What

Once an issue had ~50 articles there was no way to tell what you'd already read. This tracks per-article read state and shows it on the Daily front page.

## How

- **`DailyController.isRead` / `markRead`** — read marks keyed by `date#index`, so they reset with each day's issue and the stored set stays small (older days pruned on write).
- Tapping a headline **marks it read**, then opens that article.
- Headlines show a **filled dot** in a fixed-width gutter when **unread** (titles stay aligned regardless); read ones drop the dot and render in **muted grey**.

## Testing

- Verified on the Nomad.
- `cargo fmt --all --check`, `cargo clippy --all -- -D warnings`, `cargo test --workspace` — all green (no Rust changed).
- APK assembles + installs.

Part of #66.