### PR TITLE
feat(reader): render-path timing + grayscale/dither delegation decision

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -872,6 +872,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val bmp = bitmap ?: return
         if (handle == 0L) return
 
+        // Render-path timing (Rendering M1 observability): core render → copy → composite → blit.
+        // Cheap to measure; per-render detail is gated behind diag, and any render that approaches
+        // the e-ink budget is surfaced at I-level so slowness shows up without a debug build.
+        val tStart = SystemClock.elapsedRealtime()
         try {
             buf.clear()
             NativeBridge.nativeRenderPage(handle, buf)
@@ -879,8 +883,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             Log.e(TAG, "render failed: ${e.message}")
             return
         }
+        val tCore = SystemClock.elapsedRealtime()
         buf.rewind()
         bmp.copyPixelsFromBuffer(buf)
+        val tCopy = SystemClock.elapsedRealtime()
         currentPage = NativeBridge.nativeCurrentPage(handle)
         // Bake the CORE's strokes for this page onto the rendered page (RR6) before blitting.
         pageStrokes = try {
@@ -906,7 +912,16 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         if (currentPage == 0 && currentBookId.isNotEmpty() && !Books.thumbFile(this, currentBookId).exists()) {
             Books.saveThumbnail(this, currentBookId, bmp)
         }
+        val tComposite = SystemClock.elapsedRealtime()
         blit { canvas -> canvas.drawBitmap(bmp, 0f, 0f, null) }
+        val tBlit = SystemClock.elapsedRealtime()
+        val core = tCore - tStart; val copy = tCopy - tCore
+        val composite = tComposite - tCopy; val blitMs = tBlit - tComposite; val total = tBlit - tStart
+        // One concise line per render (renders are low-frequency — once per page turn/settle). This is
+        // the on-app cost; the panel's async EPD waveform refresh isn't observable from here. A render
+        // at/over the e-ink budget is flagged SLOW inline.
+        val slow = if (total >= SLOW_RENDER_MS) " SLOW" else ""
+        Log.i(TAG, "render p=$currentPage: core=$core copy=$copy composite=$composite blit=$blitMs total=${total}ms$slow")
         if (!deferLinks) refreshCurrentLinks()
     }
 
@@ -3175,6 +3190,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val PASTE_OFFSET = 0.03f // normalized offset so a paste lands just beside the source.
         const val FINGER_LONG_PRESS_MS = 500L // finger held ~still this long on a word → look it up.
         const val FINGER_MOVE_SLOP_PX = 24f // finger travel beyond this = a swipe, not a tap/hold.
+        const val SLOW_RENDER_MS = 250L // a render+blit at/over this approaches the e-ink budget — log it.
         // Contact major ≥ this fraction of the panel height ⇒ a palm. Lowered from 0.12 to 0.06
         // (≈154px on a 2560px panel) per on-device PALMDIAG capture: resting palms reported
         // touch-major ≈ 140–240px, well under the old 307px gate, so the very first palm leaked

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -528,6 +528,15 @@ impl ReaderSession {
             buf,
             crate::render::contrast::step_to_gamma(self.contrast),
         );
+        // Grayscale + dithering are deliberately NOT applied here. The shell blits this RGBA buffer
+        // to a SurfaceView and the Supernote's EPD controller does the waveform grayscale + dithering
+        // in hardware; pre-quantizing in the core would double-process (fighting the panel) for no
+        // gain. The `render::gray` module (to_grayscale / DitherMode) is retained for host/emulator
+        // rendering + golden tests, and for a future direct-framebuffer path (KOReader-style fb
+        // ioctl) that WOULD bypass the panel's conversion and need to dither itself — that is the only
+        // path where the DitherMode setting becomes live. The cache key fixes DitherMode::None to keep
+        // the key honest about this. (Reflow/EPUB is already grayscale-native via inkread-epub's
+        // GrayCanvas; this note is about the fixed-layout/PDF RGBA path.)
         if cacheable {
             self.caches.render().insert(key, buf.bytes().to_vec());
         }

--- a/reader-core/src/settings/mod.rs
+++ b/reader-core/src/settings/mod.rs
@@ -216,7 +216,10 @@ pub mod registry {
             K::NightFlashInterval => (Int(6), Global),
             K::AvoidFlashing => (Bool(false), Global),
             K::NightMode => (Bool(false), Global),
-            K::DitherMode => (Int(1), Global), // ordered, the e-ink default
+            // Ordered by default, but RESERVED: the fixed-layout blit path delegates grayscale +
+            // dithering to the EPD panel (see Session::render_current), so this only becomes live on a
+            // future direct-framebuffer path. Kept plumbed so that switch is a one-line change.
+            K::DitherMode => (Int(1), Global),
             K::FontSize => (Int(100), PerBook),
             K::FontFamily => (Text(String::new()), PerBook),
             K::LineSpacing => (Int(100), PerBook),


### PR DESCRIPTION
First slice of the "Rendering M1" track from the rendering review — the two lowest-risk, highest-signal items.

## 1. Render-path timing (observability)
`renderAndBlit` now measures the on-app render path and logs one concise line per render:
```
render p=42: core=180 copy=12 composite=8 blit=5 total=205ms
```
- **core** = JNI `nativeRenderPage` (PDFium / reflow raster)
- **copy** = direct-buffer → `ARGB_8888` bitmap
- **composite** = ink strokes / selection / search / minimap / bookmark draws
- **blit** = lock surface, draw, post

Renders are low-frequency (once per page turn/settle), so one `I`-level line each is cheap; a render at/over a 250ms budget is flagged `SLOW` inline. The panel's async EPD waveform refresh isn't observable from the app, so it's excluded (noted in code).

## 2. Grayscale/dither decision (resolves the review's main concrete finding)
The review correctly found the `render::gray` module (`to_grayscale`/`DitherMode`) is **plumbed through settings + the cache key but never applied** in the hot path. The decision, now **documented in `Session::render_current`**: grayscale + dithering are **delegated to the EPD panel** — the shell blits RGBA to a SurfaceView and the Supernote controller does waveform grayscale + dither in hardware; pre-quantizing in the core would double-process for no gain. The `gray` module is retained for host rendering + golden tests and a future direct-framebuffer path (the only path where `DitherMode` becomes live); the setting is marked **RESERVED**. (Reflow/EPUB is already grayscale-native via inkread-epub's `GrayCanvas`.)

## Testing
- `scripts/gate.sh` all green (fmt/clippy/test/jni-bridge/android-unit).
- `libreader.so` + APK installed on the Nomad. Baseline timing capture pending (flip a few PDF + EPUB pages).

Addresses the review's "explicit grayscale/dither policy" + "timing logs" items. Larger M1 items (dirty-rect ink layer, scratch buffers) are follow-ups.