### PR TITLE
feat(app): handwritten-notes annotations list (#85)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -252,6 +252,9 @@ object NativeBridge {
     /** Strokes on [page] in the draw-wire (decode with [WireCodec.decodeStrokes]) — for baking. */
     external fun nativeInkStrokesForDraw(handle: Long, page: Int): ByteArray
 
+    /** The 0-based pages that carry ink, sorted — drives the handwritten-notes annotations list. */
+    external fun nativeInkPages(handle: Long): IntArray
+
     /** Undo / redo the last ink edit on the current page (autosaves). Returns whether it changed. */
     external fun nativeInkUndo(handle: Long): Boolean
     external fun nativeInkRedo(handle: Long): Boolean

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -1691,6 +1691,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         control(R.drawable.ic_menu_home, "Home") { goHome() }
         // (Bookmark toggle moved to the top-right corner dog-ear; "Marks" lists them.)
         control(R.drawable.ic_menu_marks, "Marks") { showBookmarks() }
+        control(R.drawable.ic_tool_pen, "Notes") { showAnnotations() }
         control(R.drawable.ic_menu_contents, "Contents") { showContentsLazy() }
         control(R.drawable.ic_menu_search, "Search") { search.showSearchDialog() }
         // Quick zoom (circle −/+ icons — not magnifiers, which are reserved for Search). Also in Adjust → Zoom.
@@ -1784,6 +1785,75 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 }
             }
         }
+    }
+
+    /** Handwritten-notes annotations list (1.5): fetch inked pages + their stroke counts off-thread,
+     *  then show a tap-to-jump list. */
+    private fun showAnnotations() {
+        engine.execute {
+            if (docHandle == 0L) return@execute
+            val pages = try {
+                NativeBridge.nativeInkPages(docHandle)
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "ink pages failed: ${e.message}"); IntArray(0)
+            }
+            val items = pages.map { p ->
+                val count = try {
+                    WireCodec.decodeStrokes(NativeBridge.nativeInkStrokesForDraw(docHandle, p)).size
+                } catch (e: RuntimeException) { 0 }
+                p to count
+            }
+            runOnUiThread {
+                if (items.isEmpty()) {
+                    Toast.makeText(this, "No handwritten notes yet", Toast.LENGTH_SHORT).show()
+                } else {
+                    showAnnotationsList(items)
+                }
+            }
+        }
+    }
+
+    /** The inked pages as a scrollable "Page N · M notes" list; tap a row to jump there. */
+    private fun showAnnotationsList(items: List<Pair<Int, Int>>) {
+        val d = resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+        val outer = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(24), dp(22), dp(24), dp(14))
+        }
+        outer.addView(Ink.eyebrow(this, "Annotations"))
+        outer.addView(Ink.gap(this, 10))
+        outer.addView(Ink.rule(this))
+        outer.addView(Ink.gap(this, 4))
+        val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        items.forEachIndexed { i, (page, count) ->
+            if (i > 0) list.addView(View(this).apply { setBackgroundColor(Ink.hairline) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()))
+            list.addView(LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(dp(4), dp(14), dp(4), dp(14))
+                isClickable = true
+                setOnClickListener { dialog.dismiss(); postJump(page) }
+                addView(TextView(this@ReaderActivity).apply {
+                    text = "Page ${page + 1}"
+                    setTextColor(Ink.ink); textSize = 17f; typeface = Ink.serifBold
+                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                addView(TextView(this@ReaderActivity).apply {
+                    text = if (count == 1) "1 note" else "$count notes"
+                    setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
+                })
+            })
+        }
+        outer.addView(ScrollView(this).apply { addView(list) },
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, (resources.displayMetrics.heightPixels * 0.7f).toInt()))
+        dialog.setContentView(outer)
+        dialog.window?.apply {
+            setLayout((resources.displayMetrics.widthPixels * 0.82f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
+            setBackgroundDrawable(Ink.cardBg())
+        }
+        dialog.show()
     }
 
     /** The document's table of contents (RR11-FR2), shown as a scrollable list from the popup. */

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -975,6 +975,29 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkStrokesF
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeInkPages(handle) : int[] — the 0-based pages that carry ink, sorted (RR6). Drives the
+// annotations list. Mutates nothing; engine-thread only (the session is not thread-safe).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkPages<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) -> JIntArray<'local> {
+    env.with_env(|env| -> jni::errors::Result<JIntArray<'local>> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let pages: Vec<jint> = session
+            .ink_pages()
+            .map_err(|e| throw(env, &e))?
+            .into_iter()
+            .map(|p| p as jint)
+            .collect();
+        let arr = env.new_int_array(pages.len())?;
+        env.set_int_array_region(&arr, 0, &pages)?;
+        Ok(arr)
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkStrokesForDraw<'local>(
     mut env: EnvUnowned<'local>,

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -1041,6 +1041,21 @@ impl ReaderSession {
         }
     }
 
+    /// Pages that carry ink, sorted ascending (RR6) — drives the annotations list. The store's saved
+    /// pages plus the open page when its live (possibly not-yet-saved) layer has strokes.
+    pub fn ink_pages(&self) -> CoreResult<Vec<usize>> {
+        let mut pages = match &self.ink {
+            Some(store) => store.pages_with_ink()?,
+            None => Vec::new(),
+        };
+        if !self.ink_strokes().is_empty() && !pages.contains(&self.page) {
+            pages.push(self.page);
+        }
+        pages.sort_unstable();
+        pages.dedup();
+        Ok(pages)
+    }
+
     /// Begin a stroke (RR6). Pen/Highlighter accumulate points; Eraser removes strokes under each
     /// subsequent point. `width` is the stroke width (ink) or the erase radius (eraser).
     pub fn ink_begin_stroke(

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -727,6 +727,23 @@ fn ink_saves_and_reloads_across_sessions() {
 }
 
 #[test]
+fn ink_pages_lists_inked_pages_sorted() {
+    // Drives the annotations list: ink on pages 0, 3, 1 (out of order) → sorted [0, 1, 3].
+    let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
+    let mut s = session(5, DeviceCapabilities::supernote_full());
+    s.attach_ink_store(store).unwrap();
+    assert!(s.ink_pages().unwrap().is_empty(), "no ink yet");
+
+    draw(&mut s, &[(0.1, 0.1), (0.2, 0.2)]); // page 0
+    s.jump_to_page(3);
+    draw(&mut s, &[(0.3, 0.3), (0.4, 0.4)]); // page 3
+    s.jump_to_page(1);
+    draw(&mut s, &[(0.5, 0.5), (0.6, 0.6)]); // page 1
+
+    assert_eq!(s.ink_pages().unwrap(), vec![0, 1, 3], "inked pages, sorted");
+}
+
+#[test]
 fn ink_undo_redo_autosaves_to_store() {
     let store: Arc<dyn InkStore> = Arc::new(MemInkStore::new());
     let mut s = session(1, DeviceCapabilities::supernote_full());


### PR DESCRIPTION
Tier 1 item 1.5 — a browsable annotations list. Closes #85.

## What
The persisted annotation data today is **handwritten ink** (the text-highlight / excerpt path is a later item). So v1 lists the pages that carry your handwriting.

- **Core:** `Session::ink_pages()` returns inked pages, sorted (the store's saved pages plus the open page when its live, not-yet-saved layer has strokes). Exposed via JNI `nativeInkPages` → `int[]`.
- **App:** a **"Notes"** control in the bottom reading bar opens an **Annotations** list — each inked page as "Page N · M notes", tap → jump. Empty-state toast when there's no ink.

## Follow-ups
- Per-row delete (clear a page's ink) — small core op.
- Text-highlight annotations (excerpt + timestamp) once the highlighter capture is wired (P2).

## Testing
- Host test `ink_pages_lists_inked_pages_sorted` (ink on pages 0/3/1 → sorted [0,1,3]).
- `scripts/gate.sh` all green (fmt/clippy/test/jni-bridge/android-unit).
- `libreader.so` + APK installed on the Nomad.

## Acceptance (v1)
- [x] Reading bar → Annotations lists every inked page + stroke count, sorted
- [x] Tap → jumps to the page
- [x] No ink → empty-state message
- [x] Host test for the core accessor; gate green
- [ ] On-device check pending