### PR TITLE
fix(daily): interleave articles round-robin across sources

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
@@ -133,6 +133,11 @@ class DailyController(private val context: Context) {
         val articles = JSONArray()
         var feedsReached = 0
         var itemsFound = 0
+        // Collected per source first, then interleaved below (#107): appending source-by-source put
+        // late-list sources' articles at the tail, and the front page stores only the first
+        // HEADLINES_SHOWN headlines — so a newly added feed could compile into the issue yet never
+        // appear on the front page. Round-robin gives every source front-of-issue presence.
+        val perSource = mutableListOf<List<JSONObject>>()
         try {
             for (src in active) {
                 val reached = booleanArrayOf(false)
@@ -155,13 +160,18 @@ class DailyController(private val context: Context) {
                             .put("html", html)
                     }
                 }
-                pool.invokeAll(tasks).forEach { f ->
-                    runCatching { f.get() }.getOrNull()?.let { articles.put(it) }
-                }
+                perSource.add(pool.invokeAll(tasks).mapNotNull { f -> runCatching { f.get() }.getOrNull() })
             }
         } finally {
             pool.shutdown()
             pool.awaitTermination(2, TimeUnit.SECONDS)
+        }
+        // Interleave: every source's 1st article, then every source's 2nd, … Source order still
+        // decides ties, so the issue keeps a stable, predictable reading order.
+        for (rank in 0 until PER_SOURCE) {
+            for (list in perSource) {
+                list.getOrNull(rank)?.let { articles.put(it) }
+            }
         }
         Log.i(TAG, "compile: feedsReached=$feedsReached itemsFound=$itemsFound articles=${articles.length()}")
         // Specific failure messages so the cause is obvious without a logcat.


### PR DESCRIPTION
## Problem

While investigating #107 ("feeds don't appear in Daily"): `compileBlocking` appended articles source-by-source in source-list order, and the front page stores only the first `HEADLINES_SHOWN` (60) headlines. Newly added sources go to the end of the list, so a user following enough sources (~13+, given `PER_SOURCE = 5`) could compile a new feed's articles into the issue EPUB while its headlines were entirely truncated off the front page — indistinguishable from "the feed doesn't work".

## What changed

`compileBlocking` now collects each source's fetched articles into a per-source list, then builds the issue round-robin: every source's 1st article, then every source's 2nd, and so on. Ties keep source-list order, so the reading order stays stable and predictable. Headline truncation now trims the deepest ranks evenly across all sources instead of dropping whole tail sources.

The fetch pipeline (parallel article fetches per source, per-source cap, error handling) is unchanged — only the assembly order moved out of the fetch loop.

## Verification

Feed pipeline verified end-to-end against the #107 feeds (techpowerup.com news + reviews): fetch with the app's UA, feed-rs parse (80/50 items), article fetch, extraction, assembly, and an on-device compile producing the issue with headlines from both feeds. `:app:compileReleaseKotlin` green.
