### PR TITLE
feat(app): reading-bar chapter navigation + progress (#82, #84)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -110,6 +110,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private var bookmarks: Bookmarks? = null
     /** Total pages in the open doc; cached so the bottom-bar slider can read it on the UI thread. */
     @Volatile private var pageCount = 0
+    /** Chapter start pages (top-level resolved TOC targets, sorted) for chapter prev/next (1.7). */
+    @Volatile private var chapterStarts: List<Int> = emptyList()
     /** Stable id of the open book (its file name); keys thumbnails + the bookmarks file. */
     @Volatile private var currentBookId = ""
     /** Foreground reading-session start (elapsed ms) + the page it began on, for ReadingStats. */
@@ -813,19 +815,29 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 TAG,
                 "opened $bookId: $pageCount pages, resumed at page ${NativeBridge.nativeCurrentPage(docHandle)}",
             )
+            // Decode the TOC once: it drives both chapter prev/next (1.7) and the Daily per-article
+            // jump. Chapter starts = top-level resolved targets (fall back to all targets for a flat
+            // TOC), de-duped + sorted by page.
+            val toc = try {
+                WireCodec.decodeToc(NativeBridge.nativeToc(docHandle))
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "toc failed: ${e.message}"); emptyList()
+            }
+            val tops = toc.filter { it.depth == 0 }.mapNotNull { it.targetPage }
+            chapterStarts = (if (tops.isNotEmpty()) tops else toc.mapNotNull { it.targetPage })
+                .distinct().sorted()
             // Daily: a tapped headline opens the issue AT that article. The issue's TOC is
             // [Cover, article0, article1, …], so article N is TOC entry N+1.
             val dailyArticle = intent.getIntExtra(EXTRA_DAILY_ARTICLE, -1)
             if (dailyArticle >= 0) {
-                try {
-                    val toc = WireCodec.decodeToc(NativeBridge.nativeToc(docHandle))
-                    toc.getOrNull(dailyArticle + 1)?.targetPage?.let { page ->
+                toc.getOrNull(dailyArticle + 1)?.targetPage?.let { page ->
+                    try {
                         NativeBridge.nativeJumpToPage(docHandle, page)
                         currentPage = NativeBridge.nativeCurrentPage(docHandle)
                         Log.i(TAG, "daily: jumped to article $dailyArticle → page $page")
+                    } catch (e: RuntimeException) {
+                        Log.e(TAG, "daily article jump failed: ${e.message}")
                     }
-                } catch (e: RuntimeException) {
-                    Log.e(TAG, "daily article jump failed: ${e.message}")
                 }
             }
         }
@@ -1557,6 +1569,23 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
     }
 
+    /** Jump to the previous (`dir<0`) / next (`dir>0`) chapter start relative to the current page
+     *  (1.7). No-op with a brief toast at the document ends or when the doc has no chapters. */
+    private fun chapterJump(dir: Int) {
+        val starts = chapterStarts
+        if (starts.isEmpty()) {
+            Toast.makeText(this, "No chapters in this document", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val cur = currentPage
+        val target = if (dir > 0) starts.firstOrNull { it > cur } else starts.lastOrNull { it < cur }
+        if (target != null) {
+            postJump(target)
+        } else {
+            Toast.makeText(this, if (dir > 0) "Last chapter" else "First chapter", Toast.LENGTH_SHORT).show()
+        }
+    }
+
     /** Drop any lasso selection when the page changes — the ids belong to the old page (engine). */
     private fun dropSelectionForPageChange() {
         if (selectedIds.isEmpty()) return
@@ -1645,12 +1674,21 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 override fun onStopTrackingTouch(sb: SeekBar) { dialog.dismiss(); postJump(sb.progress) }
             })
         }
+        // Double-chevron chapter jumps flank the scrubber (distinct from single-page edge taps),
+        // shown only when the document has a table of contents (1.7).
+        fun chapterBtn(glyph: String, dir: Int) = TextView(this).apply {
+            text = glyph; setTextColor(Ink.ink); textSize = 20f; typeface = Ink.serifBold
+            gravity = Gravity.CENTER; setPadding(dp(8), dp(2), dp(8), dp(2)); isClickable = true
+            setOnClickListener { dialog.dismiss(); chapterJump(dir) }
+        }
         container.addView(
             LinearLayout(this).apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
                 setPadding(dp(16), dp(12), dp(16), dp(6))
+                if (chapterStarts.isNotEmpty()) addView(chapterBtn("‹‹", -1))
                 addView(seek, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                if (chapterStarts.isNotEmpty()) addView(chapterBtn("››", +1))
                 addView(pageLabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply { marginStart = dp(12) })
             },
         )
@@ -3131,6 +3169,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         bookmarks = null // bookmarks are persisted on toggle; drop the per-book store
         selectedIds = IntArray(0) // ink is persisted by the core to its sidecar
         selectionBounds = FloatArray(0)
+        chapterStarts = emptyList() // recomputed on the next open
+
         val h = docHandle
         docHandle = 0L // zero BEFORE the call so a re-entrant close is a no-op (Amendment 2)
         if (h == 0L) return

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -1598,6 +1598,20 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         return "Ch ${idx + 1}/${ch.size} · ${ch[idx].second}"
     }
 
+    /** In-chapter position "3/24" — the current page within the current chapter (this chapter's start
+     *  → the next chapter's start; the last chapter runs to the end of the document). Null with no
+     *  chapters, or before the first chapter start (front matter). */
+    private fun inChapterPosition(): String? {
+        val ch = chapters
+        if (ch.isEmpty()) return null
+        val idx = ch.indexOfLast { it.first <= currentPage }
+        if (idx < 0) return null
+        val start = ch[idx].first
+        val end = if (idx + 1 < ch.size) ch[idx + 1].first else pageCount
+        val total = (end - start).coerceAtLeast(1)
+        return "${currentPage - start + 1}/$total"
+    }
+
     /** Drop any lasso selection when the page changes — the ids belong to the old page (engine). */
     private fun dropSelectionForPageChange() {
         if (selectedIds.isEmpty()) return
@@ -1705,16 +1719,25 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             },
         )
         // Current-chapter line under the scrubber: orients the reader and makes the ‹‹/›› obvious.
-        // Tap → open the full Contents sheet. Shown only when the document has chapters.
+        // Left = "Ch i/n · Title" (ellipsized); right = in-chapter "p/q" (stays visible). Tap → the
+        // full Contents sheet. Shown only when the document has chapters.
         currentChapterLabel()?.let { lbl ->
-            container.addView(TextView(this).apply {
-                text = lbl
-                setTextColor(Ink.inkSoft); textSize = 12f; typeface = Ink.serif
-                gravity = Gravity.CENTER; maxLines = 1
-                ellipsize = android.text.TextUtils.TruncateAt.END
+            container.addView(LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
                 setPadding(dp(24), 0, dp(24), dp(8))
                 isClickable = true
                 setOnClickListener { dialog.dismiss(); showContentsLazy() }
+                addView(TextView(this@ReaderActivity).apply {
+                    text = lbl; setTextColor(Ink.inkSoft); textSize = 12f; typeface = Ink.serif
+                    maxLines = 1; ellipsize = android.text.TextUtils.TruncateAt.END
+                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                inChapterPosition()?.let { pos ->
+                    addView(TextView(this@ReaderActivity).apply {
+                        text = pos; setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
+                        setPadding(dp(10), 0, 0, 0)
+                    })
+                }
             })
         }
 

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -110,8 +110,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private var bookmarks: Bookmarks? = null
     /** Total pages in the open doc; cached so the bottom-bar slider can read it on the UI thread. */
     @Volatile private var pageCount = 0
-    /** Chapter start pages (top-level resolved TOC targets, sorted) for chapter prev/next (1.7). */
-    @Volatile private var chapterStarts: List<Int> = emptyList()
+    /** Chapters as (start page, title) from the top-level resolved TOC, sorted — drives chapter
+     *  prev/next + the current-chapter label in the reading bar (1.7/1.8). */
+    @Volatile private var chapters: List<Pair<Int, String>> = emptyList()
     /** Stable id of the open book (its file name); keys thumbnails + the bookmarks file. */
     @Volatile private var currentBookId = ""
     /** Foreground reading-session start (elapsed ms) + the page it began on, for ReadingStats. */
@@ -823,9 +824,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             } catch (e: RuntimeException) {
                 Log.e(TAG, "toc failed: ${e.message}"); emptyList()
             }
-            val tops = toc.filter { it.depth == 0 }.mapNotNull { it.targetPage }
-            chapterStarts = (if (tops.isNotEmpty()) tops else toc.mapNotNull { it.targetPage })
-                .distinct().sorted()
+            val tops = toc.filter { it.depth == 0 && it.targetPage != null }
+            chapters = (if (tops.isNotEmpty()) tops else toc.filter { it.targetPage != null })
+                .map { it.targetPage!! to it.title }
+                .distinctBy { it.first }
+                .sortedBy { it.first }
             // Daily: a tapped headline opens the issue AT that article. The issue's TOC is
             // [Cover, article0, article1, …], so article N is TOC entry N+1.
             val dailyArticle = intent.getIntExtra(EXTRA_DAILY_ARTICLE, -1)
@@ -1572,7 +1575,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     /** Jump to the previous (`dir<0`) / next (`dir>0`) chapter start relative to the current page
      *  (1.7). No-op with a brief toast at the document ends or when the doc has no chapters. */
     private fun chapterJump(dir: Int) {
-        val starts = chapterStarts
+        val starts = chapters.map { it.first }
         if (starts.isEmpty()) {
             Toast.makeText(this, "No chapters in this document", Toast.LENGTH_SHORT).show()
             return
@@ -1584,6 +1587,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         } else {
             Toast.makeText(this, if (dir > 0) "Last chapter" else "First chapter", Toast.LENGTH_SHORT).show()
         }
+    }
+
+    /** "Ch 2/9 · The Crossing" for the chapter the current page sits in, or null if the doc has no
+     *  chapters. The current chapter is the last one whose start page is ≤ the current page. */
+    private fun currentChapterLabel(): String? {
+        val ch = chapters
+        if (ch.isEmpty()) return null
+        val idx = ch.indexOfLast { it.first <= currentPage }.coerceAtLeast(0)
+        return "Ch ${idx + 1}/${ch.size} · ${ch[idx].second}"
     }
 
     /** Drop any lasso selection when the page changes — the ids belong to the old page (engine). */
@@ -1686,12 +1698,25 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
                 setPadding(dp(16), dp(12), dp(16), dp(6))
-                if (chapterStarts.isNotEmpty()) addView(chapterBtn("‹‹", -1))
+                if (chapters.isNotEmpty()) addView(chapterBtn("‹‹", -1))
                 addView(seek, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-                if (chapterStarts.isNotEmpty()) addView(chapterBtn("››", +1))
+                if (chapters.isNotEmpty()) addView(chapterBtn("››", +1))
                 addView(pageLabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply { marginStart = dp(12) })
             },
         )
+        // Current-chapter line under the scrubber: orients the reader and makes the ‹‹/›› obvious.
+        // Tap → open the full Contents sheet. Shown only when the document has chapters.
+        currentChapterLabel()?.let { lbl ->
+            container.addView(TextView(this).apply {
+                text = lbl
+                setTextColor(Ink.inkSoft); textSize = 12f; typeface = Ink.serif
+                gravity = Gravity.CENTER; maxLines = 1
+                ellipsize = android.text.TextUtils.TruncateAt.END
+                setPadding(dp(24), 0, dp(24), dp(8))
+                isClickable = true
+                setOnClickListener { dialog.dismiss(); showContentsLazy() }
+            })
+        }
 
         // Control row: flat, evenly-weighted icon+label cells.
         val controls = LinearLayout(this).apply {
@@ -3169,7 +3194,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         bookmarks = null // bookmarks are persisted on toggle; drop the per-book store
         selectedIds = IntArray(0) // ink is persisted by the core to its sidecar
         selectionBounds = FloatArray(0)
-        chapterStarts = emptyList() // recomputed on the next open
+        chapters = emptyList() // recomputed on the next open
 
         val h = docHandle
         docHandle = 0L // zero BEFORE the call so a re-entrant close is a no-op (Amendment 2)


### PR DESCRIPTION
Completes Tier 1 items **1.7** (TOC + chapter jump) and the in-chapter half of **1.8** (reading progress). Closes #82 and #84.

## Context
The **Contents sheet** already existed (nested entries, tap-to-jump, page numbers). This adds the missing reading-bar navigation + progress.

## Changes (shell-only — reuses the core's `toc()`/jump)
- Cache **chapters** as `(start page, title)` on open from the top-level resolved TOC (falls back to all targets for a flat TOC), de-duped + sorted. Reuses the TOC decode the open path already did.
- `chapterJump(dir)` jumps to the previous/next chapter start; brief toast at the ends or when there's no TOC.
- **Double-chevron `‹‹` / `››`** controls flank the scrubber (distinct from single-page edge taps), shown only when the document has a TOC.
- **Current-chapter line** under the scrubber — "Ch 2/9 · The Crossing" — orients the reader and makes the chevrons obvious; tap → Contents sheet.
- **In-chapter position** ("3/24") on that line: where you are within the current chapter (span = this chapter → next chapter, last chapter spans to doc end). Title ellipsizes; the count stays visible.
- `chapters` reset on close.

No core or JNI change.

## Testing
- `scripts/gate.sh` all green (fmt/clippy/test/jni-bridge/android-unit).
- APK installed on the Nomad; chapter jump + current-chapter line verified on device.

## Acceptance
- [x] Nested TOC for PDF + EPUB; tap-to-jump; unresolved inert
- [x] Chapter prev/next via `‹‹`/`››`
- [x] Current-chapter label + in-chapter n/m
- [x] No-op gracefully with no TOC (chevrons + line hidden)
- [x] Gate green; on-device verified