### PR TITLE
feat(daily): migrate feed parser to feed-rs (#66)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +174,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -318,6 +328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +370,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "feed-rs"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c0591d23efd0d595099af69a31863ac1823046b1b021e3b06ba3aae7e00991"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml 0.37.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +401,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -395,6 +440,17 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -479,6 +535,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +665,7 @@ dependencies = [
 name = "inkread-daily"
 version = "0.1.0-m0"
 dependencies = [
+ "feed-rs",
  "inkread-epub",
  "quick-xml 0.36.2",
  "serde",
@@ -659,6 +819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +874,15 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "mediatype"
+version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "memchr"
@@ -954,6 +1129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c135f38778ad324d9e9ee68690bac2c1a51f340fdf96ca13e2ab3914eb2e51d8"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1169,16 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
@@ -1000,6 +1194,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rbook"
@@ -1043,6 +1243,35 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rusqlite"
@@ -1279,6 +1508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1575,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1603,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1628,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b62a1e85e12d5d712bf47a85f426b73d303e2d00a90de5f3004df3596e9d216"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1562,6 +1842,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1884,60 @@ name = "zerocopy-derive"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/inkread-daily/Cargo.toml
+++ b/inkread-daily/Cargo.toml
@@ -17,6 +17,7 @@ quick-xml = { workspace = true }
 # JSON at the JNI boundary: the shell hands the core a fetched issue (sources + article HTML) as JSON.
 serde = { workspace = true }
 serde_json = { workspace = true }
+feed-rs = "2.3.1"
 
 [dev-dependencies]
 # Round-trip the assembled issue through the real EPUB parser the reader uses, so a malformed

--- a/inkread-daily/src/feed.rs
+++ b/inkread-daily/src/feed.rs
@@ -1,134 +1,61 @@
-//! RSS / Atom feed parsing (#66): feed XML → a list of article links the shell then fetches.
+//! RSS / Atom / JSON feed parsing (#66) via [`feed_rs`].
 //!
-//! A small pull parser over [`quick_xml`] that handles both RSS (`<item>` · `<title>` · `<link>` text
-//! · `<pubDate>`) and Atom (`<entry>` · `<title>` · `<link href>` · `<published>`/`<updated>`).
-//! Tolerant: unknown elements are ignored and a malformed feed yields the items parsed so far rather
-//! than an error (RR21-FR3 — never panics). Pure + host-testable; the network lives in the shell.
+//! `feed-rs` maps RSS 0.9x/1.0/2.0, Atom, and JSON Feed into one model, so users can add arbitrary
+//! feeds and we still get consistent `(title, link, date)` extraction from a single tolerant parser.
+//! This replaces an earlier hand-rolled `quick-xml` parser (which mis-handled self-closing links and
+//! namespaced elements). Malformed input yields an empty list rather than an error (RR21-FR3 — never
+//! panics). Pure + host-testable; the network lives in the shell.
 
-use quick_xml::events::Event;
-use quick_xml::Reader;
+use feed_rs::model::Link;
 use serde::Serialize;
 
 /// One entry discovered in a feed — enough for the shell to fetch + attribute the article.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct FeedItem {
-    /// Entry title.
+    /// Entry title (entities already decoded by the parser).
     pub title: String,
-    /// Article URL (RSS `<link>` text or Atom `<link href>`).
+    /// Article URL — the entry's `alternate` link (the human page), else its first link.
     pub url: String,
-    /// Published/updated timestamp as the feed states it, if present (raw; the shell formats it).
+    /// Published (or, failing that, updated) date, formatted "DD Mon YYYY"; `None` if the feed omits it.
     pub published: Option<String>,
 }
 
-#[derive(Clone, Copy)]
-enum Field {
-    Title,
-    Link,
-    Published,
-}
-
-/// Parse an RSS or Atom feed into its entries, in document order. Tolerant of malformed input.
+/// Parse an RSS / Atom / JSON feed into its entries, in document order. Tolerant of malformed input.
 #[must_use]
 pub fn parse_feed(xml: &str) -> Vec<FeedItem> {
-    let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
-    let mut items: Vec<FeedItem> = Vec::new();
-    let mut cur: Option<FeedItem> = None;
-    let mut field: Option<Field> = None;
-
-    loop {
-        match reader.read_event() {
-            // A self-closing element (e.g. Atom `<link href="…"/>`): grab the href, but DON'T set a
-            // text field — there is no body, so a later text node must not leak into it (the bug that
-            // put an author name in The Verge's URL).
-            Ok(Event::Empty(e)) => {
-                if local_name(e.name().as_ref()) == "link" {
-                    if let (Some(c), Some(href)) = (cur.as_mut(), attr(&e, b"href")) {
-                        if c.url.is_empty() {
-                            c.url = href;
-                        }
-                    }
-                }
-            }
-            Ok(Event::Start(e)) => match local_name(e.name().as_ref()).as_str() {
-                "item" | "entry" => cur = Some(FeedItem::default()),
-                "title" => field = Some(Field::Title),
-                "link" => {
-                    // Atom carries the URL in the href attribute (RSS uses the element text).
-                    if let (Some(c), Some(href)) = (cur.as_mut(), attr(&e, b"href")) {
-                        if c.url.is_empty() {
-                            c.url = href;
-                        }
-                    }
-                    field = Some(Field::Link);
-                }
-                "pubdate" | "published" | "updated" => field = Some(Field::Published),
-                _ => {}
-            },
-            // Text and CData are distinct event types; funnel both through one applier.
-            Ok(Event::Text(t)) => apply_text(&mut cur, field, &to_string(t.into_inner())),
-            Ok(Event::CData(t)) => apply_text(&mut cur, field, &to_string(t.into_inner())),
-            Ok(Event::End(e)) => {
-                if matches!(local_name(e.name().as_ref()).as_str(), "item" | "entry") {
-                    if let Some(c) = cur.take() {
-                        if !c.title.is_empty() || !c.url.is_empty() {
-                            items.push(c);
-                        }
-                    }
-                }
-                field = None; // any element close ends the active text field (no cross-element leak)
-            }
-            Ok(Event::Eof) | Err(_) => break, // tolerant: stop on EOF or a malformed event
-            _ => {}
-        }
-    }
-    items
-}
-
-/// Decode raw element bytes to a (lossy) String.
-fn to_string(bytes: std::borrow::Cow<'_, [u8]>) -> String {
-    String::from_utf8_lossy(&bytes).into_owned()
-}
-
-/// Apply a text/CData run to the current entry's active field.
-fn apply_text(cur: &mut Option<FeedItem>, field: Option<Field>, text: &str) {
-    if let (Some(c), Some(f)) = (cur.as_mut(), field) {
-        let t = text.trim();
-        match f {
-            // Decode entities so a headline reads "children's", not "children&#x27;s".
-            Field::Title => c.title.push_str(&crate::extract::decode_entities(t)),
-            Field::Link => {
-                if c.url.is_empty() {
-                    c.url.push_str(t);
-                }
-            }
-            Field::Published => {
-                if c.published.is_none() && !t.is_empty() {
-                    c.published = Some(t.to_string());
-                }
-            }
-        }
-    }
-}
-
-/// The lowercased local element name (namespace prefix stripped).
-fn local_name(qname: &[u8]) -> String {
-    let name = match qname.iter().rposition(|&b| b == b':') {
-        Some(i) => &qname[i + 1..],
-        None => qname,
+    let feed = match feed_rs::parser::parse(xml.as_bytes()) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
     };
-    String::from_utf8_lossy(name).to_ascii_lowercase()
+    feed.entries
+        .into_iter()
+        .map(|e| FeedItem {
+            // feed-rs does one XML entity decode; some feeds double-encode (e.g. The Verge ships
+            // "&amp;#8217;"), leaving a numeric ref in the text. A second decode pass (shared with
+            // extraction) finishes the job so a headline reads "Guardian's", not "Guardian&#8217;s".
+            title: e
+                .title
+                .map(|t| crate::extract::decode_entities(t.content.trim()))
+                .unwrap_or_default(),
+            url: entry_url(&e.links),
+            published: e
+                .published
+                .or(e.updated)
+                .map(|d| d.format("%d %b %Y").to_string()),
+        })
+        .collect()
 }
 
-/// Read a tag attribute value by (lowercased) name.
-fn attr(e: &quick_xml::events::BytesStart<'_>, name: &[u8]) -> Option<String> {
-    e.attributes().flatten().find_map(|a| {
-        if local_name(a.key.as_ref()) == String::from_utf8_lossy(name) {
-            Some(String::from_utf8_lossy(&a.value).into_owned())
-        } else {
-            None
-        }
-    })
+/// The article URL for an entry: prefer the `alternate` link (the readable page), else the first
+/// link. Atom feeds carry several links (`self`, `alternate`, enclosures); picking `alternate`
+/// avoids pointing at the feed itself.
+fn entry_url(links: &[Link]) -> String {
+    links
+        .iter()
+        .find(|l| l.rel.as_deref() == Some("alternate"))
+        .or_else(|| links.first())
+        .map(|l| l.href.clone())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -136,61 +63,80 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_rss_items() {
-        let xml = r#"<rss><channel>
-            <title>Feed</title>
-            <item><title>First post</title><link>https://x.test/1</link><pubDate>Mon, 24 Jun 2026</pubDate></item>
-            <item><title>Second</title><link>https://x.test/2</link></item>
-        </channel></rss>"#;
-        let items = parse_feed(xml);
-        assert_eq!(items.len(), 2);
-        assert_eq!(items[0].title, "First post");
-        assert_eq!(items[0].url, "https://x.test/1");
-        assert_eq!(items[0].published.as_deref(), Some("Mon, 24 Jun 2026"));
-        assert_eq!(items[1].url, "https://x.test/2");
-        assert_eq!(items[1].published, None);
-    }
-
-    #[test]
-    fn parses_atom_entries_with_href_links() {
-        let xml = r#"<feed xmlns="http://www.w3.org/2005/Atom">
-            <title>Site</title>
-            <entry><title>Atom one</title><link href="https://a.test/1"/><published>2026-06-24</published></entry>
-        </feed>"#;
+    fn parses_rss_title_link_and_date() {
+        let xml = r#"<?xml version="1.0"?><rss version="2.0"><channel>
+            <item><title>Hello World</title><link>https://x.test/a</link>
+            <pubDate>Wed, 25 Jun 2026 18:33:54 +0000</pubDate></item>
+            </channel></rss>"#;
         let items = parse_feed(xml);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].title, "Atom one");
-        assert_eq!(items[0].url, "https://a.test/1");
-        assert_eq!(items[0].published.as_deref(), Some("2026-06-24"));
+        assert_eq!(items[0].title, "Hello World");
+        assert_eq!(items[0].url, "https://x.test/a");
+        assert_eq!(items[0].published.as_deref(), Some("25 Jun 2026"));
     }
 
     #[test]
-    fn cdata_titles_and_malformed_tail_are_tolerated() {
-        let xml = "<rss><channel><item><title><![CDATA[Title & <b>markup</b>]]></title>\
-            <link>https://x.test/c</link></item><item><title>truncated";
-        let items = parse_feed(xml);
-        assert!(!items.is_empty());
-        assert_eq!(items[0].title, "Title & <b>markup</b>");
-        assert_eq!(items[0].url, "https://x.test/c");
-    }
-
-    #[test]
-    fn self_closing_link_does_not_leak_following_text_into_the_url() {
-        // Regression (The Verge): a self-closing <link href/> must not leave the URL field "open" so
-        // a following <author><name> leaks into the URL.
-        let xml = r#"<feed xmlns="http://www.w3.org/2005/Atom">
-            <entry><title>Real title</title><link href="https://x.test/1"/>
-            <author><name>Sheena Vasani</name></author></entry></feed>"#;
+    fn atom_self_closing_link_uses_href_not_leaked_text() {
+        // Regression for the old parser's bug: a self-closing <link href/> followed by other text
+        // must take the href as the URL, never the trailing text (which put an author in the URL).
+        let xml = r#"<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom">
+            <entry><title>Atom Title</title>
+            <link href="https://x.test/b"/>
+            <author><name>Sheena Vasani</name></author>
+            <updated>2026-06-25T18:00:00Z</updated></entry></feed>"#;
         let items = parse_feed(xml);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].url, "https://x.test/1");
-        assert_eq!(items[0].title, "Real title");
+        assert_eq!(items[0].url, "https://x.test/b");
         assert!(!items[0].url.contains("Sheena"));
     }
 
     #[test]
-    fn empty_or_junk_input_yields_no_items_without_panicking() {
+    fn atom_prefers_the_alternate_link() {
+        let xml = r#"<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom">
+            <entry><title>T</title>
+            <link rel="self" href="https://x.test/feed"/>
+            <link rel="alternate" href="https://x.test/article"/>
+            </entry></feed>"#;
+        let items = parse_feed(xml);
+        assert_eq!(items[0].url, "https://x.test/article");
+    }
+
+    #[test]
+    fn decodes_title_entities() {
+        let xml = r#"<?xml version="1.0"?><rss version="2.0"><channel>
+            <item><title>Tom &amp; Jerry&#x27;s day</title><link>https://x.test/c</link></item>
+            </channel></rss>"#;
+        let items = parse_feed(xml);
+        assert_eq!(items[0].title, "Tom & Jerry's day");
+    }
+
+    #[test]
+    fn second_pass_decodes_double_encoded_titles() {
+        // The Verge ships "&amp;#8217;": feed-rs decodes once to "&#8217;", our second pass finishes
+        // it to the curly apostrophe (U+2019).
+        let xml = r#"<?xml version="1.0"?><rss version="2.0"><channel>
+            <item><title>Guardian&amp;#8217;s phone</title><link>https://x.test/v</link></item>
+            </channel></rss>"#;
+        let items = parse_feed(xml);
+        assert_eq!(items[0].title, "Guardian\u{2019}s phone");
+    }
+
+    #[test]
+    fn parses_json_feed() {
+        // New capability over the old XML-only parser: JSON Feed (jsonfeed.org).
+        let json = r#"{"version":"https://jsonfeed.org/version/1","title":"Site",
+            "items":[{"id":"1","url":"https://x.test/j","title":"JSON Item",
+            "date_published":"2026-06-25T18:00:00Z"}]}"#;
+        let items = parse_feed(json);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "JSON Item");
+        assert_eq!(items[0].url, "https://x.test/j");
+    }
+
+    #[test]
+    fn malformed_input_yields_empty_not_panic() {
+        assert!(parse_feed("<not a feed").is_empty());
         assert!(parse_feed("").is_empty());
-        assert!(parse_feed("not xml at all <<<").is_empty());
+        assert!(parse_feed("plain text, definitely not a feed").is_empty());
     }
 }

--- a/inkread-daily/src/lib.rs
+++ b/inkread-daily/src/lib.rs
@@ -196,7 +196,7 @@ mod json_tests {
     #[test]
     fn parse_feed_json_round_trips() {
         let json = parse_feed_json(
-            r#"<rss><channel><item><title>T</title><link>https://x.test/1</link></item></channel></rss>"#,
+            r#"<rss version="2.0"><channel><item><title>T</title><link>https://x.test/1</link></item></channel></rss>"#,
         );
         assert!(
             json.contains("\"title\":\"T\"") && json.contains("https://x.test/1"),


### PR DESCRIPTION
## What

Replaces the hand-rolled `quick-xml` feed parser with **feed-rs**, which maps RSS 0.9x/1.0/2.0, Atom, and JSON Feed into one model. User-added feeds of any format now parse through a single, well-tested path, and the parser-bug class we kept hand-fixing (self-closing links, namespaced elements) is gone.

Follows the spike (cross-compiles to aarch64-android, negligible `.so` impact, licenses pass the RR18 allowlist gate).

## Changes
- `parse_feed` delegates to `feed_rs`. **`FeedItem`'s shape is unchanged**, so the JNI + Kotlin sides are untouched.
- URL picks the entry's `alternate` link (the article page), not `self`.
- Dates format as `DD Mon YYYY`.
- **Second entity-decode pass** on titles (shared with extraction): feed-rs decodes XML entities once, but double-encoded feeds (The Verge ships `&amp;#8217;`) need a second pass to read "Guardian’s", not "Guardian&#8217;s".

## Dependency note
Adds feed-rs + its transitive tree (the ICU/`zerovec` charset machinery). All licenses pass `check-licenses.sh` (RR18-AC2). Measured `.so` delta is ~0 — the linker GCs the unused i18n code; the binary is dominated by embedded fonts/patterns.

## Testing
- `scripts/gate.sh` all green: fmt, clippy, `test --workspace`, jni-bridge cross-compile, android unit.
- New unit tests: RSS, Atom, JSON Feed, alternate-link preference, self-closing-link (the old bug), double-encoded titles, malformed→empty.
- **Host-validated against the 10 live curated feeds**: Verge 10, BBC 40, HN 20, Ars 20, NPR 10, Daring Fireball 48 — matching the device logs.
- `libreader.so` + APK built and installed on the Nomad.

Part of #66.