### PR TITLE
feat(update): in-app GitHub self-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,10 @@ name: Release
 # the dictionary corpus is staged → Gradle assembles the APK. The APK is attached to the
 # Release so anyone can sideload it without a toolchain.
 #
-# NOTE (M0 / ADR Decision 3): the "release" variant is self-signed with the debug key for
-# sideload bring-up. A real release signingConfig lands in M4 (RR29-FR2) — wire the keystore
-# in via repo secrets here when it does.
+# SIGNING (RR29-FR2 / ADR-INKREAD-0014 Decision 0): when the repo secret INKREAD_KEYSTORE_BASE64
+# (+ INKREAD_KEYSTORE_PASSWORD / INKREAD_KEY_ALIAS / INKREAD_KEY_PASSWORD) is set, the APK is
+# production-signed with the stable inkread release key — the prerequisite for the in-app
+# self-updater. Without the secret it falls back to the debug key (and the updater stays inert).
 
 on:
   push:
@@ -117,10 +118,43 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
           echo "reader-core crate version → $(grep '^version = ' Cargo.toml)"
 
+      # --- Decode the release signing keystore (RR29-FR2 / ADR-INKREAD-0014 Decision 0) ---
+      # The self-updater requires a STABLE release key: Android rejects an update whose signer
+      # differs from the installed app. When the INKREAD_KEYSTORE_BASE64 secret is set, decode it to
+      # an ephemeral file under RUNNER_TEMP (never committed) and export the signing vars that
+      # app/build.gradle.kts reads; absent the secret, the build falls back to the debug key and the
+      # updater stays inert (signer-pin fails closed). Passwords go via $GITHUB_ENV, which is masked
+      # and not printed — they never appear in logs.
+      - name: Set up release signing
+        id: signing
+        env:
+          KEYSTORE_BASE64: ${{ secrets.INKREAD_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.INKREAD_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.INKREAD_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.INKREAD_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KEYSTORE_BASE64:-}" ]; then
+            echo "::warning::No INKREAD_KEYSTORE_BASE64 secret — the release APK will be DEBUG-signed and cannot auto-update an existing install. Add the four INKREAD_* signing secrets to enable production signing."
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ks="$RUNNER_TEMP/inkread-release.jks"
+          echo "$KEYSTORE_BASE64" | base64 --decode > "$ks"
+          {
+            echo "INKREAD_KEYSTORE_FILE=$ks"
+            echo "INKREAD_KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD"
+            echo "INKREAD_KEY_ALIAS=$KEY_ALIAS"
+            echo "INKREAD_KEY_PASSWORD=$KEY_PASSWORD"
+          } >> "$GITHUB_ENV"
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+          echo "Release keystore staged for signing."
+
       # --- Build the APK via the canonical script (Rust core + pdfium + dict + Gradle) ---
       # Gradle reads ORG_GRADLE_PROJECT_<name> env vars as project properties, so the tag's
       # version lands in the APK's versionName/versionCode (see app/build.gradle.kts) — no
-      # change to buildApk.sh needed. versionCode uses the monotonic CI run number.
+      # change to buildApk.sh needed. versionCode uses the monotonic CI run number. The signing
+      # vars exported above (when present) flow in via $GITHUB_ENV → the release signingConfig.
       - name: Build APK (./buildApk.sh)
         env:
           ORG_GRADLE_PROJECT_inkreadVersionName: ${{ steps.ver.outputs.version }}
@@ -165,8 +199,6 @@ jobs:
             adb install -r inkread-${{ steps.ver.outputs.tag }}.apk
             ```
 
-            > This build is self-signed with the debug key for sideload bring-up (M0, ADR
-            > Decision 3). Verify the attached `.sha256` before installing. A production-signed
-            > release lands in M4 (RR29-FR2).
+            > ${{ steps.signing.outputs.signed == 'true' && 'Production-signed with the inkread release key — installs and in-app updates verify against it. Verify the attached `.sha256` before installing.' || 'This build is DEBUG-signed for sideload bring-up; it cannot update an existing install in place. Verify the attached `.sha256` before installing.' }}
 
             ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkread-update"
+version = "0.1.0-m0"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,6 +1235,7 @@ dependencies = [
  "inkread-epub",
  "inkread-ink",
  "inkread-pdftext",
+ "inkread-update",
  "jni",
  "jpeg-decoder",
  "pdfium-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # RR1-AC3: bare `cargo test -p reader-core` builds with `jni` absent from the resolved graph.
 [workspace]
 resolver = "2"
-members = ["build-dict", "device-eink", "inkread-daily", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "inkread-pdftext", "reader-core"]
+members = ["build-dict", "device-eink", "inkread-daily", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "inkread-pdftext", "inkread-update", "reader-core"]
 
 [workspace.package]
 version = "0.1.0-m0"
@@ -25,6 +25,7 @@ inkread-epub = { path = "inkread-epub" }
 inkread-ink = { path = "inkread-ink" }
 inkread-lua = { path = "inkread-lua" }
 inkread-pdftext = { path = "inkread-pdftext" }
+inkread-update = { path = "inkread-update" }
 reader-core = { path = "reader-core" }
 
 # External — versions verified against docs.rs at implementation time.
@@ -54,6 +55,9 @@ jpeg-decoder = { version = "0.3", default-features = false }
 png = "0.17"
 # inkread-daily (#66): RSS/Atom feed parsing. Pure-Rust pull parser, MIT/Apache, cross-compiles clean.
 quick-xml = "0.36"
+# inkread-update (ADR-INKREAD-0014): semver comparison of the installed version against the GitHub
+# release tag. Pure Rust, MIT/Apache (AGPL-compatible → auto-passes check-licenses.sh).
+semver = "1"
 
 [profile.release]
 # A reader on a battery e-ink device: optimize for size + speed, strip symbols.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,12 +28,37 @@ android {
     // libreader.so + libpdfium.so are staged into src/main/jniLibs/ by buildApk.sh.
     sourceSets["main"].jniLibs.srcDirs("src/main/jniLibs")
 
+    // Release signing (RR29-FR2 / ADR-INKREAD-0014 Decision 0). The keystore is supplied by CI via
+    // env vars (release.yml decodes a repo secret to a file); local/dev builds leave them unset and
+    // fall back to the debug key for sideload bring-up. A STABLE release key is the prerequisite for
+    // the in-app self-updater: Android rejects an update whose signer differs from the installed app.
+    val keystorePath = System.getenv("INKREAD_KEYSTORE_FILE")
+        ?: project.findProperty("inkreadKeystoreFile") as String?
+    signingConfigs {
+        create("release") {
+            if (!keystorePath.isNullOrBlank()) {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("INKREAD_KEYSTORE_PASSWORD")
+                    ?: project.findProperty("inkreadKeystorePassword") as String?
+                keyAlias = System.getenv("INKREAD_KEY_ALIAS")
+                    ?: project.findProperty("inkreadKeyAlias") as String?
+                keyPassword = System.getenv("INKREAD_KEY_PASSWORD")
+                    ?: project.findProperty("inkreadKeyPassword") as String?
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
-            // M0 is self-signed via the default debug key for sideload bring-up (ADR
-            // Decision 3); a real release signingConfig is wired in M4 (RR29-FR2).
-            signingConfig = signingConfigs.getByName("debug")
+            // Production-sign when a keystore is configured (CI); otherwise self-sign with the debug
+            // key for local sideload bring-up. The self-updater stays inert (signer-pin fails closed)
+            // until a release-key build is the installed one.
+            signingConfig = if (!keystorePath.isNullOrBlank()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,11 @@
     <!-- Opt-in online dictionary fallback (Wiktionary) for non-bundled languages (RR12 / D4). -->
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- In-app self-update (ADR-INKREAD-0014): a sideloaded build has no store to push fixes, so it
+         checks GitHub Releases and installs a newer signed APK via PackageInstaller. The OS still
+         shows its own final install confirmation (no device-owner ⇒ no silent install). -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
     <!-- All-files access (ADR-INKREAD-0005): the PDF export writes the annotated copy into a
          public, Partner-synced folder (e.g. /storage/emulated/0/EXPORT) so it reaches the desktop.
          Granted via Settings → All files access (Android 11+); sideloaded-app scope. -->
@@ -56,5 +61,11 @@
             android:name=".DailyActivity"
             android:exported="false"
             android:configChanges="orientation|screenSize|keyboardHidden" />
+
+        <!-- Self-update install callback (ADR-INKREAD-0014): receives the PackageInstaller session
+             result and launches the OS install-confirmation intent. Internal only. -->
+        <receiver
+            android:name=".UpdateInstallReceiver"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
@@ -11,6 +11,10 @@ object AppSettings {
     private const val PREFS = "settings"
     private const val KEY_OVERWRITE_ON_EXPORT = "overwrite_on_export"
     private const val KEY_ONLINE_LOOKUP = "online_lookup"
+    private const val KEY_AUTO_UPDATE_CHECK = "auto_update_check"
+    private const val KEY_AUTO_INSTALL_UPDATES = "auto_install_updates"
+    private const val KEY_UPDATE_SKIP_VERSION = "update_skip_version"
+    private const val KEY_UPDATE_LAST_CHECK_MS = "update_last_check_ms"
 
     private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -33,4 +37,46 @@ object AppSettings {
 
     fun setOnlineLookup(c: Context, value: Boolean) =
         prefs(c).edit().putBoolean(KEY_ONLINE_LOOKUP, value).apply()
+
+    // ── Self-update (ADR-INKREAD-0014) ────────────────────────────────────────────────────────────
+
+    /**
+     * When true, inkread checks GitHub for a newer release on launch and prompts to install it
+     * (UPD-FR6/FR8). On by default — a sideloaded build has no store to deliver fixes, so surfacing
+     * them is the floor; the check is a single on-launch request, never background polling.
+     */
+    fun autoUpdateCheck(c: Context): Boolean = prefs(c).getBoolean(KEY_AUTO_UPDATE_CHECK, true)
+
+    fun setAutoUpdateCheck(c: Context, value: Boolean) =
+        prefs(c).edit().putBoolean(KEY_AUTO_UPDATE_CHECK, value).apply()
+
+    /**
+     * When true, a detected update is downloaded + verified and sent straight to the system
+     * installer without the in-app prompt (UPD-FR7). Off by default — auto-installing without an
+     * explicit opt-in is surprising and uses data. Only effective while [autoUpdateCheck] is on
+     * ([autoInstallEffective]); Android still shows its own final install confirmation.
+     */
+    fun autoInstallUpdates(c: Context): Boolean = prefs(c).getBoolean(KEY_AUTO_INSTALL_UPDATES, false)
+
+    fun setAutoInstallUpdates(c: Context, value: Boolean) =
+        prefs(c).edit().putBoolean(KEY_AUTO_INSTALL_UPDATES, value).apply()
+
+    /** Auto-install acts only when both it and the launch check are enabled (UPD-FR8). */
+    fun autoInstallEffective(c: Context): Boolean = autoUpdateCheck(c) && autoInstallUpdates(c)
+
+    /**
+     * The release version the reader chose to skip (UPD-FR6 "Skip this version"), or "" for none.
+     * A matching candidate is suppressed; any newer version clears past it.
+     */
+    fun updateSkipVersion(c: Context): String =
+        prefs(c).getString(KEY_UPDATE_SKIP_VERSION, "").orEmpty()
+
+    fun setUpdateSkipVersion(c: Context, version: String) =
+        prefs(c).edit().putString(KEY_UPDATE_SKIP_VERSION, version).apply()
+
+    /** Epoch-ms of the last completed update check (UPD-FR6 throttle); 0 if never. */
+    fun updateLastCheckMs(c: Context): Long = prefs(c).getLong(KEY_UPDATE_LAST_CHECK_MS, 0L)
+
+    fun setUpdateLastCheckMs(c: Context, ms: Long) =
+        prefs(c).edit().putLong(KEY_UPDATE_LAST_CHECK_MS, ms).apply()
 }

--- a/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
-import java.net.HttpURLConnection
 import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -322,44 +321,8 @@ class DailyController(private val context: Context) {
 
     // ── Fetch (HTTPS/HTTP, off the UI thread) ─────────────────────────────────────────────────────
 
-    private fun fetch(url: String): String? {
-        if (url.isBlank()) return null
-        return try {
-            val conn = (URL(url).openConnection() as HttpURLConnection).apply {
-                connectTimeout = TIMEOUT_MS
-                readTimeout = TIMEOUT_MS
-                instanceFollowRedirects = true
-                setRequestProperty("User-Agent", "Mozilla/5.0 (inkread-daily/0.1)")
-                setRequestProperty("Accept", "text/html,application/xhtml+xml,application/xml,application/rss+xml,*/*")
-            }
-            val code = conn.responseCode
-            if (code !in 200..299) {
-                Log.e(TAG, "fetch $url -> HTTP $code")
-                return null
-            }
-            conn.inputStream.use { input ->
-                val bytes = input.readBytes(MAX_BYTES)
-                String(bytes, Charsets.UTF_8)
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "fetch failed: $url — ${e.message}")
-            null
-        }
-    }
-
-    /** Read up to [cap] bytes, then stop (a runaway page never exhausts memory). */
-    private fun java.io.InputStream.readBytes(cap: Int): ByteArray {
-        val out = java.io.ByteArrayOutputStream()
-        val buf = ByteArray(16 * 1024)
-        var total = 0
-        while (total < cap) {
-            val n = read(buf)
-            if (n < 0) break
-            out.write(buf, 0, n)
-            total += n
-        }
-        return out.toByteArray()
-    }
+    private fun fetch(url: String): String? =
+        HttpFetch.getText(url, FETCH_USER_AGENT, FETCH_ACCEPT, TIMEOUT_MS, MAX_BYTES)
 
     private fun todayKey(): String = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
     private fun todayDisplay(): String = SimpleDateFormat("EEEE, MMMM d, yyyy", Locale.getDefault()).format(Date())
@@ -387,5 +350,7 @@ class DailyController(private val context: Context) {
         const val HEADLINES_SHOWN = 60 // headlines stored for the front page (grouped by source)
         const val TIMEOUT_MS = 10_000
         const val MAX_BYTES = 2 * 1024 * 1024 // cap a fetched page at 2 MiB
+        const val FETCH_USER_AGENT = "Mozilla/5.0 (inkread-daily/0.1)"
+        const val FETCH_ACCEPT = "text/html,application/xhtml+xml,application/xml,application/rss+xml,*/*"
     }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -85,6 +85,7 @@ class HomeActivity : Activity() {
             setContentView(buildView()) // refresh covers + progress after returning from the reader
             shelfSig = sig
         }
+        UpdateGate.maybeCheckOnLaunch(this) // throttled GitHub release check (ADR-INKREAD-0014)
     }
 
     /** A stable digest of what the shelf renders — recents order + per-book read progress. */

--- a/app/src/main/java/dev/jraghavan/inkread/HttpFetch.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HttpFetch.kt
@@ -1,0 +1,91 @@
+package dev.jraghavan.inkread
+
+import android.util.Log
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * The shell's one bounded HTTP GET, shared by the network features (the daily fetch #66 and the
+ * self-updater, ADR-INKREAD-0014). The Rust core stays IO-free (IR-7) — every HTTP byte enters here.
+ * Both entry points cap the response so a runaway/hostile body can never exhaust memory or disk, and
+ * both swallow failures into a `null`/`false` so callers degrade silently (offline ⇒ no-op).
+ */
+object HttpFetch {
+
+    /** GET [url] as UTF-8 text, capped at [capBytes]; `null` on blank URL / non-2xx / IO error. */
+    fun getText(url: String, userAgent: String, accept: String?, timeoutMs: Int, capBytes: Int): String? {
+        if (url.isBlank()) return null
+        return try {
+            val conn = open(url, userAgent, accept, timeoutMs)
+            if (conn.responseCode !in 200..299) {
+                Log.w(TAG, "GET $url -> HTTP ${conn.responseCode}")
+                null
+            } else {
+                conn.inputStream.use { String(it.readCapped(capBytes), Charsets.UTF_8) }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "GET $url failed: ${e.message}")
+            null
+        }
+    }
+
+    /** Stream [url] to [dest], aborting past [capBytes]; `false` on non-2xx / IO error / oversize. */
+    fun download(url: String, dest: File, userAgent: String, timeoutMs: Int, capBytes: Long): Boolean {
+        if (url.isBlank()) return false
+        return try {
+            val conn = open(url, userAgent, null, timeoutMs)
+            if (conn.responseCode !in 200..299) {
+                Log.w(TAG, "download $url -> HTTP ${conn.responseCode}")
+                return false
+            }
+            conn.inputStream.use { input ->
+                dest.outputStream().use { out ->
+                    val buf = ByteArray(64 * 1024)
+                    var total = 0L
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n < 0) break
+                        total += n
+                        if (total > capBytes) {
+                            Log.w(TAG, "download $url exceeds ${capBytes}B cap")
+                            return false
+                        }
+                        out.write(buf, 0, n)
+                    }
+                }
+            }
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "download $url failed: ${e.message}")
+            false
+        }
+    }
+
+    private fun open(url: String, userAgent: String, accept: String?, timeoutMs: Int): HttpURLConnection =
+        (URL(url).openConnection() as HttpURLConnection).apply {
+            connectTimeout = timeoutMs
+            readTimeout = timeoutMs
+            instanceFollowRedirects = true // GitHub asset URLs 302 to an HTTPS CDN (same-protocol → followed)
+            setRequestProperty("User-Agent", userAgent)
+            if (accept != null) setRequestProperty("Accept", accept)
+        }
+
+    /** Read up to [cap] bytes (the last chunk may cross it by &lt;64 KiB), then stop. */
+    private fun InputStream.readCapped(cap: Int): ByteArray {
+        val out = ByteArrayOutputStream()
+        val buf = ByteArray(16 * 1024)
+        var total = 0
+        while (total < cap) {
+            val n = read(buf)
+            if (n < 0) break
+            out.write(buf, 0, n)
+            total += n
+        }
+        return out.toByteArray()
+    }
+
+    private const val TAG = "HttpFetch"
+}

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -88,6 +88,12 @@ object NativeBridge {
      *  Returns the EPUB bytes; throws on malformed JSON (#66). */
     external fun nativeDailyAssemble(issueJson: String): ByteArray
 
+    /** Decide whether [releaseJson] (a fetched GitHub releases/latest payload) is a newer build than
+     *  [installedVersion] (BuildConfig.VERSION_NAME). Standalone — the shell fetches, the core
+     *  semver-compares and returns the decision JSON `{updateAvailable,version,notes,apkUrl,
+     *  sha256Url}` (ADR-INKREAD-0014). Junk in -> `{"updateAvailable":false}`. */
+    external fun nativeUpdateDecide(installedVersion: String, releaseJson: String): String
+
     /**
      * Render the current page into [directBuffer] — a DIRECT [ByteBuffer] of exactly
      * `width*height*4` bytes (RGBA). The core borrows it for the call only (Amendment 5).

--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -91,6 +91,32 @@ class SettingsActivity : Activity() {
             },
         )
 
+        // ── Updates (ADR-INKREAD-0014) ───────────────────────────────────────────────
+        column.addView(spacer(dp(34)))
+        column.addView(eyebrow("Updates"))
+        column.addView(spacer(dp(12)))
+        column.addView(
+            toggleRow(
+                title = "Check for updates automatically",
+                desc = "On launch, check GitHub for a newer release and offer to install it. " +
+                    "inkread is sideloaded, so there is no store to deliver fixes. A single check, " +
+                    "never background polling.",
+                on = AppSettings.autoUpdateCheck(this),
+            ) { onAutoCheckTapped() },
+        )
+        column.addView(spacer(dp(18)))
+        column.addView(
+            toggleRow(
+                title = "Install updates automatically",
+                desc = "When a newer release is found, download and verify it and go straight to " +
+                    "install — skipping the prompt. Android still shows its own final install " +
+                    "confirmation. Off by default.",
+                on = AppSettings.autoInstallUpdates(this),
+            ) { onAutoInstallTapped() },
+        )
+        column.addView(spacer(dp(18)))
+        column.addView(actionRow("Check for updates now") { UpdateGate.checkNow(this) })
+
         // ── How it works ───────────────────────────────────────────────────────────
         column.addView(spacer(dp(34)))
         column.addView(eyebrow("How it works"))
@@ -135,7 +161,35 @@ class SettingsActivity : Activity() {
             .show()
     }
 
+    /** Toggling auto-check off also disables auto-install (UPD-FR8) — the latter needs the check. */
+    private fun onAutoCheckTapped() {
+        val on = !AppSettings.autoUpdateCheck(this)
+        AppSettings.setAutoUpdateCheck(this, on)
+        if (!on) AppSettings.setAutoInstallUpdates(this, false)
+        refresh()
+    }
+
+    /** Turning auto-install on implies auto-check on (it has nothing to act on otherwise). */
+    private fun onAutoInstallTapped() {
+        val on = !AppSettings.autoInstallUpdates(this)
+        AppSettings.setAutoInstallUpdates(this, on)
+        if (on) AppSettings.setAutoUpdateCheck(this, true)
+        refresh()
+    }
+
     // ── Pieces ──────────────────────────────────────────────────────────────────────
+
+    /** A tappable action with a title on the left and an outlined affordance pill on the right. */
+    private fun actionRow(title: String, onTap: () -> Unit): View =
+        LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            isClickable = true; setOnClickListener { onTap() }
+            addView(TextView(this@SettingsActivity).apply {
+                text = title; setTextColor(ink); textSize = 17f; typeface = serif
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply { marginEnd = dp(16) })
+            addView(pill("Check", false))
+        }
 
     /** A setting with a title + description on the left and an On/Off pill on the right. */
     private fun toggleRow(title: String, desc: String, on: Boolean, onTap: () -> Unit): View =

--- a/app/src/main/java/dev/jraghavan/inkread/UpdateController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/UpdateController.kt
@@ -12,8 +12,6 @@ import android.provider.Settings
 import android.util.Log
 import org.json.JSONObject
 import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
 
 /**
  * The Android shell's half of the in-app self-updater (ADR-INKREAD-0014). The network and the
@@ -36,6 +34,17 @@ class UpdateController(private val context: Context) {
         val sha256Url: String,
     )
 
+    /**
+     * The outcome of a [check]: a newer release, nothing newer, or the check never reached the
+     * server. Distinguishing [Failed] from [UpToDate] lets the UX avoid burning the throttle on an
+     * offline launch and report "couldn't check" vs "up to date" honestly (UPD-FR9).
+     */
+    sealed interface CheckResult {
+        data class Update(val available: Available) : CheckResult
+        object UpToDate : CheckResult
+        object Failed : CheckResult
+    }
+
     /** The installed `versionName` (the basis for the semver comparison), or "" if unavailable. */
     fun installedVersion(): String =
         runCatching { context.packageManager.getPackageInfo(context.packageName, 0).versionName }
@@ -43,24 +52,28 @@ class UpdateController(private val context: Context) {
             .orEmpty()
 
     /**
-     * Fetch `releases/latest` and ask the core whether it is newer. Returns the [Available] update,
-     * or `null` when offline / rate-limited / nothing newer / no installable asset (UPD-FR9: any
-     * failure is a silent no-op). Blocking — call off the UI thread.
+     * Fetch `releases/latest` and ask the core whether it is newer. [CheckResult.Failed] means the
+     * server was never reached (offline / rate-limited / bad local version) — the caller leaves the
+     * throttle untouched; [CheckResult.UpToDate] means the server answered with nothing installable.
+     * Blocking — call off the UI thread.
      */
-    fun check(): Available? {
+    fun check(): CheckResult {
         val installed = installedVersion()
-        if (installed.isEmpty()) return null
-        val json = fetchText(LATEST_RELEASE_URL, ACCEPT_GITHUB) ?: return null
+        if (installed.isEmpty()) return CheckResult.Failed
+        val json = HttpFetch.getText(LATEST_RELEASE_URL, USER_AGENT, ACCEPT_GITHUB, TIMEOUT_MS, MAX_TEXT_BYTES)
+            ?: return CheckResult.Failed
         val decision = runCatching { JSONObject(NativeBridge.nativeUpdateDecide(installed, json)) }
-            .getOrNull() ?: return null
-        if (!decision.optBoolean("updateAvailable", false)) return null
+            .getOrNull() ?: return CheckResult.Failed
+        if (!decision.optBoolean("updateAvailable", false)) return CheckResult.UpToDate
         val apkUrl = decision.optString("apkUrl")
-        if (apkUrl.isEmpty()) return null
-        return Available(
-            version = decision.optString("version"),
-            notes = decision.optString("notes"),
-            apkUrl = apkUrl,
-            sha256Url = decision.optString("sha256Url"),
+        if (apkUrl.isEmpty()) return CheckResult.UpToDate
+        return CheckResult.Update(
+            Available(
+                version = decision.optString("version"),
+                notes = decision.optString("notes"),
+                apkUrl = apkUrl,
+                sha256Url = decision.optString("sha256Url"),
+            ),
         )
     }
 
@@ -85,7 +98,7 @@ class UpdateController(private val context: Context) {
         val dir = File(context.cacheDir, UPDATE_DIR).apply { mkdirs() }
         // One slot, overwritten each attempt — never accumulate stale APKs.
         val apk = File(dir, "update.apk")
-        if (!download(a.apkUrl, apk)) {
+        if (!HttpFetch.download(a.apkUrl, apk, USER_AGENT, TIMEOUT_MS, MAX_APK_BYTES)) {
             apk.delete()
             return null
         }
@@ -98,7 +111,11 @@ class UpdateController(private val context: Context) {
 
         // Checksum gate: a *published* digest must match; an *absent* one falls back to signer-pin
         // alone (UPD-FR3) — distinguish the two so a missing file is not silently treated as a pass.
-        val checksumText = if (a.sha256Url.isNotEmpty()) fetchText(a.sha256Url, null) else null
+        val checksumText = if (a.sha256Url.isNotEmpty()) {
+            HttpFetch.getText(a.sha256Url, USER_AGENT, null, TIMEOUT_MS, MAX_TEXT_BYTES)
+        } else {
+            null
+        }
         if (UpdateVerify.expectedShaFrom(checksumText) != null &&
             !UpdateVerify.matchesPublishedSha(apkBytes, checksumText)
         ) {
@@ -140,76 +157,6 @@ class UpdateController(private val context: Context) {
         }
     }
 
-    // ── network ───────────────────────────────────────────────────────────────────────────────────
-
-    /** GET [url] as text (capped); `null` on any non-2xx / IO error. [accept] sets the Accept header. */
-    private fun fetchText(url: String, accept: String?): String? = try {
-        val conn = open(url, accept)
-        if (conn.responseCode in 200..299) {
-            conn.inputStream.use { String(it.readBytes(MAX_TEXT_BYTES), Charsets.UTF_8) }
-        } else {
-            Log.w(TAG, "fetch $url -> HTTP ${conn.responseCode}")
-            null
-        }
-    } catch (e: Exception) {
-        Log.w(TAG, "fetch $url failed: ${e.message}")
-        null
-    }
-
-    /** Stream [url] to [dest] (capped); `false` on any non-2xx / IO error / oversize. */
-    private fun download(url: String, dest: File): Boolean = try {
-        val conn = open(url, null)
-        if (conn.responseCode !in 200..299) {
-            Log.w(TAG, "download $url -> HTTP ${conn.responseCode}")
-            false
-        } else {
-            conn.inputStream.use { input ->
-                dest.outputStream().use { out ->
-                    var total = 0L
-                    val buf = ByteArray(64 * 1024)
-                    while (true) {
-                        val n = input.read(buf)
-                        if (n < 0) break
-                        total += n
-                        if (total > MAX_APK_BYTES) {
-                            Log.w(TAG, "download $url exceeds ${MAX_APK_BYTES}B cap")
-                            return false
-                        }
-                        out.write(buf, 0, n)
-                    }
-                }
-            }
-            true
-        }
-    } catch (e: Exception) {
-        Log.w(TAG, "download $url failed: ${e.message}")
-        false
-    }
-
-    private fun open(url: String, accept: String?): HttpURLConnection =
-        (URL(url).openConnection() as HttpURLConnection).apply {
-            connectTimeout = TIMEOUT_MS
-            readTimeout = TIMEOUT_MS
-            instanceFollowRedirects = true
-            setRequestProperty("User-Agent", USER_AGENT)
-            if (accept != null) setRequestProperty("Accept", accept)
-        }
-
-    /** Bounded `readBytes` so a hostile/huge response cannot exhaust memory (mirrors DailyController). */
-    private fun java.io.InputStream.readBytes(cap: Int): ByteArray {
-        val out = java.io.ByteArrayOutputStream()
-        val buf = ByteArray(16 * 1024)
-        var total = 0
-        while (true) {
-            val n = read(buf)
-            if (n < 0) break
-            total += n
-            if (total > cap) break
-            out.write(buf, 0, n)
-        }
-        return out.toByteArray()
-    }
-
     // ── signer extraction (signing-cert API moved at API 28) ───────────────────────────────────────
 
     private fun installedSignerCerts(): List<ByteArray> = runCatching {
@@ -233,10 +180,11 @@ class UpdateController(private val context: Context) {
     @Suppress("DEPRECATION")
     private fun certBytesOf(info: PackageInfo): List<ByteArray> =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            val signers = info.signingInfo ?: return emptyList()
-            val sigs = if (signers.hasMultipleSigners()) signers.apkContentsSigners
-            else signers.signingCertificateHistory
-            sigs?.map { it.toByteArray() }.orEmpty()
+            // apkContentsSigners = the certs the package is CURRENTLY signed by, symmetric for an
+            // installed app and a downloaded archive. signingCertificateHistory would add the
+            // on-device rotation lineage the archive lacks, which certsMatch's size-equality would
+            // then falsely reject (a legit update after any future key rotation).
+            info.signingInfo?.apkContentsSigners?.map { it.toByteArray() }.orEmpty()
         } else {
             info.signatures?.map { it.toByteArray() }.orEmpty()
         }
@@ -251,7 +199,9 @@ class UpdateController(private val context: Context) {
         private const val USER_AGENT = "inkread-updater"
         private const val ACTION_INSTALLED = "dev.jraghavan.inkread.UPDATE_INSTALLED"
 
-        private const val UPDATE_DIR = "updates"
+        /** Private cache subdir holding the single staged APK — shared with [UpdateInstallReceiver]
+         *  so its post-install cleanup targets the same directory. */
+        const val UPDATE_DIR = "updates"
         private const val TIMEOUT_MS = 15_000
         private const val MAX_TEXT_BYTES = 512 * 1024 // release JSON / checksum line
         private const val MAX_APK_BYTES = 200L * 1024 * 1024 // APK ceiling (guards a hostile stream)

--- a/app/src/main/java/dev/jraghavan/inkread/UpdateController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/UpdateController.kt
@@ -1,0 +1,259 @@
+package dev.jraghavan.inkread
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageInstaller
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * The Android shell's half of the in-app self-updater (ADR-INKREAD-0014). The network and the
+ * install live here (IR-7 — the Rust core stays IO-free and only *decides*): this fetches the
+ * project's GitHub `releases/latest` payload, hands it to [NativeBridge.nativeUpdateDecide] for the
+ * semver decision, then — on the reader's say-so or under auto-update — downloads the APK, verifies
+ * it ([UpdateVerify]: published SHA-256 + signer pin), and installs it via the [PackageInstaller]
+ * session API.
+ *
+ * Every method here blocks on I/O; callers invoke them off the UI thread (see [HomeActivity]). The
+ * controller is mechanism only — the skip/throttle/auto-install *policy* lives in the UX layer.
+ */
+class UpdateController(private val context: Context) {
+
+    /** A newer release the core surfaced — the parsed [NativeBridge.nativeUpdateDecide] decision. */
+    data class Available(
+        val version: String,
+        val notes: String,
+        val apkUrl: String,
+        val sha256Url: String,
+    )
+
+    /** The installed `versionName` (the basis for the semver comparison), or "" if unavailable. */
+    fun installedVersion(): String =
+        runCatching { context.packageManager.getPackageInfo(context.packageName, 0).versionName }
+            .getOrNull()
+            .orEmpty()
+
+    /**
+     * Fetch `releases/latest` and ask the core whether it is newer. Returns the [Available] update,
+     * or `null` when offline / rate-limited / nothing newer / no installable asset (UPD-FR9: any
+     * failure is a silent no-op). Blocking — call off the UI thread.
+     */
+    fun check(): Available? {
+        val installed = installedVersion()
+        if (installed.isEmpty()) return null
+        val json = fetchText(LATEST_RELEASE_URL, ACCEPT_GITHUB) ?: return null
+        val decision = runCatching { JSONObject(NativeBridge.nativeUpdateDecide(installed, json)) }
+            .getOrNull() ?: return null
+        if (!decision.optBoolean("updateAvailable", false)) return null
+        val apkUrl = decision.optString("apkUrl")
+        if (apkUrl.isEmpty()) return null
+        return Available(
+            version = decision.optString("version"),
+            notes = decision.optString("notes"),
+            apkUrl = apkUrl,
+            sha256Url = decision.optString("sha256Url"),
+        )
+    }
+
+    /** Whether the OS will let this app launch an install (the "install unknown apps" grant). */
+    fun canRequestInstall(): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.packageManager.canRequestPackageInstalls()
+        } else {
+            true // pre-O relies on the global "unknown sources" toggle; the installer surfaces it.
+        }
+
+    /** Intent to the per-app "install unknown apps" screen, so the reader can grant it once. */
+    fun unknownSourcesSettingsIntent(): Intent =
+        Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:${context.packageName}"))
+
+    /**
+     * Download [a]'s APK to private cache and verify it: the published SHA-256 (when present) MUST
+     * match, and the signer set MUST equal the installed app's (UPD-FR3/FR4). Returns the verified
+     * file, or `null` on any download/verify failure (the partial file is discarded). Blocking.
+     */
+    fun downloadAndVerify(a: Available): File? {
+        val dir = File(context.cacheDir, UPDATE_DIR).apply { mkdirs() }
+        // One slot, overwritten each attempt — never accumulate stale APKs.
+        val apk = File(dir, "update.apk")
+        if (!download(a.apkUrl, apk)) {
+            apk.delete()
+            return null
+        }
+
+        val apkBytes = runCatching { apk.readBytes() }.getOrNull()
+        if (apkBytes == null) {
+            apk.delete()
+            return null
+        }
+
+        // Checksum gate: a *published* digest must match; an *absent* one falls back to signer-pin
+        // alone (UPD-FR3) — distinguish the two so a missing file is not silently treated as a pass.
+        val checksumText = if (a.sha256Url.isNotEmpty()) fetchText(a.sha256Url, null) else null
+        if (UpdateVerify.expectedShaFrom(checksumText) != null &&
+            !UpdateVerify.matchesPublishedSha(apkBytes, checksumText)
+        ) {
+            Log.w(TAG, "update APK checksum mismatch — discarding")
+            apk.delete()
+            return null
+        }
+
+        // Signer-pin gate: the download must be signed by this app's key, else the OS would reject
+        // it anyway (and a swapped asset is refused before the installer is ever invoked).
+        if (!UpdateVerify.certsMatch(installedSignerCerts(), archiveSignerCerts(apk))) {
+            Log.w(TAG, "update APK signer mismatch — discarding")
+            apk.delete()
+            return null
+        }
+        return apk
+    }
+
+    /**
+     * Hand [apk] to the system installer via a [PackageInstaller] session (streams the bytes — no
+     * FileProvider needed). The OS shows its own final "install?" confirmation; the outcome is
+     * delivered to [UpdateInstallReceiver]. Throws only on a session-open failure the caller logs.
+     */
+    fun install(apk: File) {
+        val installer = context.packageManager.packageInstaller
+        val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+        params.setAppPackageName(context.packageName)
+        val sessionId = installer.createSession(params)
+        installer.openSession(sessionId).use { session ->
+            session.openWrite("inkread", 0, apk.length()).use { out ->
+                apk.inputStream().use { it.copyTo(out) }
+                session.fsync(out)
+            }
+            val intent = Intent(context, UpdateInstallReceiver::class.java).setAction(ACTION_INSTALLED)
+            val flags = PendingIntent.FLAG_UPDATE_CURRENT or
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+            val pending = PendingIntent.getBroadcast(context, sessionId, intent, flags)
+            session.commit(pending.intentSender)
+        }
+    }
+
+    // ── network ───────────────────────────────────────────────────────────────────────────────────
+
+    /** GET [url] as text (capped); `null` on any non-2xx / IO error. [accept] sets the Accept header. */
+    private fun fetchText(url: String, accept: String?): String? = try {
+        val conn = open(url, accept)
+        if (conn.responseCode in 200..299) {
+            conn.inputStream.use { String(it.readBytes(MAX_TEXT_BYTES), Charsets.UTF_8) }
+        } else {
+            Log.w(TAG, "fetch $url -> HTTP ${conn.responseCode}")
+            null
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "fetch $url failed: ${e.message}")
+        null
+    }
+
+    /** Stream [url] to [dest] (capped); `false` on any non-2xx / IO error / oversize. */
+    private fun download(url: String, dest: File): Boolean = try {
+        val conn = open(url, null)
+        if (conn.responseCode !in 200..299) {
+            Log.w(TAG, "download $url -> HTTP ${conn.responseCode}")
+            false
+        } else {
+            conn.inputStream.use { input ->
+                dest.outputStream().use { out ->
+                    var total = 0L
+                    val buf = ByteArray(64 * 1024)
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n < 0) break
+                        total += n
+                        if (total > MAX_APK_BYTES) {
+                            Log.w(TAG, "download $url exceeds ${MAX_APK_BYTES}B cap")
+                            return false
+                        }
+                        out.write(buf, 0, n)
+                    }
+                }
+            }
+            true
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "download $url failed: ${e.message}")
+        false
+    }
+
+    private fun open(url: String, accept: String?): HttpURLConnection =
+        (URL(url).openConnection() as HttpURLConnection).apply {
+            connectTimeout = TIMEOUT_MS
+            readTimeout = TIMEOUT_MS
+            instanceFollowRedirects = true
+            setRequestProperty("User-Agent", USER_AGENT)
+            if (accept != null) setRequestProperty("Accept", accept)
+        }
+
+    /** Bounded `readBytes` so a hostile/huge response cannot exhaust memory (mirrors DailyController). */
+    private fun java.io.InputStream.readBytes(cap: Int): ByteArray {
+        val out = java.io.ByteArrayOutputStream()
+        val buf = ByteArray(16 * 1024)
+        var total = 0
+        while (true) {
+            val n = read(buf)
+            if (n < 0) break
+            total += n
+            if (total > cap) break
+            out.write(buf, 0, n)
+        }
+        return out.toByteArray()
+    }
+
+    // ── signer extraction (signing-cert API moved at API 28) ───────────────────────────────────────
+
+    private fun installedSignerCerts(): List<ByteArray> = runCatching {
+        certBytesOf(context.packageManager.getPackageInfo(context.packageName, signingFlag()))
+    }.getOrDefault(emptyList())
+
+    private fun archiveSignerCerts(apk: File): List<ByteArray> = runCatching {
+        context.packageManager.getPackageArchiveInfo(apk.absolutePath, signingFlag())
+            ?.let { certBytesOf(it) }
+            .orEmpty()
+    }.getOrDefault(emptyList())
+
+    @Suppress("DEPRECATION") // GET_SIGNATURES is the only option below API 28 (minSdk 24).
+    private fun signingFlag(): Int =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            PackageManager.GET_SIGNATURES
+        }
+
+    @Suppress("DEPRECATION")
+    private fun certBytesOf(info: PackageInfo): List<ByteArray> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val signers = info.signingInfo ?: return emptyList()
+            val sigs = if (signers.hasMultipleSigners()) signers.apkContentsSigners
+            else signers.signingCertificateHistory
+            sigs?.map { it.toByteArray() }.orEmpty()
+        } else {
+            info.signatures?.map { it.toByteArray() }.orEmpty()
+        }
+
+    companion object {
+        private const val TAG = "UpdateController"
+
+        /** The project's GitHub releases endpoint (the only place the host is named — IR-7 keeps the
+         *  core unaware; the shell owns the URL). `/latest` already excludes drafts + prereleases. */
+        const val LATEST_RELEASE_URL = "https://api.github.com/repos/j-raghavan/inkread/releases/latest"
+        private const val ACCEPT_GITHUB = "application/vnd.github+json"
+        private const val USER_AGENT = "inkread-updater"
+        private const val ACTION_INSTALLED = "dev.jraghavan.inkread.UPDATE_INSTALLED"
+
+        private const val UPDATE_DIR = "updates"
+        private const val TIMEOUT_MS = 15_000
+        private const val MAX_TEXT_BYTES = 512 * 1024 // release JSON / checksum line
+        private const val MAX_APK_BYTES = 200L * 1024 * 1024 // APK ceiling (guards a hostile stream)
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/UpdateGate.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/UpdateGate.kt
@@ -20,6 +20,12 @@ object UpdateGate {
      *  screen should never wait on the network (UPD-FR6). */
     private const val THROTTLE_MS = 6L * 60 * 60 * 1000 // 6 hours
 
+    /** One reusable daemon thread for all update I/O — never blocks the UI, never leaks a thread per
+     *  check (and a daemon never holds the JVM alive). Update work is sequential, so one suffices. */
+    private val io = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "inkread-update").apply { isDaemon = true }
+    }
+
     /** On-launch check (from [HomeActivity.onResume]): honours the auto-check toggle + throttle. */
     fun maybeCheckOnLaunch(activity: Activity) {
         val ctx = activity.applicationContext
@@ -38,20 +44,39 @@ object UpdateGate {
     private fun runCheck(activity: Activity, manual: Boolean) {
         val ctx = activity.applicationContext
         val controller = UpdateController(ctx)
-        Executors.newSingleThreadExecutor().execute {
-            val available = controller.check()
-            AppSettings.setUpdateLastCheckMs(ctx, System.currentTimeMillis())
+        io.execute {
+            val result = controller.check()
+            // Only a check that actually reached the server advances the throttle — an offline launch
+            // must stay free to retry the moment connectivity returns (UPD-FR9).
+            if (result !is UpdateController.CheckResult.Failed) {
+                AppSettings.setUpdateLastCheckMs(ctx, System.currentTimeMillis())
+            }
             onUi(activity) {
-                when {
-                    available == null -> if (manual) toast(activity, "inkread is up to date")
-                    // A skipped version stays silent on an automatic check, but a manual check always
-                    // surfaces it (the reader explicitly asked).
-                    !manual && available.version == AppSettings.updateSkipVersion(ctx) -> Unit
-                    !manual && AppSettings.autoInstallEffective(ctx) && controller.canRequestInstall() ->
-                        downloadThenInstall(activity, controller, available)
-                    else -> showPrompt(activity, controller, available)
+                when (result) {
+                    is UpdateController.CheckResult.Failed ->
+                        if (manual) toast(activity, "Couldn't check for updates")
+                    is UpdateController.CheckResult.UpToDate ->
+                        if (manual) toast(activity, "inkread is up to date")
+                    is UpdateController.CheckResult.Update -> onUpdate(activity, controller, result.available, manual, ctx)
                 }
             }
+        }
+    }
+
+    /** Route a found update: a skipped version stays silent on an automatic check (a manual one
+     *  always surfaces it); auto-install goes straight to download+install; otherwise prompt. */
+    private fun onUpdate(
+        activity: Activity,
+        controller: UpdateController,
+        a: UpdateController.Available,
+        manual: Boolean,
+        ctx: android.content.Context,
+    ) {
+        when {
+            !manual && a.version == AppSettings.updateSkipVersion(ctx) -> Unit
+            !manual && AppSettings.autoInstallEffective(ctx) && controller.canRequestInstall() ->
+                downloadThenInstall(activity, controller, a)
+            else -> showPrompt(activity, controller, a)
         }
     }
 
@@ -81,7 +106,7 @@ object UpdateGate {
     /** Download + verify off the UI thread, then hand the verified APK to the system installer. */
     private fun downloadThenInstall(activity: Activity, controller: UpdateController, a: UpdateController.Available) {
         toast(activity, "Downloading v${a.version}…")
-        Executors.newSingleThreadExecutor().execute {
+        io.execute {
             val apk = controller.downloadAndVerify(a)
             onUi(activity) {
                 if (apk == null) {

--- a/app/src/main/java/dev/jraghavan/inkread/UpdateGate.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/UpdateGate.kt
@@ -1,0 +1,115 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.widget.Toast
+import java.util.concurrent.Executors
+
+/**
+ * The self-updater's UX policy (ADR-INKREAD-0014 UPD-FR6/FR7/FR8) — the calm, e-ink-first layer over
+ * the mechanism in [UpdateController]. Decides *when* to check (throttled, on launch, off the UI
+ * thread — never background polling) and *how* to surface a result: the in-app "Update available"
+ * prompt, or, under the opt-in auto-update toggle, straight to the system installer.
+ *
+ * Kept off [HomeActivity] so the launch hook is a single call; all blocking work runs on a worker
+ * thread and every UI touch is guarded against a finishing Activity.
+ */
+object UpdateGate {
+
+    /** At most one launch check per window — a sideloaded reader is often offline, and the home
+     *  screen should never wait on the network (UPD-FR6). */
+    private const val THROTTLE_MS = 6L * 60 * 60 * 1000 // 6 hours
+
+    /** On-launch check (from [HomeActivity.onResume]): honours the auto-check toggle + throttle. */
+    fun maybeCheckOnLaunch(activity: Activity) {
+        val ctx = activity.applicationContext
+        if (!AppSettings.autoUpdateCheck(ctx)) return
+        if (System.currentTimeMillis() - AppSettings.updateLastCheckMs(ctx) < THROTTLE_MS) return
+        runCheck(activity, manual = false)
+    }
+
+    /** Manual "Check for updates" (from [SettingsActivity]): ignores the throttle and reports when
+     *  there is nothing newer (UPD-FR8). */
+    fun checkNow(activity: Activity) {
+        Toast.makeText(activity, "Checking for updates…", Toast.LENGTH_SHORT).show()
+        runCheck(activity, manual = true)
+    }
+
+    private fun runCheck(activity: Activity, manual: Boolean) {
+        val ctx = activity.applicationContext
+        val controller = UpdateController(ctx)
+        Executors.newSingleThreadExecutor().execute {
+            val available = controller.check()
+            AppSettings.setUpdateLastCheckMs(ctx, System.currentTimeMillis())
+            onUi(activity) {
+                when {
+                    available == null -> if (manual) toast(activity, "inkread is up to date")
+                    // A skipped version stays silent on an automatic check, but a manual check always
+                    // surfaces it (the reader explicitly asked).
+                    !manual && available.version == AppSettings.updateSkipVersion(ctx) -> Unit
+                    !manual && AppSettings.autoInstallEffective(ctx) && controller.canRequestInstall() ->
+                        downloadThenInstall(activity, controller, available)
+                    else -> showPrompt(activity, controller, available)
+                }
+            }
+        }
+    }
+
+    /** The "Update available" prompt: Install / Skip this version / Later (UPD-FR6). */
+    private fun showPrompt(activity: Activity, controller: UpdateController, a: UpdateController.Available) {
+        AlertDialog.Builder(activity, R.style.InkDialog)
+            .setTitle("Update available — v${a.version}")
+            .setMessage(promptBody(a))
+            .setPositiveButton("Install") { _, _ -> beginInstall(activity, controller, a) }
+            .setNegativeButton("Skip this version") { _, _ ->
+                AppSettings.setUpdateSkipVersion(activity.applicationContext, a.version)
+            }
+            .setNeutralButton("Later", null)
+            .show()
+    }
+
+    /** Start the install flow from the prompt — route to the permission grant if it is not held. */
+    private fun beginInstall(activity: Activity, controller: UpdateController, a: UpdateController.Available) {
+        if (!controller.canRequestInstall()) {
+            toast(activity, "Allow inkread to install apps, then tap Install again")
+            runCatching { activity.startActivity(controller.unknownSourcesSettingsIntent()) }
+            return
+        }
+        downloadThenInstall(activity, controller, a)
+    }
+
+    /** Download + verify off the UI thread, then hand the verified APK to the system installer. */
+    private fun downloadThenInstall(activity: Activity, controller: UpdateController, a: UpdateController.Available) {
+        toast(activity, "Downloading v${a.version}…")
+        Executors.newSingleThreadExecutor().execute {
+            val apk = controller.downloadAndVerify(a)
+            onUi(activity) {
+                if (apk == null) {
+                    toast(activity, "Update download failed — will retry on next launch")
+                } else {
+                    runCatching { controller.install(apk) }
+                        .onFailure { toast(activity, "Couldn't start the installer") }
+                }
+            }
+        }
+    }
+
+    /** Version + a trimmed slice of the release notes — enough to decide, not a wall of text. */
+    private fun promptBody(a: UpdateController.Available): String {
+        val notes = a.notes.trim()
+        if (notes.isEmpty()) return "A newer version of inkread is available."
+        val trimmed = if (notes.length > NOTES_LIMIT) notes.take(NOTES_LIMIT).trimEnd() + "…" else notes
+        return "What's new:\n\n$trimmed"
+    }
+
+    private fun onUi(activity: Activity, block: () -> Unit) {
+        activity.runOnUiThread {
+            if (!activity.isFinishing && !activity.isDestroyed) block()
+        }
+    }
+
+    private fun toast(activity: Activity, msg: String) =
+        Toast.makeText(activity, msg, Toast.LENGTH_SHORT).show()
+
+    private const val NOTES_LIMIT = 600
+}

--- a/app/src/main/java/dev/jraghavan/inkread/UpdateInstallReceiver.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/UpdateInstallReceiver.kt
@@ -1,0 +1,53 @@
+package dev.jraghavan.inkread
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.util.Log
+import java.io.File
+
+/**
+ * Receives the [PackageInstaller] session callback for a self-update (ADR-INKREAD-0014 UPD-FR5).
+ *
+ * The single unavoidable user step on a sideloaded app: when the session reaches
+ * [PackageInstaller.STATUS_PENDING_USER_ACTION] the OS hands back a confirmation intent that we must
+ * launch — that is Android's own "Install update?" dialog (no device-owner ⇒ no silent install).
+ * Terminal statuses just log and tidy the cached APK.
+ */
+class UpdateInstallReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (val status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS, Int.MIN_VALUE)) {
+            PackageInstaller.STATUS_PENDING_USER_ACTION -> {
+                @Suppress("DEPRECATION")
+                val confirm = intent.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+                if (confirm != null) {
+                    confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    context.startActivity(confirm)
+                } else {
+                    Log.w(TAG, "pending user action with no confirmation intent")
+                }
+            }
+
+            PackageInstaller.STATUS_SUCCESS -> {
+                Log.i(TAG, "update installed")
+                clearCache(context)
+            }
+
+            else -> {
+                val msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                Log.w(TAG, "update install failed (status=$status): $msg")
+                clearCache(context)
+            }
+        }
+    }
+
+    /** Drop the staged APK once the session is terminal — never leave it in cache. */
+    private fun clearCache(context: Context) {
+        runCatching { File(context.cacheDir, "updates").deleteRecursively() }
+    }
+
+    private companion object {
+        const val TAG = "UpdateInstall"
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/UpdateInstallReceiver.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/UpdateInstallReceiver.kt
@@ -44,7 +44,7 @@ class UpdateInstallReceiver : BroadcastReceiver() {
 
     /** Drop the staged APK once the session is terminal — never leave it in cache. */
     private fun clearCache(context: Context) {
-        runCatching { File(context.cacheDir, "updates").deleteRecursively() }
+        runCatching { File(context.cacheDir, UpdateController.UPDATE_DIR).deleteRecursively() }
     }
 
     private companion object {

--- a/app/src/main/java/dev/jraghavan/inkread/UpdateVerify.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/UpdateVerify.kt
@@ -1,0 +1,86 @@
+package dev.jraghavan.inkread
+
+import java.security.MessageDigest
+
+/**
+ * Pure integrity checks for a downloaded update APK (ADR-INKREAD-0014 UPD-FR3/FR4). Kept free of
+ * Android types so it is host-unit-tested under `:app:testDebugUnitTest` (the [PalmFilter]
+ * precedent) — the [UpdateController] does the Android I/O (download, PackageManager cert
+ * extraction) and delegates the actual comparisons here.
+ *
+ * Two independent gates must both pass before the system installer is invoked:
+ *  - **checksum** ([matchesPublishedSha]) — the bytes are exactly what the release published;
+ *  - **signer pin** ([certsMatch]) — the APK is signed by *this* installed app's key, the defense
+ *    that makes the debug-key interim (Decision 0) fail closed.
+ */
+object UpdateVerify {
+
+    /** Length of a SHA-256 digest as lowercase hex. */
+    private const val SHA256_HEX_LEN = 64
+
+    /**
+     * Extract the expected hex digest from a `sha256sum`-style checksum file, whose first line is
+     * `"<64-hex>  <filename>"`. Returns the lowercased digest, or `null` if the text carries no
+     * well-formed 64-char hex token — the caller treats `null` as "no checksum published" (fall
+     * back to signer-pin only) and a *present but mismatched* digest as a hard abort, so the two
+     * cases must stay distinguishable.
+     */
+    fun expectedShaFrom(checksumFileText: String?): String? {
+        if (checksumFileText.isNullOrBlank()) return null
+        val token = checksumFileText.trimStart().substringBefore(' ').substringBefore('\n').trim()
+        val hex = token.lowercase()
+        return if (isSha256Hex(hex)) hex else null
+    }
+
+    /** Lowercase hex SHA-256 of [bytes]. */
+    fun sha256Hex(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        val sb = StringBuilder(digest.size * 2)
+        for (b in digest) {
+            val v = b.toInt() and 0xFF
+            sb.append(HEX[v ushr 4]).append(HEX[v and 0x0F])
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Whether [apkBytes] hashes to the digest published in [checksumFileText]. Returns `false` when
+     * the checksum text is missing/malformed — so the caller MUST first decide via [expectedShaFrom]
+     * whether a checksum was published at all (absent ⇒ skip this gate; present ⇒ require a match).
+     */
+    fun matchesPublishedSha(apkBytes: ByteArray, checksumFileText: String?): Boolean {
+        val expected = expectedShaFrom(checksumFileText) ?: return false
+        return constantTimeEquals(expected, sha256Hex(apkBytes))
+    }
+
+    /**
+     * Whether the candidate APK's signer set equals the installed app's signer set. Both lists hold
+     * the raw signing-certificate bytes (`Signature.toByteArray()`); a match requires the same
+     * multiset of certificates and at least one signer on each side (an empty set never matches —
+     * an unsigned or signer-stripped APK is rejected).
+     */
+    fun certsMatch(installed: List<ByteArray>, candidate: List<ByteArray>): Boolean {
+        if (installed.isEmpty() || candidate.isEmpty()) return false
+        if (installed.size != candidate.size) return false
+        val remaining = candidate.toMutableList()
+        for (cert in installed) {
+            val idx = remaining.indexOfFirst { it.contentEquals(cert) }
+            if (idx < 0) return false
+            remaining.removeAt(idx)
+        }
+        return remaining.isEmpty()
+    }
+
+    private fun isSha256Hex(s: String): Boolean =
+        s.length == SHA256_HEX_LEN && s.all { it in '0'..'9' || it in 'a'..'f' }
+
+    /** Length-aware constant-time hex compare (inputs are already lowercased). */
+    private fun constantTimeEquals(a: String, b: String): Boolean {
+        if (a.length != b.length) return false
+        var diff = 0
+        for (i in a.indices) diff = diff or (a[i].code xor b[i].code)
+        return diff == 0
+    }
+
+    private val HEX = "0123456789abcdef".toCharArray()
+}

--- a/app/src/test/java/dev/jraghavan/inkread/UpdateVerifyTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/UpdateVerifyTest.kt
@@ -1,0 +1,84 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for [UpdateVerify] (ADR-INKREAD-0014 UPD-FR3/FR4 integrity gates). Pure logic —
+ * the checksum parse/compute/compare and signer-set equality — exercised without a device, so a
+ * weakened integrity check fails the host gate rather than shipping.
+ */
+class UpdateVerifyTest {
+
+    private val inkreadBytes = "inkread".toByteArray()
+
+    @Test
+    fun sha256_matches_known_vector() {
+        // Compute once and assert the hex shape + determinism rather than hard-coding the digest.
+        val h = UpdateVerify.sha256Hex(inkreadBytes)
+        assertEquals(64, h.length)
+        assertTrue(h.all { it in '0'..'9' || it in 'a'..'f' })
+        assertEquals(h, UpdateVerify.sha256Hex(inkreadBytes)) // stable
+    }
+
+    @Test
+    fun expectedShaFrom_parses_sha256sum_format() {
+        val hex = "a".repeat(64)
+        // `sha256sum` writes "<hex>  <filename>" (two spaces); also tolerate a single space + newline.
+        assertEquals(hex, UpdateVerify.expectedShaFrom("$hex  inkread-v1.0.0.apk\n"))
+        assertEquals(hex, UpdateVerify.expectedShaFrom("$hex inkread.apk"))
+        assertEquals(hex, UpdateVerify.expectedShaFrom("${hex.uppercase()}  FILE")) // lowercased
+    }
+
+    @Test
+    fun expectedShaFrom_rejects_garbage_and_absence() {
+        assertNull(UpdateVerify.expectedShaFrom(null))
+        assertNull(UpdateVerify.expectedShaFrom(""))
+        assertNull(UpdateVerify.expectedShaFrom("   "))
+        assertNull(UpdateVerify.expectedShaFrom("not-a-hash file"))
+        assertNull(UpdateVerify.expectedShaFrom("a".repeat(63) + "  f")) // too short
+        assertNull(UpdateVerify.expectedShaFrom("g".repeat(64) + "  f")) // non-hex
+    }
+
+    @Test
+    fun matchesPublishedSha_true_on_match_false_on_tamper() {
+        val good = UpdateVerify.sha256Hex(inkreadBytes)
+        assertTrue(UpdateVerify.matchesPublishedSha(inkreadBytes, "$good  inkread.apk"))
+        // A single flipped byte must fail.
+        val tampered = inkreadBytes.copyOf().also { it[0] = (it[0] + 1).toByte() }
+        assertFalse(UpdateVerify.matchesPublishedSha(tampered, "$good  inkread.apk"))
+    }
+
+    @Test
+    fun matchesPublishedSha_false_when_no_checksum() {
+        // Absent/malformed checksum is NOT a match — the caller falls back to signer-pin only.
+        assertFalse(UpdateVerify.matchesPublishedSha(inkreadBytes, null))
+        assertFalse(UpdateVerify.matchesPublishedSha(inkreadBytes, "garbage"))
+    }
+
+    @Test
+    fun certsMatch_true_for_same_set_any_order() {
+        val a = byteArrayOf(1, 2, 3)
+        val b = byteArrayOf(4, 5, 6)
+        assertTrue(UpdateVerify.certsMatch(listOf(a, b), listOf(b.copyOf(), a.copyOf())))
+    }
+
+    @Test
+    fun certsMatch_false_on_different_signer() {
+        val installed = listOf(byteArrayOf(1, 2, 3))
+        val attacker = listOf(byteArrayOf(9, 9, 9))
+        assertFalse(UpdateVerify.certsMatch(installed, attacker))
+    }
+
+    @Test
+    fun certsMatch_false_on_empty_or_size_mismatch() {
+        val a = byteArrayOf(1, 2, 3)
+        assertFalse(UpdateVerify.certsMatch(emptyList(), listOf(a)))
+        assertFalse(UpdateVerify.certsMatch(listOf(a), emptyList()))
+        // Subset must not pass (size differs).
+        assertFalse(UpdateVerify.certsMatch(listOf(a), listOf(a.copyOf(), byteArrayOf(7))))
+    }
+}

--- a/inkread-update/Cargo.toml
+++ b/inkread-update/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "inkread-update"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "inkread-update (ADR-INKREAD-0014): decide whether a fetched GitHub releases/latest payload is a newer build than the installed one, and surface its APK + checksum asset URLs. Pure, host-testable, IO- and vendor-free (IR-7) — the Android shell does the fetch/download/install."
+
+[dependencies]
+# Semver comparison of the release tag against the installed version (the decision's core).
+semver = { workspace = true }
+# Parse the GitHub releases/latest payload the shell fetched, and emit the decision JSON the JNI
+# bridge hands back to Kotlin — the same string-over-JNI contract inkread-daily uses.
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/inkread-update/src/lib.rs
+++ b/inkread-update/src/lib.rs
@@ -1,0 +1,268 @@
+//! `inkread-update` (ADR-INKREAD-0014): the **decision** half of the in-app self-updater.
+//!
+//! inkread is sideloaded onto GMS-less Supernote devices, so there is no store to push updates. The
+//! Android shell fetches the project's GitHub `releases/latest` payload and hands the JSON to this
+//! crate, which decides whether that release is a newer build than the installed one and, if so,
+//! surfaces the `.apk` + `.apk.sha256` asset URLs the shell should download. Everything here is
+//! **pure**: no network, no clock, no vendor/host string (IR-7) — the shell owns the URL, the
+//! download, the integrity checks, and the install.
+//!
+//! The public surface is a single string-in/string-out function, [`decide`], matching the
+//! `parse_feed_json` contract `inkread-daily` exposes over the same JNI bridge.
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+/// Decide whether `release_json` (a GitHub `releases/latest` payload) is a newer build than
+/// `installed_version` (the app's `BuildConfig.VERSION_NAME`, e.g. `"0.3.0"`).
+///
+/// Returns the decision as a JSON string (see [`Decision`]). Any unusable input — malformed JSON, an
+/// unparseable tag, a tag that is not strictly newer, or a release with no `.apk` asset — yields
+/// `{"updateAvailable":false}` rather than an error (RR21-FR3: junk in → benign out).
+pub fn decide(installed_version: &str, release_json: &str) -> String {
+    let decision = match serde_json::from_str::<Release>(release_json) {
+        Ok(release) => evaluate(installed_version, &release),
+        Err(_) => Decision::none(),
+    };
+    // Serializing a plain struct of owned strings/bools cannot fail; fall back defensively anyway.
+    serde_json::to_string(&decision).unwrap_or_else(|_| Decision::NONE_JSON.to_string())
+}
+
+/// Pure core of [`decide`] over a parsed [`Release`] — the host-tested seam.
+fn evaluate(installed_version: &str, release: &Release) -> Decision {
+    // A draft release is never published to users; ignore it defensively even though
+    // `releases/latest` excludes drafts on the GitHub side.
+    if release.draft {
+        return Decision::none();
+    }
+
+    let installed = match parse_version(installed_version) {
+        Some(v) => v,
+        // If we cannot parse our own installed version we cannot safely compare — decline rather
+        // than risk nagging with a wrong-direction "update".
+        None => return Decision::none(),
+    };
+    let candidate = match parse_version(&release.tag_name) {
+        Some(v) => v,
+        None => return Decision::none(),
+    };
+    if candidate <= installed {
+        return Decision::none();
+    }
+
+    // An update is only actionable if there is an APK to install. The `.apk.sha256` checksum is
+    // optional (signer-pin verification still gates the install if it is absent).
+    let apk_url = match release.assets.iter().find(|a| is_apk(&a.name)) {
+        Some(asset) => asset.browser_download_url.clone(),
+        None => return Decision::none(),
+    };
+    let sha256_url = release
+        .assets
+        .iter()
+        .find(|a| is_sha256(&a.name))
+        .map(|a| a.browser_download_url.clone())
+        .unwrap_or_default();
+
+    Decision {
+        update_available: true,
+        version: candidate.to_string(),
+        notes: release.body.clone().unwrap_or_default(),
+        apk_url,
+        sha256_url,
+    }
+}
+
+/// Parse a release tag or installed version into a [`Version`], tolerating a single leading `v`/`V`
+/// (the release CI tags `v*`, the installed `VERSION_NAME` is the tag minus that `v`).
+fn parse_version(raw: &str) -> Option<Version> {
+    let trimmed = raw.trim();
+    let body = trimmed
+        .strip_prefix('v')
+        .or_else(|| trimmed.strip_prefix('V'))
+        .unwrap_or(trimmed);
+    Version::parse(body).ok()
+}
+
+/// An installable APK asset — anything ending `.apk` (and, by construction, not `.apk.sha256`).
+fn is_apk(name: &str) -> bool {
+    name.ends_with(".apk")
+}
+
+/// The published checksum sidecar (`<apk>.sha256`, as `sha256sum` writes it).
+fn is_sha256(name: &str) -> bool {
+    name.ends_with(".sha256")
+}
+
+/// The shell-facing decision, serialized to the JSON contract in ADR-INKREAD-0014 Decision 2.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct Decision {
+    #[serde(rename = "updateAvailable")]
+    update_available: bool,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    version: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    notes: String,
+    #[serde(rename = "apkUrl", skip_serializing_if = "String::is_empty")]
+    apk_url: String,
+    #[serde(rename = "sha256Url", skip_serializing_if = "String::is_empty")]
+    sha256_url: String,
+}
+
+impl Decision {
+    const NONE_JSON: &'static str = "{\"updateAvailable\":false}";
+
+    /// The "no update" decision — the single benign result for every unusable input.
+    fn none() -> Self {
+        Decision {
+            update_available: false,
+            version: String::new(),
+            notes: String::new(),
+            apk_url: String::new(),
+            sha256_url: String::new(),
+        }
+    }
+}
+
+/// The slice of the GitHub `releases/latest` payload the decision needs. Unknown fields are ignored.
+#[derive(Debug, Deserialize)]
+struct Release {
+    tag_name: String,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    assets: Vec<Asset>,
+}
+
+/// One release asset (the attached APK and its checksum file).
+#[derive(Debug, Deserialize)]
+struct Asset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A realistic `releases/latest` payload with both assets, parameterized by tag.
+    fn release_json(tag: &str) -> String {
+        let base = format!("https://example.test/{tag}");
+        serde_json::json!({
+            "tag_name": tag,
+            "draft": false,
+            "prerelease": false,
+            "body": format!("### inkread {tag}\n- fixes"),
+            "assets": [
+                {"name": format!("inkread-{tag}.apk"), "browser_download_url": format!("{base}/inkread-{tag}.apk")},
+                {"name": format!("inkread-{tag}.apk.sha256"), "browser_download_url": format!("{base}/inkread-{tag}.apk.sha256")},
+            ],
+        })
+        .to_string()
+    }
+
+    /// Parse the JSON `decide` returns back into a typed view for assertions.
+    fn decision_of(installed: &str, json: &str) -> Decision {
+        let s = decide(installed, json);
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        Decision {
+            update_available: v["updateAvailable"].as_bool().unwrap(),
+            version: v["version"].as_str().unwrap_or_default().to_string(),
+            notes: v["notes"].as_str().unwrap_or_default().to_string(),
+            apk_url: v["apkUrl"].as_str().unwrap_or_default().to_string(),
+            sha256_url: v["sha256Url"].as_str().unwrap_or_default().to_string(),
+        }
+    }
+
+    #[test]
+    fn newer_tag_is_offered_with_asset_urls() {
+        let d = decision_of("0.3.0", &release_json("v0.4.0"));
+        assert!(d.update_available);
+        assert_eq!(d.version, "0.4.0");
+        assert_eq!(d.apk_url, "https://example.test/v0.4.0/inkread-v0.4.0.apk");
+        assert_eq!(
+            d.sha256_url,
+            "https://example.test/v0.4.0/inkread-v0.4.0.apk.sha256"
+        );
+        assert!(d.notes.contains("fixes"));
+    }
+
+    #[test]
+    fn equal_version_is_not_offered() {
+        assert!(!decision_of("0.4.0", &release_json("v0.4.0")).update_available);
+    }
+
+    #[test]
+    fn older_tag_is_not_offered() {
+        assert!(!decision_of("0.5.0", &release_json("v0.4.0")).update_available);
+    }
+
+    #[test]
+    fn v_prefix_is_tolerated_on_both_sides() {
+        // Installed "v0.3.0" (defensive) vs tag "0.4.0" (no v) still compares correctly.
+        assert!(decision_of("v0.3.0", &release_json("0.4.0")).update_available);
+    }
+
+    #[test]
+    fn prerelease_installed_upgrades_to_stable() {
+        // The M0 build ships VERSION_NAME "0.1.0-m0"; a "0.1.0" release supersedes it (semver: a
+        // prerelease precedes its release).
+        assert!(decision_of("0.1.0-m0", &release_json("v0.1.0")).update_available);
+    }
+
+    #[test]
+    fn stable_is_not_downgraded_to_a_prerelease_of_same_version() {
+        // 0.1.0 installed vs a 0.1.0-rc tag: the rc is *older* than the release → not offered.
+        assert!(!decision_of("0.1.0", &release_json("v0.1.0-rc.1")).update_available);
+    }
+
+    #[test]
+    fn missing_apk_asset_is_not_offered() {
+        let json = r#"{"tag_name":"v9.0.0","draft":false,"assets":[
+            {"name":"notes.txt","browser_download_url":"https://example.test/notes.txt"}]}"#;
+        assert!(!decision_of("0.3.0", json).update_available);
+    }
+
+    #[test]
+    fn missing_checksum_still_offers_with_empty_sha_url() {
+        let json = r#"{"tag_name":"v9.0.0","draft":false,"assets":[
+            {"name":"inkread-v9.0.0.apk","browser_download_url":"https://example.test/a.apk"}]}"#;
+        let d = decision_of("0.3.0", json);
+        assert!(d.update_available);
+        assert!(d.sha256_url.is_empty());
+    }
+
+    #[test]
+    fn draft_release_is_ignored() {
+        let json = r#"{"tag_name":"v9.0.0","draft":true,"assets":[
+            {"name":"inkread-v9.0.0.apk","browser_download_url":"https://example.test/a.apk"}]}"#;
+        assert!(!decision_of("0.3.0", json).update_available);
+    }
+
+    #[test]
+    fn malformed_json_is_benign() {
+        assert_eq!(decide("0.3.0", "not json at all"), Decision::NONE_JSON);
+        assert_eq!(decide("0.3.0", ""), Decision::NONE_JSON);
+        assert_eq!(decide("0.3.0", "{}"), Decision::NONE_JSON);
+    }
+
+    #[test]
+    fn unparseable_installed_version_declines() {
+        assert!(!decision_of("not-a-version", &release_json("v9.0.0")).update_available);
+    }
+
+    #[test]
+    fn unparseable_tag_declines() {
+        let json = r#"{"tag_name":"latest","draft":false,"assets":[
+            {"name":"inkread.apk","browser_download_url":"https://example.test/a.apk"}]}"#;
+        assert!(!decision_of("0.3.0", json).update_available);
+    }
+
+    #[test]
+    fn none_decision_serializes_without_empty_fields() {
+        // The benign result is exactly the documented constant — no null/empty noise the shell
+        // must special-case.
+        assert_eq!(decide("0.3.0", "garbage"), "{\"updateAvailable\":false}");
+    }
+}

--- a/reader-core/Cargo.toml
+++ b/reader-core/Cargo.toml
@@ -26,6 +26,9 @@ inkread-ink = { workspace = true }
 # inkread-daily (#66): RSS/Atom parse + readability extraction + issue→EPUB assembly, reached over
 # the JNI bridge so the shell can compile a daily issue. Pure Rust; cross-compiles clean.
 inkread-daily = { workspace = true }
+# inkread-update (ADR-INKREAD-0014): the self-updater's pure decision, reached over the JNI bridge —
+# the shell fetches the GitHub release JSON, the core decides if it is newer. Pure Rust.
+inkread-update = { workspace = true }
 # EPUB backend: parsing + reflow layout + glyph rasterization (RR2-FR5). Pure Rust; the EpubBackend
 # adapter (document/reflow) maps it to the Document trait.
 inkread-epub = { workspace = true }

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -371,6 +371,25 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeDailyAssemb
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeUpdateDecide(installedVersion, releaseJson) : String — decide whether a fetched GitHub
+// releases/latest payload is a newer build than the installed one (ADR-INKREAD-0014 UPD-FR2). The
+// shell does the network fetch; the core only compares (semver) and returns the decision JSON
+// (`{"updateAvailable":…}`). Junk in -> `{"updateAvailable":false}`, never a throw (RR21-FR3).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeUpdateDecide<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    installed_version: JString<'local>,
+    release_json: JString<'local>,
+) -> JString<'local> {
+    env.with_env(|env| -> jni::errors::Result<JString<'local>> {
+        let installed: String = installed_version.try_to_string(env)?;
+        let json: String = release_json.try_to_string(env)?;
+        env.new_string(inkread_update::decide(&installed, &json))
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // =====================================================================================
 // nativeRenderPage(handle, directBuffer) — render the current page into the direct
 // ByteBuffer the shell locked. The PixelBuffer borrow never outlives this call (Amendment 5).


### PR DESCRIPTION
## In-app GitHub self-updater

inkread is sideloaded onto GMS-less Supernote devices, so there is no store to deliver fixes. This adds an in-app updater that checks the project's GitHub Releases and, on the reader's say-so (or under an opt-in auto-update toggle), downloads and installs a newer **signed** APK.

### Architecture (mirrors the daily companion #66)
The Rust core only *decides*; the Kotlin shell does all I/O (IR-7).

- **`inkread-update` (new crate):** pure, host-tested `decide(installedVersion, releaseJson) → decisionJson` — parses the `releases/latest` payload, semver-compares the tag, and surfaces the `.apk` + `.apk.sha256` asset URLs. IO/vendor-free; reuses `semver` + `serde_json`.
- **`nativeUpdateDecide` JNI bridge:** exposes `decide` over the existing seam; boundary errors resolve to `{"updateAvailable":false}` (never unwinds across JNI, RR21-FR3). reader-core still builds host-only without the `jni-bridge` feature.
- **`UpdateController`:** fetch → decide → download to private cache → verify → `PackageInstaller` session hand-off.
- **`UpdateGate`:** UX policy — throttled on-launch check, prompt vs auto-install routing, permission gating.
- **`HttpFetch`:** shared bounded HTTP GET; `UpdateController` and `DailyController` now use it instead of duplicating fetch/timeout/UA/`readBytes`.

### Integrity (two independent gates, both required before install)
1. **SHA-256** against the published `.apk.sha256` (a *present* digest must match; an *absent* one falls back to the signer pin — the two cases are kept distinct).
2. **Signer pin** — the downloaded APK's `apkContentsSigners` must equal the installed app's. Compared symmetrically so a future key rotation can't false-reject.

### UX
- **Default (notify):** on launch, a throttled (≤1/6h) off-thread check; a newer release shows an `InkDialog` — version + release notes — with **Install / Skip this version / Later**.
- **Auto-update (opt-in, default off):** Settings toggle; a detected release is downloaded + verified and sent straight to the system installer.
- Android always shows its own final "Install update?" confirmation — a sideloaded app has no device-owner, so silent install is not possible.
- Settings → Updates: "Check for updates automatically" (on), "Install updates automatically" (off, interlocked with the former), and a manual "Check for updates now".
- `check()` distinguishes *failed/offline* from *up-to-date*, so an offline launch does not burn the throttle and a manual check reports honestly.

### Release signing (prerequisite — wired here)
The updater requires a stable release key (Android rejects an update whose signer differs from the installed app).

- `app/build.gradle.kts`: a `release` signingConfig reads the keystore + credentials from env/gradle props; falls back to the debug key when unset, so local `buildApk.sh` is unchanged.
- `release.yml`: decodes the `INKREAD_KEYSTORE_BASE64` secret to an ephemeral file and exports the signing vars; release notes reflect the actual signing status.
- The four `INKREAD_*` repo secrets are configured, so the next tagged release is production-signed.

### Gates run
- Rust: `cargo fmt`/`clippy -D warnings`/`test` — `inkread-update` 13 host tests; reader-core clippy (jni-bridge) + host-only build.
- Kotlin: `:app:testDebugUnitTest` — `UpdateVerify` 8 tests; `:app:compileDebugKotlin`.
- Gradle signing verified both paths via `:app:signingReport` (debug fallback; release config with a keystore).

### Scope / follow-ups
- **Device verification pending:** the download/`PackageInstaller`/OS-confirm flow cannot be host-tested (no Android SDK in the Rust gate, no emulator for the device path) — needs a manual run on a Supernote once a production-signed release exists.
- **Migration:** existing **debug-signed** installs cannot auto-update to the first production-signed build (signer change) — they need a one-time uninstall + reinstall; updates flow in place after that.
- Design doc: `spec/adr/ADR-INKREAD-0014` (gitignored).
