### PR TITLE
feat(app): reading style presets + night mode (#87)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -181,6 +181,9 @@ object NativeBridge {
      *  remap (works on PDF + EPUB); re-render after calling. */
     external fun nativeSetContrast(handle: Long, step: Int)
 
+    /** Night mode: invert the page (light-on-dark) after contrast (RR4). Re-render after calling. */
+    external fun nativeSetNight(handle: Long, on: Boolean)
+
     /** Update the render viewport after a surface resize / screen rotation (RR21-FR4). Required so
      *  the core renders into the new buffer size (PDF re-renders, EPUB repaginates). Re-render after. */
     external fun nativeSetViewport(handle: Long, width: Int, height: Int, dpi: Int)

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -788,6 +788,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             }
             // Re-apply the saved display contrast (RR4); 0 = off (a no-op in the core).
             try { NativeBridge.nativeSetContrast(docHandle, contrastPref()) } catch (e: RuntimeException) {}
+            // Re-apply night mode (invert); default off (RR4 / style presets).
+            try { NativeBridge.nativeSetNight(docHandle, nightPref()) } catch (e: RuntimeException) {}
             // Re-apply the saved page fit mode (RR4); default Page/contain.
             try { NativeBridge.nativeSetFit(docHandle, fitPref()) } catch (e: RuntimeException) {}
             // Re-apply the saved auto-crop + margin (RR4); default off.
@@ -2804,6 +2806,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val content = android.widget.FrameLayout(this)
 
         val panels: List<Triple<String, Int, () -> View>> = listOf(
+            Triple("Style", R.drawable.ic_menu_adjust) { stylePanel() },
             Triple("Rotate", R.drawable.ic_menu_rotate) { rotationPanel() },
             Triple("Crop", R.drawable.ic_menu_crop) { cropPanel() },
             Triple("Zoom", R.drawable.ic_menu_fit) { zoomPanel() },
@@ -3172,6 +3175,66 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         return container
     }
 
+    /** A reading style preset (1.10): a bundle of (text scale, line-spacing index, contrast step,
+     *  night). Font/spacing are no-ops on fixed-layout PDFs; contrast/night apply to both. */
+    private data class StyleSpec(val scale: Float, val spacing: Int, val contrast: Int, val night: Boolean)
+
+    private fun styleSpec(name: String): StyleSpec = when (name) {
+        "Bold" -> StyleSpec(1.0f, 1, 4, false) // darker text (heavier ink)
+        "Night" -> StyleSpec(1.0f, 1, 0, true) // inverted (light on dark)
+        "Outdoor" -> StyleSpec(1.0f, 1, CONTRAST_MAX, false) // maximum contrast
+        "Relaxed" -> StyleSpec(1.15f, 2, 0, false) // larger + airier
+        else -> StyleSpec(1.0f, 1, 0, false) // Original — defaults
+    }
+
+    /** The "Style" tab: one-tap presets that bundle font size, spacing, contrast, and night. */
+    private fun stylePanel(): View {
+        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        container.addView(
+            settingRow(
+                "Preset",
+                segmented(STYLE_PRESETS, STYLE_PRESETS.indexOf(stylePresetPref()).coerceAtLeast(0)) { which ->
+                    applyStylePreset(STYLE_PRESETS[which])
+                },
+            ),
+        )
+        return container
+    }
+
+    /** Apply + persist a style preset: set every knob, then repaginate/re-render. */
+    private fun applyStylePreset(name: String) {
+        val s = styleSpec(name)
+        setStylePresetPref(name)
+        setTextScalePref(s.scale)
+        setLineSpacingPref(s.spacing)
+        setContrastPref(s.contrast)
+        setNightPref(s.night)
+        engine.execute {
+            try {
+                NativeBridge.nativeSetTextScale(docHandle, s.scale)
+                NativeBridge.nativeSetLineSpacing(docHandle, LINE_SPACINGS[s.spacing])
+                NativeBridge.nativeSetContrast(docHandle, s.contrast)
+                NativeBridge.nativeSetNight(docHandle, s.night)
+                pageCount = NativeBridge.nativePageCount(docHandle)
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "style preset apply failed: ${e.message}")
+            }
+            repaintPanel()
+        }
+    }
+
+    private fun nightPref(): Boolean =
+        getSharedPreferences("display", MODE_PRIVATE).getBoolean("night", false)
+
+    private fun setNightPref(on: Boolean) =
+        getSharedPreferences("display", MODE_PRIVATE).edit().putBoolean("night", on).apply()
+
+    private fun stylePresetPref(): String =
+        getSharedPreferences("display", MODE_PRIVATE).getString("style_preset", "Original") ?: "Original"
+
+    private fun setStylePresetPref(name: String) =
+        getSharedPreferences("display", MODE_PRIVATE).edit().putString("style_preset", name).apply()
+
     private fun renderQualityPref(): Int =
         getSharedPreferences("display", MODE_PRIVATE).getInt("render_quality", 1).coerceIn(0, 2)
 
@@ -3327,6 +3390,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val OPEN_DRAG_FRAC = 0.08f // lasso: start-to-lift distance (normalized) above which the gesture is an open drag (vs a closed loop).
         const val CONTRAST_MAX = 8 // mirrors reader-core render::contrast::MAX_CONTRAST_STEP (RR4).
         val LINE_SPACINGS = floatArrayOf(1.2f, 1.4f, 1.7f) // Small / Medium / Large (RR4).
+        val STYLE_PRESETS = listOf("Original", "Bold", "Night", "Outdoor", "Relaxed") // 1.10
         const val HIGHLIGHT_WIDTH_PX = 30f // wide marker band (vs INK_STROKE_WIDTH for the pen).
         const val STROKE_PAUSE_MS = 600L // commit a stroke after this pen-pause (swallowed-UP net).
         const val INK_FLUSH_MS = 1500L // trailing-edge delay before the deferred ink autosave fsyncs.

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -655,6 +655,23 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetContrast
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSetNight(handle, on) — night mode: invert the page after contrast (RR4). The shell
+// re-renders afterward. Never throws.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetNight<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    on: jboolean,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        session.set_night(on);
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetFit(handle, mode) — page fit mode (0=Page/contain, 1=Width, 2=Height; RR4). Aspect-
 // preserving; the shell re-renders afterward. Never throws (mode decoded leniently).
 #[unsafe(no_mangle)]
@@ -992,7 +1009,7 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeInkPages<'l
             .map(|p| p as jint)
             .collect();
         let arr = env.new_int_array(pages.len())?;
-        env.set_int_array_region(&arr, 0, &pages)?;
+        arr.set_region(env, 0, &pages)?;
         Ok(arr)
     })
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -119,6 +119,9 @@ pub struct ReaderSession {
     /// Contrast/display-enhancement step (`0` = off; RR4 — KOReader's "Contrast"). Applied as a
     /// per-pixel remap after render so faint scans read better on e-ink.
     contrast: u8,
+    /// Night mode: invert the rendered page (light text on dark) after contrast (RR4). Part of the
+    /// cache key so a cached page isn't served at the wrong polarity.
+    night: bool,
     /// How a fixed-layout page is fit to the viewport (RR4 — KOReader's "Fit"). Default: contain.
     fit_mode: FitMode,
     /// Auto-crop the page's white margins (RR4 — KOReader Crop = auto). `false` = full page.
@@ -284,6 +287,7 @@ impl ReaderSession {
             clipboard: Vec::new(),
             identity,
             contrast: 0,
+            night: false,
             fit_mode: FitMode::Page,
             crop_auto: false,
             crop_margin: 0,
@@ -489,6 +493,9 @@ impl ReaderSession {
                 buf,
                 crate::render::contrast::step_to_gamma(self.contrast),
             );
+            if self.night {
+                crate::render::gray::invert_in_place(buf);
+            }
             return Ok(());
         }
         // Non-magnified page render — the page-turn / revisit case. The rendered bytes are a pure
@@ -546,6 +553,9 @@ impl ReaderSession {
             buf,
             crate::render::contrast::step_to_gamma(self.contrast),
         );
+        if self.night {
+            crate::render::gray::invert_in_place(buf); // light-on-dark (night mode)
+        }
         Ok(())
     }
 
@@ -590,7 +600,7 @@ impl ReaderSession {
             self.page as u32,
             1.0,
             0,
-            false,
+            self.night, // invert flag — night pages cache separately from day
             crate::render::DitherMode::None,
             1.0,
         )
@@ -647,6 +657,17 @@ impl ReaderSession {
     #[must_use]
     pub fn contrast(&self) -> u8 {
         self.contrast
+    }
+
+    /// Enable/disable night mode (invert the page; RR4). Re-render to apply.
+    pub fn set_night(&mut self, on: bool) {
+        self.night = on;
+    }
+
+    /// Whether night mode (invert) is on.
+    #[must_use]
+    pub fn night(&self) -> bool {
+        self.night
     }
 
     /// Set the page fit mode (RR4 — KOReader's "Fit"). Re-render to apply.

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -1349,6 +1349,29 @@ fn contrast_darkens_a_gray_page_after_render() {
 }
 
 #[test]
+fn night_mode_inverts_the_page() {
+    let mut s = ReaderSession::with_document(
+        Box::new(GrayDoc(80)),
+        DeviceCapabilities::supernote_full(),
+        Viewport::new(8, 8, 226),
+    );
+    let mut bytes = vec![0u8; 8 * 8 * 4];
+    {
+        let mut buf = PixelBuffer::from_rgba(&mut bytes, 8, 8).unwrap();
+        s.render_current(&mut buf).unwrap();
+    }
+    assert_eq!(bytes[0], 80, "day: the gray page renders as-is");
+
+    s.set_night(true);
+    {
+        let mut buf = PixelBuffer::from_rgba(&mut bytes, 8, 8).unwrap();
+        s.render_current(&mut buf).unwrap(); // night caches separately (invert in the key)
+    }
+    assert_eq!(bytes[0], 255 - 80, "night: the page is inverted");
+    assert_eq!(bytes[3], 0xFF, "alpha preserved");
+}
+
+#[test]
 fn prefetch_warms_the_next_page_without_changing_the_displayed_one() {
     let mut s = session(3, DeviceCapabilities::supernote_full());
     let mut bytes = vec![0u8; 100 * 120 * 4];


### PR DESCRIPTION
Tier 1 item 1.10 — one-tap reading style presets. Closes #87.

## What
A **Style** tab in the Adjust sheet with presets that bundle the display knobs:

| Preset | Bundle |
|---|---|
| **Original** | defaults |
| **Bold** | darker text (higher contrast) |
| **Night** | inverted (light-on-dark) |
| **Outdoor** | maximum contrast |
| **Relaxed** | larger font + more line spacing |

## New capability — night mode (invert)
- **Core:** `Session::set_night()` inverts the page after contrast via the existing `gray::invert_in_place`. The render **cache key carries the invert flag** so night/day pages cache separately (no stale polarity). Applied in both the fit and zoom render paths.
- **JNI** `nativeSetNight`; the shell persists it (`night` pref) and reapplies on open.

Each preset sets text scale + line spacing + contrast + night, then re-renders. Font/spacing are **no-ops on fixed-layout PDFs** (contrast/night apply to both), as expected.

## Testing
- Host test `night_mode_inverts_the_page` (gray 80 → 175 inverted, alpha preserved; verifies the invert cache key too).
- `scripts/gate.sh` all green (fmt/clippy/test/jni-bridge/android-unit).
- `libreader.so` + APK installed on the Nomad.

## Acceptance (#87)
- [x] Style sheet lists presets; tapping applies + persists
- [x] Night inverts (host test); active preset reapplies on open
- [x] Font/spacing presets no-op on PDFs
- [x] Host test for night-invert; gate green
- [ ] On-device check pending