### PR TITLE
feat(daily): show a Compiling… notice while the issue builds

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
@@ -2,6 +2,7 @@ package dev.jraghavan.inkread
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.Typeface
@@ -48,6 +49,12 @@ class DailyActivity : Activity() {
 
     private val daily by lazy { DailyController(this) }
 
+    /** The "Compiling…" busy notice — a compile takes seconds (network fetch + native assembly), so
+     *  without it the screen looks frozen after the tap. Guarded so a re-tap can't start a second
+     *  concurrent compile ([DailyController.compile] spawns a fresh worker per call). */
+    private var compileDialog: Dialog? = null
+    private var compileInProgress = false
+
     private var scale = 1f
     private fun dim(u: Number) = dp((u.toFloat() * scale).toInt()).coerceAtLeast(1)
     private fun fs(u: Number) = u.toFloat() * scale
@@ -61,6 +68,19 @@ class DailyActivity : Activity() {
     override fun onResume() {
         super.onResume()
         setContentView(buildView()) // refresh after returning (a freshly compiled issue, etc.)
+        // Returning while a compile is still running (onPause dropped the dialog window): re-show
+        // the notice, otherwise the screen looks idle while the guard silently swallows re-taps.
+        if (compileInProgress && compileDialog == null) {
+            compileDialog = Ink.progressDialog(this, "Compiling today's issue…")
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // Drop the dialog window before the activity goes away (leak guard); the compile itself
+        // keeps running and its completion callback still refreshes the view / toasts the result.
+        compileDialog?.let { runCatching { it.dismiss() } }
+        compileDialog = null
     }
 
     private fun buildView(): View {
@@ -414,13 +434,18 @@ class DailyActivity : Activity() {
     )
 
     private fun compileFlow() {
+        if (compileInProgress) return // one compile at a time; the dialog is already up
         if (daily.sources().isEmpty()) {
             suggestedSourcesDialog()
             return
         }
-        Toast.makeText(this, "Compiling today's issue…", Toast.LENGTH_SHORT).show()
+        compileInProgress = true
+        compileDialog = Ink.progressDialog(this, "Compiling today's issue…")
         daily.compile { ok, msg ->
             runOnUiThread {
+                compileDialog?.let { runCatching { it.dismiss() } }
+                compileDialog = null
+                compileInProgress = false
                 Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
                 if (ok) setContentView(buildView())
             }

--- a/app/src/main/java/dev/jraghavan/inkread/Ink.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Ink.kt
@@ -1,5 +1,6 @@
 package dev.jraghavan.inkread
 
+import android.app.Dialog
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
@@ -7,6 +8,7 @@ import android.graphics.drawable.GradientDrawable
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.widget.LinearLayout
 import android.widget.TextView
 
@@ -96,6 +98,26 @@ object Ink {
     fun gap(ctx: Context, h: Int): View =
         View(ctx).apply {
             layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(h))
+        }
+
+    /** A non-cancelable busy notice ("Reflowing…", "Compiling…") on the white card, shown
+     *  immediately; the caller keeps the returned dialog and dismisses it when the work completes.
+     *  The explicit light window background matters: without it the dialog renders as a black box
+     *  on this e-ink theme (#55). */
+    fun progressDialog(ctx: Context, message: String): Dialog =
+        Dialog(ctx).apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setCancelable(false)
+            setContentView(
+                TextView(ctx).apply {
+                    text = message
+                    textSize = 16f
+                    setTextColor(ink)
+                    setPadding(dp(28), dp(22), dp(28), dp(22))
+                },
+            )
+            window?.setBackgroundDrawable(cardBg())
+            runCatching { show() }
         }
 
     /** A pill button — filled (black) for the primary action, outlined for secondary. */

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -133,23 +133,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     /** Shows the "Reflowing…" notice — posted with a short delay so a fast reflow never flashes it. */
     private val showReflowProgress = Runnable {
         if (isFinishing || docHandle == 0L) return@Runnable
-        val d = resources.displayMetrics.density
-        fun px(v: Int) = (v * d).toInt()
-        val msg = TextView(this).apply {
-            text = "Reflowing…"
-            textSize = 16f
-            setTextColor(Ink.ink) // black text on the white card below
-            setPadding(px(28), px(22), px(28), px(22))
-        }
-        reflowProgressDialog = Dialog(this).apply {
-            requestWindowFeature(Window.FEATURE_NO_TITLE)
-            setCancelable(false)
-            setContentView(msg)
-            // Without an explicit light window background the dialog renders as a black box on this
-            // e-ink theme; use the app's white card (matches the other sheets) (#55).
-            window?.setBackgroundDrawable(Ink.cardBg())
-            runCatching { show() }
-        }
+        reflowProgressDialog = Ink.progressDialog(this, "Reflowing…")
     }
 
     // ---- dictionary (RR12 / D4) — owns the corpus handle + lookup/define/manage UI (SRP) ----


### PR DESCRIPTION
## Problem

Compiling a Daily issue takes seconds (feed fetch + native assembly), and the only feedback was a transient toast — the screen looked frozen after the tap, and nothing stopped a second tap from starting a concurrent compile (#66 follow-up).

## What changed

- **`Ink.progressDialog(context, message)`**: the Reader's inline "Reflowing…" busy dialog (#55) lifted into a shared builder — same non-cancelable white-card presentation, reusable by any surface running multi-second work. `ReaderActivity` now uses it; its 250 ms delayed-show policy and `isFinishing`/handle guards are unchanged.
- **`DailyActivity.compileFlow()`**: shows "Compiling today's issue…" via the shared helper from all three compile entry points (compile prompt, Today's Desk Regenerate/Compile, the primary tile), dismisses it in the completion callback before the view rebuild, and keeps the result toast for status/errors.
- **Re-tap guard**: `compileInProgress` blocks a second concurrent compile (`DailyController.compile` spawns a fresh worker per call). The guard always clears — the controller invokes the callback on both success and failure paths.
- **Lifecycle**: `onPause` drops the dialog window (leak guard) while the compile keeps running; `onResume` re-shows the notice if a compile is still in flight, so returning mid-compile never looks idle while taps are being swallowed.

## Tests

`:app:compileReleaseKotlin` green; APK built and installed on a Supernote Nomad — dialog appears on tap, persists across leave/return, and dismisses on the completion toast.
