### PR TITLE
perf(pdf): reuse scratch buffer for fit/crop render + real-PDF golden test

### DIFF
--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -172,6 +172,10 @@ pub struct PdfBackend {
     /// The last viewport (panel) size rendered at — the initial pagination guess when reflow is
     /// enabled, so the position-preserving jump lands correctly (the first render then confirms it).
     last_viewport: Cell<(u32, u32)>,
+    /// Reused temp buffer for the aspect-fit / crop composite (a per-page render previously allocated
+    /// a fresh ~viewport-sized buffer each time). Interior mutability so the `&self` render paths can
+    /// grow + reuse it; render is serialized on the engine thread, so a single borrow is never aliased.
+    fit_scratch: RefCell<Vec<u8>>,
 }
 
 impl PdfBackend {
@@ -186,7 +190,34 @@ impl PdfBackend {
             document,
             reflow: RefCell::new(None),
             last_viewport: Cell::new((0, 0)),
+            fit_scratch: RefCell::new(Vec::new()),
         })
+    }
+
+    /// Render a `tw×th` page image via `render` into the reused [`Self::fit_scratch`] buffer, then
+    /// composite it centered into `buf`. Reuses the scratch across page renders so the common fit/crop
+    /// path doesn't allocate (and free) a fresh ~viewport-sized buffer every turn. `render` fully
+    /// overwrites the `tw×th` window, so no clear is needed.
+    fn composite_via_scratch(
+        &self,
+        buf: &mut PixelBuffer<'_>,
+        tw: i32,
+        th: i32,
+        pan_x: f32,
+        pan_y: f32,
+        render: impl FnOnce(&mut PixelBuffer<'_>) -> CoreResult<()>,
+    ) -> CoreResult<()> {
+        let need = (tw as usize) * (th as usize) * 4;
+        let mut scratch = self.fit_scratch.borrow_mut();
+        if scratch.len() < need {
+            scratch.resize(need, 0);
+        }
+        {
+            let mut tbuf = PixelBuffer::from_rgba(&mut scratch[..need], tw as u32, th as u32)?;
+            render(&mut tbuf)?;
+        }
+        composite_centered(buf, &scratch[..need], tw, th, pan_x, pan_y);
+        Ok(())
     }
 
     /// The number of source (fixed-layout) pages in the document.
@@ -519,20 +550,16 @@ impl Document for PdfBackend {
             return self.render_page(index, buf);
         }
 
-        // Render the page aspect-correct into a temp buffer, then composite it into the white page.
+        // Render the page aspect-correct into the reused scratch, then composite into the white page.
         let (tw, th) = fit_dims(aspect, bw, bh, mode);
-        let mut tmp = vec![0u8; (tw as usize) * (th as usize) * 4];
-        {
-            let mut tbuf = PixelBuffer::from_rgba(&mut tmp, tw as u32, th as u32)?;
-            self.render_with_config(index, &mut tbuf, |w, h| {
+        self.composite_via_scratch(buf, tw, th, pan_x, pan_y, |tbuf| {
+            self.render_with_config(index, tbuf, |w, h| {
                 PdfRenderConfig::new()
                     .set_target_size(w, h)
                     .set_format(PdfBitmapFormat::BGRA)
                     .set_reverse_byte_order(true)
-            })?;
-        }
-        composite_centered(buf, &tmp, tw, th, pan_x, pan_y);
-        Ok(())
+            })
+        })
     }
 
     #[allow(clippy::too_many_arguments)] // mirrors the render params + the crop window
@@ -677,13 +704,9 @@ impl Document for PdfBackend {
         let s = tw as f32 / crop_w_pt;
         let off_x = (x0 * pw * s).round() as i32;
         let off_y = (y0 * ph * s).round() as i32;
-        let mut tmp = vec![0u8; (tw as usize) * (th as usize) * 4];
-        {
-            let mut tbuf = PixelBuffer::from_rgba(&mut tmp, tw as u32, th as u32)?;
-            self.render_region(index, &mut tbuf, s, off_x, off_y)?;
-        }
-        composite_centered(buf, &tmp, tw, th, pan_x, pan_y);
-        Ok(())
+        self.composite_via_scratch(buf, tw, th, pan_x, pan_y, |tbuf| {
+            self.render_region(index, tbuf, s, off_x, off_y)
+        })
     }
 
     fn render_zoom(

--- a/reader-core/src/document/fixed/pdf_tests.rs
+++ b/reader-core/src/document/fixed/pdf_tests.rs
@@ -521,6 +521,45 @@ fn render_fit_page_letterboxes_and_preserves_aspect() {
     assert!(px.chunks_exact(4).all(|p| p[3] == 0xFF), "opaque");
 }
 
+// Golden/regression safety net for render-path scratch reuse: render_fit must be byte-identical
+// across repeated calls — even after an intervening render at a DIFFERENT size, the failure mode if a
+// reused scratch buffer leaked stale pixels. Pins real-PDF render output without a version-fragile
+// golden image.
+#[test]
+fn render_fit_is_deterministic_across_intervening_sizes() {
+    let _g = pdfium_serial();
+    if !host_pdfium_available() {
+        eprintln!("SKIP render_fit_deterministic: host libpdfium UNVERIFIED");
+        return;
+    }
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/minimal.pdf"
+    ))
+    .expect("fixture present");
+    let doc = PdfBackend::open(bytes).unwrap();
+    let (w, h) = (220u32, 300u32);
+    let render_fit = |doc: &PdfBackend| {
+        let mut px = vec![0u8; (w * h * 4) as usize];
+        let mut pb = PixelBuffer::from_rgba(&mut px, w, h).unwrap();
+        doc.render_fit(0, &mut pb, FitMode::Page, 0.0, 0.0).unwrap();
+        px
+    };
+    let first = render_fit(&doc);
+    // A larger intervening render grows any shared scratch; a stale tail must not bleed into the next.
+    {
+        let (bw, bh) = (360u32, 460u32);
+        let mut px = vec![0u8; (bw * bh * 4) as usize];
+        let mut pb = PixelBuffer::from_rgba(&mut px, bw, bh).unwrap();
+        doc.render_fit(0, &mut pb, FitMode::Page, 0.0, 0.0).unwrap();
+    }
+    let second = render_fit(&doc);
+    assert_eq!(
+        first, second,
+        "render_fit is byte-identical regardless of a prior render's size"
+    );
+}
+
 // RR4 Crop: content_bbox finds a box tighter than the full page (text doesn't fill the sheet),
 // and render_cropped renders that region without error.
 #[test]


### PR DESCRIPTION
The two achievable Rendering-M1 items (after we ruled out dirty-rect — see below).

## 1. Reusable scratch buffer (perf hygiene)
The fit + crop PDF render paths each allocated and freed a fresh ~viewport-sized temp (~20 MB) on **every** page render — and, since prefetch (#80), on every read-ahead too — churning the allocator on a daily-driver device.

- `PdfBackend` gains a reused `fit_scratch: RefCell<Vec<u8>>` and a `composite_via_scratch` helper that grows + reuses it. `render_fit` and `render_crop` route through it instead of allocating per call. Render is serialized on the engine thread (single non-aliased borrow); the render fully overwrites the window, so no clear is needed.

## 2. Real-PDF golden test (safety net)
`render_fit_is_deterministic_across_intervening_sizes`: renders `minimal.pdf` via `render_fit`, does a **larger** intervening render, renders again, and asserts the two outputs are **byte-identical** — the exact failure mode if a reused buffer leaked stale pixels. Pins real-PDF output without a version-fragile golden image.

## Why not dirty-rect ink (the review's headline)
The **RK3566 is a full-only EPD panel** — `SupernoteEinkAdapter` documents there's **no usable partial/region refresh for a sideloaded app** (region intents collapse to a full frame; same as KOReader on this SoC). So dirty-rect's core — partial ink refresh — is infeasible here. The pen is already firmware-smooth (live EMR overlay, no app refresh). Decision recorded; we took the achievable wins instead.

## Testing
- `scripts/gate.sh` all green (fmt/clippy/test/jni-bridge/android-unit).
- **Full PDF suite (21 tests incl. the new golden) run locally WITH libpdfium** — byte-identical output confirms the reuse is safe (not just the host-skip path).
- `libreader.so` + APK installed on the Nomad.

Closes the Rendering-M1 track started from the rendering review.