### PR TITLE
feat(reader): prefetch the next page into the render cache (read-ahead)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -75,6 +75,10 @@ object NativeBridge {
     /** The document's author from its metadata, or "" if none. */
     external fun nativeDocAuthor(handle: Long): String
 
+    /** Render [page] into the session's render cache without displaying it, so a turn to it is a
+     *  cache hit (read-ahead). Best-effort — a failure is swallowed in the core. Engine-thread only. */
+    external fun nativePrefetchPage(handle: Long, page: Int)
+
     /** Parse an RSS/Atom feed into a JSON array of {title,url,published} (#66). Standalone — no
      *  document handle; the shell fetches the feed, the core parses it. "[]" on junk input. */
     external fun nativeDailyParseFeed(xml: String): String

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -922,6 +922,17 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // at/over the e-ink budget is flagged SLOW inline.
         val slow = if (total >= SLOW_RENDER_MS) " SLOW" else ""
         Log.i(TAG, "render p=$currentPage: core=$core copy=$copy composite=$composite blit=$blitMs total=${total}ms$slow")
+        // Read-ahead: warm the next page (in the direction of travel) into the core's render cache,
+        // off the critical path — the next turn then hits the cache (core≈0), attacking the render's
+        // biggest cost. Deduped so chrome repaints of the same page don't re-enqueue.
+        val ahead = currentPage + lastTurnDir
+        if (zoom <= 1f && ahead in 0 until pageCount && ahead != lastPrefetchedPage) {
+            lastPrefetchedPage = ahead
+            engine.execute {
+                val h = docHandle
+                if (h != 0L) runCatching { NativeBridge.nativePrefetchPage(h, ahead) }
+            }
+        }
         if (!deferLinks) refreshCurrentLinks()
     }
 
@@ -1473,8 +1484,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private var pendingPageDelta = 0
     /** True while a coalesced jump is rendering; taps accumulate instead of enqueuing more (UI thread). */
     private var turnInFlight = false
+    /** Direction of travel (+1 forward / -1 back); biases read-ahead. Forward by default. */
+    @Volatile private var lastTurnDir = 1
+    /** Last page handed to read-ahead — dedupes prefetch enqueues across chrome repaints of one page. */
+    private var lastPrefetchedPage = -1
 
     private fun queuePageTurn(delta: Int) {
+        if (delta != 0) lastTurnDir = if (delta < 0) -1 else 1
         pendingPageDelta += delta
         flushPageTurns()
     }

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -411,6 +411,26 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeRenderPage<
 }
 
 // =====================================================================================
+// nativePrefetchPage(handle, page) — render `page` into the session's render cache WITHOUT
+// displaying it, so a turn to it is a cache hit (RR24 read-ahead). Best-effort: a prefetch
+// failure is swallowed (it must never disturb reading). Mutates the cache, so engine-thread only.
+// =====================================================================================
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativePrefetchPage<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    page: jint,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let _ = session.prefetch_page(page.max(0) as usize); // best-effort; never throws
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// =====================================================================================
 // nativeOnGesture(handle, code) : ByteArray  — apply the gesture, return the encoded
 // RefreshCommand stream (Fork 2, Amendment 6). Returns an empty array on an unknown code
 // (after throwing), per the resolve default.

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -506,6 +506,26 @@ impl ReaderSession {
                 }
             }
         }
+        self.render_fit_pixels(buf)?;
+        // Grayscale + dithering are deliberately NOT applied here. The shell blits this RGBA buffer
+        // to a SurfaceView and the Supernote's EPD controller does the waveform grayscale + dithering
+        // in hardware; pre-quantizing in the core would double-process (fighting the panel) for no
+        // gain. The `render::gray` module (to_grayscale / DitherMode) is retained for host/emulator
+        // rendering + golden tests, and for a future direct-framebuffer path (KOReader-style fb
+        // ioctl) that WOULD bypass the panel's conversion and need to dither itself — that is the only
+        // path where the DitherMode setting becomes live. The cache key fixes DitherMode::None to keep
+        // the key honest about this. (Reflow/EPUB is already grayscale-native via inkread-epub's
+        // GrayCanvas; this note is about the fixed-layout/PDF RGBA path.)
+        if cacheable {
+            self.caches.render().insert(key, buf.bytes().to_vec());
+        }
+        Ok(())
+    }
+
+    /// Rasterize the current page's fit/crop pixels (honoring render-quality supersampling) and apply
+    /// contrast, into `buf`. The shared core of [`Self::render_current`]'s non-magnified path and
+    /// [`Self::prefetch_page`]; touches neither the cache nor zoom.
+    fn render_fit_pixels(&self, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
         let q = render_quality_factor(self.render_quality);
         if (q - 1.0).abs() < 1e-3 {
             self.render_fit_or_crop(buf)?;
@@ -521,25 +541,44 @@ impl ReaderSession {
             }
             crate::render::resample::resample_bilinear(&tmp, qw, qh, buf);
         }
-        // Display enhancement (RR4): remap pixels for contrast after the backend renders. The
-        // cached buffer is the final displayed pixels (the key carries the contrast step), so a
-        // later serve needs no re-apply.
+        // Display enhancement (RR4): remap pixels for contrast after the backend renders.
         crate::render::contrast::apply_contrast(
             buf,
             crate::render::contrast::step_to_gamma(self.contrast),
         );
-        // Grayscale + dithering are deliberately NOT applied here. The shell blits this RGBA buffer
-        // to a SurfaceView and the Supernote's EPD controller does the waveform grayscale + dithering
-        // in hardware; pre-quantizing in the core would double-process (fighting the panel) for no
-        // gain. The `render::gray` module (to_grayscale / DitherMode) is retained for host/emulator
-        // rendering + golden tests, and for a future direct-framebuffer path (KOReader-style fb
-        // ioctl) that WOULD bypass the panel's conversion and need to dither itself — that is the only
-        // path where the DitherMode setting becomes live. The cache key fixes DitherMode::None to keep
-        // the key honest about this. (Reflow/EPUB is already grayscale-native via inkread-epub's
-        // GrayCanvas; this note is about the fixed-layout/PDF RGBA path.)
-        if cacheable {
-            self.caches.render().insert(key, buf.bytes().to_vec());
+        Ok(())
+    }
+
+    /// Render-ahead: rasterize `page` into the render cache **without displaying it**, so a turn to it
+    /// is a cache hit (the biggest page-turn cost is the pdfium/reflow raster — RR24). No-op when
+    /// magnified (only fit pages are cached) or when the page is already warm. Meant to be called on
+    /// the engine thread right after the visible page is rendered, so it never delays the current turn
+    /// (and if the reader turns before it finishes, the queued render simply serves the next turn).
+    pub fn prefetch_page(&mut self, page: usize) -> CoreResult<()> {
+        if self.zoom > 1.0 + 1e-3 {
+            return Ok(());
         }
+        let page = page.min(self.page_count().saturating_sub(1));
+        let saved = self.page;
+        self.page = page;
+        let result = self.prefetch_current_into_cache();
+        self.page = saved; // never leave the displayed page changed, even on error
+        result
+    }
+
+    /// Render the (temporarily swapped-in) current page into the cache if not already present.
+    fn prefetch_current_into_cache(&mut self) -> CoreResult<()> {
+        let key = self.render_cache_key();
+        if self.caches.render().get(&key).is_some() {
+            return Ok(()); // already warm — nothing to do
+        }
+        let (w, h) = (self.viewport.width, self.viewport.height);
+        let mut scratch = vec![0u8; (w as usize) * (h as usize) * 4];
+        {
+            let mut buf = PixelBuffer::from_rgba(&mut scratch, w, h)?;
+            self.render_fit_pixels(&mut buf)?;
+        }
+        self.caches.render().insert(key, scratch);
         Ok(())
     }
 

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -1330,3 +1330,35 @@ fn contrast_darkens_a_gray_page_after_render() {
     );
     assert_eq!(bytes[3], 0xFF, "alpha preserved");
 }
+
+#[test]
+fn prefetch_warms_the_next_page_without_changing_the_displayed_one() {
+    let mut s = session(3, DeviceCapabilities::supernote_full());
+    let mut bytes = vec![0u8; 100 * 120 * 4];
+    {
+        let mut buf = PixelBuffer::from_rgba(&mut bytes, 100, 120).unwrap();
+        s.render_current(&mut buf).unwrap(); // page 0 → one cache entry
+    }
+    let base = s.caches().render().len();
+    assert_eq!(s.current_page(), 0);
+
+    s.prefetch_page(1).unwrap();
+    assert_eq!(
+        s.current_page(),
+        0,
+        "prefetch must not change the displayed page"
+    );
+    assert!(
+        s.caches().render().len() > base,
+        "prefetch warmed a new page: {} -> {}",
+        base,
+        s.caches().render().len()
+    );
+
+    // Re-prefetching a warm page adds nothing; an out-of-range page clamps and never panics.
+    let warm = s.caches().render().len();
+    s.prefetch_page(1).unwrap();
+    assert_eq!(s.caches().render().len(), warm, "re-prefetch is a no-op");
+    s.prefetch_page(999).unwrap();
+    assert_eq!(s.current_page(), 0);
+}


### PR DESCRIPTION
First optimization from the render-timing baseline. The timing data showed the pdfium/reflow raster (`core`) dominates a page turn — ~150ms of a ~220ms turn — so we warm the next page ahead of time.

## How
- **`Session::prefetch_page(page)`** renders a page into the render cache **without displaying it** (no-op when magnified or already warm); shares a new `render_fit_pixels` helper with `render_current` so the cached bytes match exactly. Never changes the shown page (swap-and-restore).
- **`nativePrefetchPage`** (JNI) is **best-effort** — a prefetch failure is swallowed, never thrown, so it can't disturb reading.
- **`ReaderActivity`** tracks travel direction (`lastTurnDir`) and enqueues the read-ahead at the end of `renderAndBlit` on the engine thread (off the critical path), **deduped** so chrome repaints of one page don't re-enqueue.

## Device results (Nomad)
Sustained forward page turns: **~220ms → ~87ms** (`core` ~150ms → ~9ms — cache hit). Only the cold-open first page is unwarmed.

```
before:  render p=11: core=252 copy=7 composite=1 blit=67 total=327ms SLOW
after:   render p=11: core=8   copy=8 composite=2 blit=67 total=85ms
```

## Blit investigation (bonus finding)
Temporary split-timing (since reverted) showed the constant ~67ms blit is **entirely `draw`** (`lock`/`post` ≈ 2ms each) — the software `drawBitmap` of the full 1920×2560 page. It's near the floor for a full-screen software blit, so it's **not** worth chasing for page turns; the lever is the **dirty-rect ink layer** (partial updates / writing latency), a future PR.

## Testing
- `scripts/gate.sh` all green; new test asserts prefetch warms the cache, leaves the current page unchanged, no-ops when warm, and clamps out-of-range.
- `libreader.so` + APK installed on the Nomad.

Part of the Rendering M1 track.