### PR TITLE
Review Feedback R2: spec index, CI packaging check, ReaderActivity decomposition, release checklist, e-ink limits docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ Closes #
 - [ ] `cargo test --workspace` is green
 - [ ] Added/updated a test that fails without this change (for bugs/new behaviour)
 - [ ] Verified on a device (Supernote) — _or_ host-only change, N/A
+      (release PRs: run [`docs/RELEASE-SMOKE-CHECKLIST.md`](../docs/RELEASE-SMOKE-CHECKLIST.md))
 
 ## Pre-merge checklist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 # Host-first CI (RR29-FR3): the Rust core builds + tests on the host with NO Android SDK
 # (RR1-AC3), then the JNI bridge is cross-checked for the device target, and the license
-# manifest is verified (RR18-AC2). The full APK build is intentionally out of this gate for
-# M0 (it needs the NDK + a device to be meaningful); CI proves the core + the seams.
+# manifest is verified (RR18-AC2). The apk-assemble job builds an UNSIGNED debug APK through
+# the canonical ./buildApk.sh pipeline so Gradle ↔ JNI ↔ pdfium packaging regressions fail
+# here instead of at release time — signing and on-device behavior stay release/manual concerns.
 #
 # The pdfium render tests (open/render/DRM/corrupt) SKIP unless PDFIUM_DYNAMIC_LIB_PATH is
 # set, so the `host` job fetches the BSD bblanchon libpdfium and re-runs them with the env
@@ -127,6 +128,51 @@ jobs:
       # (ADR Decision 2); a new dep with an unvetted license fails the build (RR18-AC2).
       - name: Verify dependency licenses against the allowlist
         run: ./scripts/check-licenses.sh
+
+  apk-assemble:
+    name: assemble debug APK (packaging check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+      # Same NDK resolution as release.yml — buildApk.sh drives cargo-ndk off ANDROID_NDK_HOME.
+      - name: Configure Android NDK
+        run: |
+          set -euo pipefail
+          ndk="${ANDROID_NDK_LATEST_HOME:-${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}}"
+          test -n "$ndk" || { echo "::error::No Android NDK found on the runner"; exit 1; }
+          echo "ANDROID_NDK_HOME=$ndk" >> "$GITHUB_ENV"
+          echo "Using NDK: $ndk"
+      # The canonical pipeline (cargo-ndk → pinned libpdfium staging → Gradle), debug variant:
+      # unsigned, no keystore secrets, same packaging path the release build takes.
+      - name: Build debug APK (./buildApk.sh --debug)
+        run: |
+          chmod +x ./buildApk.sh
+          ./buildApk.sh --debug
+      # The point of the job: the APK must actually CONTAIN the native libs Gradle is meant
+      # to package — a silent jniLibs/sourceSets/packaging regression otherwise ships a
+      # reader that dies on loadLibrary at first launch.
+      - name: Assert native libs packaged in the APK
+        run: |
+          set -euo pipefail
+          apk="$(find app/build/outputs/apk/debug -type f -name '*.apk' -print -quit)"
+          test -n "$apk" || { echo "::error::No APK produced under app/build/outputs/apk/debug"; exit 1; }
+          listing="$(unzip -l "$apk")"
+          for lib in lib/arm64-v8a/libreader.so lib/arm64-v8a/libpdfium.so; do
+            echo "$listing" | grep -q "$lib" || { echo "::error::$lib missing from $apk"; exit 1; }
+          done
+          echo "APK OK: $apk contains libreader.so + libpdfium.so (arm64-v8a)"
 
   android-unit-tests:
     name: android unit tests (host JVM)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,10 @@ name: CI
 
 # Host-first CI (RR29-FR3): the Rust core builds + tests on the host with NO Android SDK
 # (RR1-AC3), then the JNI bridge is cross-checked for the device target, and the license
-# manifest is verified (RR18-AC2). The apk-assemble job builds an UNSIGNED debug APK through
-# the canonical ./buildApk.sh pipeline so Gradle ↔ JNI ↔ pdfium packaging regressions fail
-# here instead of at release time — signing and on-device behavior stay release/manual concerns.
+# manifest is verified (RR18-AC2). The apk-assemble job builds a debug APK (debug-keystore
+# signed; no release secrets) through the canonical ./buildApk.sh pipeline so Gradle ↔ JNI ↔
+# pdfium packaging regressions fail here instead of at release time — release signing and
+# on-device behavior stay release/manual concerns.
 #
 # The pdfium render tests (open/render/DRM/corrupt) SKIP unless PDFIUM_DYNAMIC_LIB_PATH is
 # set, so the `host` job fetches the BSD bblanchon libpdfium and re-runs them with the env
@@ -155,7 +156,7 @@ jobs:
           echo "ANDROID_NDK_HOME=$ndk" >> "$GITHUB_ENV"
           echo "Using NDK: $ndk"
       # The canonical pipeline (cargo-ndk → pinned libpdfium staging → Gradle), debug variant:
-      # unsigned, no keystore secrets, same packaging path the release build takes.
+      # debug-keystore signed, no release secrets, same packaging path the release build takes.
       - name: Build debug APK (./buildApk.sh --debug)
         run: |
           chmod +x ./buildApk.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
 # Build the signed APK and publish a GitHub Release with auto-generated notes when a
-# v* tag is pushed (or via manual dispatch). Mirrors the local `./buildApk.sh` pipeline:
+# v* tag is pushed (or via manual dispatch). Before tagging, run the on-device pass in
+# docs/RELEASE-SMOKE-CHECKLIST.md — CI proves the host + packaging, never the EPD/pen behavior.
+# Mirrors the local `./buildApk.sh` pipeline:
 # cargo-ndk builds libreader.so → the pinned BSD libpdfium is fetched + sha256-verified →
 # the dictionary corpus is staged → Gradle assembles the APK. The APK is attached to the
 # Release so anyone can sideload it without a toolchain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ You don't have to write Rust to help:
 | Contribution                | Examples                                                              |
 | --------------------------- | --------------------------------------------------------------------- |
 | 🐛 **Bug reports**          | Crashes, wrong layout, ink that doesn't render, a refresh that ghosts |
-| 💡 **Feature ideas**        | See [`spec/NEOREADER-FEATURE-BACKLOG.md`] for the roadmap             |
+| 💡 **Feature ideas**        | See the open [milestones and issues] for the roadmap                  |
 | 📝 **Docs**                 | Clarify a confusing README/spec, fix a typo, improve this guide       |
 | 🧪 **Tests / fixtures**     | A PDF/EPUB that breaks reflow is a *gift* — add it as a golden test   |
 | 🦀 **Rust core**            | Parsing, reflow, ink, refresh policy, dictionary, Lua plugin API      |
@@ -84,8 +84,10 @@ Two rules fall out of this split and they shape almost every review comment:
 
 > The canonical design lives in `spec/` (gitignored, not in this repo): `SPEC-INKREAD.md` plus the
 > `ADR-INKREAD-*` set and the `RR` requirement ledger. PRs reference requirements by number
-> (e.g. *RR5-FR1*, *ADR-0010*). If you're an external contributor and need a requirement clarified,
-> ask in the issue/PR — a maintainer will quote the relevant contract.
+> (e.g. *RR5-FR1*, *ADR-0010*). **[`docs/SPEC-INDEX.md`](./docs/SPEC-INDEX.md) is the public,
+> redacted index of every citable ID** — start there to resolve any `RR…`/`ADR-…`/`IR-…` citation.
+> If a summary there is too thin, ask in the issue/PR — a maintainer will quote the relevant
+> contract.
 
 ---
 
@@ -255,4 +257,4 @@ security issues in the public tracker.
 
 Welcome aboard — we're glad you're here. 🚀
 
-[`spec/NEOREADER-FEATURE-BACKLOG.md`]: ./spec/NEOREADER-FEATURE-BACKLOG.md
+[milestones and issues]: https://github.com/j-raghavan/inkread/milestones

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ https://github.com/user-attachments/assets/4381ee07-3683-45ef-9fa4-9ed7cdd11295
 | Annotation portability | **Written into the PDF** + portable sidecar | Sidecar metadata | Proprietary, locked-in |
 | Document reading (PDF reflow, dictionary) | Yes | **Mature** | Limited |
 | Daily reading companion (RSS → on-device issue) | **Built-in** (InkRead Daily) | Plugin (NewsDownloader) | No |
-| E-ink refresh control | Vendor-neutral policy in core | **Excellent** | Native / vendor-optimal |
+| E-ink refresh control | Vendor-neutral policy in core ([platform-capped](./docs/EINK-LIMITS.md)) | **Excellent** (on devices that allow it) | Native / vendor-optimal |
 | Extensibility | Native Lua API + selected KOReader-shim | **Huge Lua ecosystem** | None (closed) |
 | Architecture | Rust core, host-testable | C + Lua | Closed-source |
 | Open source | **AGPL-3.0** | **AGPL-3.0** | Proprietary |
@@ -123,7 +123,9 @@ https://github.com/user-attachments/assets/4381ee07-3683-45ef-9fa4-9ed7cdd11295
 
 > Honest take: KOReader is the more mature *reader* and runs on far more hardware; the Supernote
 > reader is the more polished *native* experience. inkread is the **only one of the three that's both
-> open and built handwriting-first**, and it's **early** — see status below.
+> open and built handwriting-first**, and it's **early** — see status below. Pen latency rides the
+> firmware's own sub-frame ink path; refresh tuning is capped by what the platform exposes to
+> sideloaded apps — [docs/EINK-LIMITS.md](./docs/EINK-LIMITS.md) states those limits plainly.
 
 inkread is **not** a KOReader clone. KOReader is prior art and compatibility inspiration; inkread
 reuses its plugin *style* (a selected `.koplugin` shim) but ships its own Rust-native engine.

--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -1,0 +1,519 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.app.Dialog
+import android.content.pm.ActivityInfo
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.widget.Toast
+
+/**
+ * The KOReader-style tabbed document-settings sheet (RR4), extracted from `ReaderActivity` (SRP):
+ * one bottom-bar entry consolidates the document controls (Style / Rotate / Crop / Zoom / Page /
+ * Font / Display). Owns the tab panels, the segmented / cell-bar / settings-row widgets, the style
+ * presets, and the reflow font-scale application. Page geometry stays in the shell — the reflow
+ * toggle and zoom mutations go through [Host].
+ *
+ * Threading mirrors the original inline code: panels are built on the UI thread; native calls run
+ * on the engine thread via [Host.engineExecute].
+ */
+class AdjustSheetController(private val host: Host) {
+
+    /** What the settings sheet needs from the reader shell. */
+    interface Host {
+        /** Context for dialogs/toasts/resources, `runOnUiThread`, `requestedOrientation`. */
+        val activity: Activity
+
+        /** The open document handle (`0` = none); read live per call. */
+        val docHandle: Long
+
+        /** The persisted display/typography settings. */
+        val prefs: DisplayPrefs
+
+        /** Whether PDF reflow mode is currently on (ADR-INKREAD-0011). */
+        val reflowOn: Boolean
+
+        /** Current zoom as a percentage, for the Zoom tab's label. */
+        val zoomPercent: Int
+
+        /** Run [block] on the single engine thread (serializes native access). */
+        fun engineExecute(block: () -> Unit)
+
+        /** Re-render + blit the current page (any thread). */
+        fun repaintPanel()
+
+        /** Engine thread only: re-read the page count after a repagination. */
+        fun refreshPageCount()
+
+        /** Toggle PDF reflow; owns the zoom/pan/progress-dialog state the toggle disturbs. */
+        fun setReflowMode(on: Boolean)
+
+        /** Zoom one step in/out (the shell owns the zoom model + step constant). */
+        fun zoomIn()
+
+        fun zoomOut()
+
+        /** No document open: fall back to the system file picker. */
+        fun openPicker()
+
+        /** Wrap dialog content so a resting palm can't tap through it (mirrors the bottom bar). */
+        fun palmGuard(content: View): View
+
+        /** Verbose diagnostic log, gated by the shell's `DIAG` flag. */
+        fun diag(msg: () -> String)
+    }
+
+    private val activity: Activity get() = host.activity
+    private val prefs: DisplayPrefs get() = host.prefs
+
+    /**
+     * A KOReader-style tabbed settings sheet that consolidates the document controls
+     * (Rotate / Fit / Font / Display) behind one bottom-bar entry — matching KOReader's bottom
+     * sheet structure. Each tab swaps an inline control panel; changes apply live + persist.
+     */
+    fun show() {
+        if (host.docHandle == 0L) { host.openPicker(); return }
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val dialog = Dialog(activity).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+        val content = android.widget.FrameLayout(activity)
+
+        val panels: List<Triple<String, Int, () -> View>> = listOf(
+            Triple("Style", R.drawable.ic_menu_adjust) { stylePanel() },
+            Triple("Rotate", R.drawable.ic_menu_rotate) { rotationPanel() },
+            Triple("Crop", R.drawable.ic_menu_crop) { cropPanel() },
+            Triple("Zoom", R.drawable.ic_menu_fit) { zoomPanel() },
+            Triple("Page", R.drawable.ic_menu_page) { pagePanel() },
+            Triple("Font", R.drawable.ic_menu_font) { fontPanel() },
+            Triple("Display", R.drawable.ic_menu_display) { displayPanel() },
+        )
+        val cells = ArrayList<LinearLayout>()
+        fun select(i: Int) {
+            content.removeAllViews()
+            content.addView(panels[i].third())
+            cells.forEachIndexed { j, c ->
+                // Active tab: white, boxed (connected to the panel) + bold label. Inactive: flat gray.
+                if (j == i) {
+                    c.background = GradientDrawable().apply {
+                        setColor(Ink.paper); setStroke(Ink.keyline(), Ink.ink)
+                    }
+                } else {
+                    c.background = null
+                    c.setBackgroundColor(Ink.fill)
+                }
+                val tab = c.getChildAt(1) as? TextView
+                tab?.setTypeface(Ink.mono, if (j == i) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
+                tab?.setTextColor(if (j == i) Ink.ink else Ink.inkSoft)
+            }
+        }
+        val tabRow = LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setBackgroundColor(Ink.fill)
+        }
+        panels.forEachIndexed { i, (label, icon, _) ->
+            val cell = LinearLayout(activity).apply {
+                orientation = LinearLayout.VERTICAL; gravity = Gravity.CENTER
+                setPadding(dp(4), dp(10), dp(4), dp(10)); isClickable = true
+                setOnClickListener { select(i) }
+                addView(
+                    ImageView(activity).apply { setImageResource(icon); setColorFilter(Ink.ink) },
+                    LinearLayout.LayoutParams(dp(24), dp(24)),
+                )
+                addView(TextView(activity).apply {
+                    text = label; textSize = 10f; setTextColor(Ink.inkSoft); typeface = Ink.mono
+                    gravity = Gravity.CENTER; setPadding(0, dp(3), 0, 0)
+                })
+            }
+            cells.add(cell)
+            tabRow.addView(cell, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        }
+        val container = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Ink.paper)
+            // Black keyline up top so the sheet reads as a docked surface (bottom-bar template).
+            addView(
+                View(activity).apply { setBackgroundColor(Ink.ink) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
+            )
+            // Active tab's panel — WRAP_CONTENT so the sheet GROWS UP per tab (KOReader-style),
+            // bottom-anchored, instead of a fixed box with dead space.
+            addView(
+                content,
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT),
+            )
+            addView(
+                View(activity).apply { setBackgroundColor(Ink.hairline) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
+            )
+            addView(tabRow)
+        }
+        select(0)
+        dialog.setContentView(host.palmGuard(container)) // same palm guard as the bottom bar
+        dialog.window?.apply {
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            setGravity(Gravity.BOTTOM)
+            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Ink.paper))
+        }
+        dialog.show()
+    }
+
+    /** A KOReader-style **segmented control**: a rounded pill of [options] with the [selected]
+     *  segment filled dark. Updates its own highlight on tap, then calls [onSelect]. */
+    private fun segmented(options: List<String>, selected: Int, onSelect: (Int) -> Unit): View {
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val radius = dp(20).toFloat()
+        var sel = selected
+        val segs = ArrayList<TextView>()
+        fun style(tv: TextView, on: Boolean) {
+            if (on) {
+                tv.setTextColor(Ink.paper)
+                tv.setTypeface(null, android.graphics.Typeface.BOLD)
+                tv.background = GradientDrawable().apply { setColor(Ink.ink); cornerRadius = radius }
+            } else {
+                tv.setTextColor(Ink.ink)
+                tv.setTypeface(null, android.graphics.Typeface.NORMAL)
+                tv.background = null
+            }
+        }
+        return LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            background = GradientDrawable().apply {
+                setColor(Ink.paper); cornerRadius = radius
+                setStroke(Ink.hair(), Ink.ringSoft)
+            }
+            val p = dp(3); setPadding(p, p, p, p)
+            options.forEachIndexed { i, opt ->
+                val tv = TextView(activity).apply {
+                    text = opt; textSize = 15f; gravity = Gravity.CENTER
+                    setPadding(dp(6), dp(10), dp(6), dp(10)); isClickable = true
+                    setOnClickListener { sel = i; segs.forEachIndexed { j, t -> style(t, j == sel) }; onSelect(i) }
+                }
+                style(tv, i == sel)
+                segs.add(tv)
+                addView(tv, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+            }
+        }
+    }
+
+    /** A KOReader-style **cell bar**: [count] boxes filled up to the current level; tapping box i
+     *  sets level i+1 (tapping the current top cell turns it off → 0). Repaints on tap. */
+    private fun cellBar(count: Int, initial: Int, onSet: (Int) -> Unit): View {
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        var filled = initial
+        val draws = ArrayList<GradientDrawable>()
+        fun repaint() = draws.forEachIndexed { i, g ->
+            g.setColor(if (i < filled) Ink.ink else Ink.paper)
+        }
+        return LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            for (i in 0 until count) {
+                val g = GradientDrawable().apply { setStroke(Ink.hair(), Ink.ringSoft) }
+                draws.add(g)
+                addView(View(activity).apply {
+                    background = g; isClickable = true
+                    setOnClickListener {
+                        filled = if (i + 1 == filled) 0 else i + 1
+                        repaint(); invalidate()
+                        onSet(filled)
+                    }
+                }, LinearLayout.LayoutParams(0, dp(30), 1f).apply { val m = dp(2); setMargins(m, 0, m, 0) })
+            }
+            repaint()
+        }
+    }
+
+    /** A KOReader-style settings row: a right-aligned [label] on the left, the [control] on the right. */
+    private fun settingRow(label: String, control: View): View {
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        return LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(16), dp(14), dp(16), dp(14))
+            addView(TextView(activity).apply {
+                text = label; textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.END
+            }, LinearLayout.LayoutParams(dp(96), ViewGroup.LayoutParams.WRAP_CONTENT))
+            addView(control, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
+                marginStart = dp(14)
+            })
+        }
+    }
+
+    private fun rotationPanel(): View {
+        val orients = intArrayOf(
+            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
+            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
+            ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT,
+            ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
+        )
+        val sel = orients.indexOf(prefs.orientation).coerceAtLeast(0)
+        return settingRow("Rotation", segmented(listOf("0°", "90°", "180°", "270°"), sel) { which ->
+            host.diag { "DIAG rotation -> $which" }
+            applyOrientation(orients[which])
+        })
+    }
+
+    /** Set + persist the screen orientation; the resize re-renders the page (engine via surfaceChanged). */
+    private fun applyOrientation(orientation: Int) {
+        prefs.orientation = orientation
+        activity.requestedOrientation = orientation
+    }
+
+    private fun fitPanel(): View {
+        val sel = prefs.fit.coerceIn(0, 2) // index = core FitMode code
+        return settingRow("Fit", segmented(listOf("Full", "Width", "Height"), sel) { which ->
+            prefs.fit = which
+            host.diag { "DIAG fit -> mode=$which" }
+            host.engineExecute {
+                try { NativeBridge.nativeSetFit(host.docHandle, which) } catch (e: RuntimeException) {}
+                host.repaintPanel()
+            }
+        })
+    }
+
+    /** The "Crop" tab: Page Crop (None/Auto) + a Margin cell bar (margin kept around the content). */
+    private fun cropPanel(): View {
+        val container = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        container.addView(settingRow("Page Crop", segmented(listOf("None", "Auto"), if (prefs.cropAuto) 1 else 0) { which ->
+            prefs.cropAuto = which == 1
+            host.diag { "DIAG crop auto=${which == 1}" }
+            host.engineExecute {
+                try { NativeBridge.nativeSetCrop(host.docHandle, which, prefs.cropMargin) } catch (e: RuntimeException) {}
+                host.repaintPanel()
+            }
+        }))
+        container.addView(settingRow("Margin", cellBar(8, prefs.cropMargin) { level ->
+            prefs.cropMargin = level
+            host.diag { "DIAG crop margin=$level" }
+            host.engineExecute {
+                try { NativeBridge.nativeSetCrop(host.docHandle, if (prefs.cropAuto) 1 else 0, level) } catch (e: RuntimeException) {}
+                host.repaintPanel()
+            }
+        }))
+        return container
+    }
+
+    /** The "Page" tab: reflow Line Spacing + Alignment (EPUB; a toast on fixed-layout PDF). */
+    private fun pagePanel(): View {
+        fun applyReflow(call: () -> Int) {
+            host.engineExecute {
+                val np = try { call() } catch (e: RuntimeException) { -1 }
+                if (np >= 0) {
+                    host.refreshPageCount()
+                    host.repaintPanel()
+                } else {
+                    activity.runOnUiThread {
+                        Toast.makeText(activity, "Page layout adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+        val container = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        // Reflow toggle — only for a text-layer PDF (EPUB is always reflowable; a scanned PDF can't).
+        // It gates whether the Line Spacing / Alignment / Font Size controls take effect on a PDF.
+        val supportsReflow = try { NativeBridge.nativeSupportsReflow(host.docHandle) } catch (e: RuntimeException) { false }
+        if (supportsReflow) {
+            container.addView(settingRow("Reflow", segmented(listOf("Off", "On"), if (host.reflowOn) 1 else 0) { which ->
+                host.diag { "DIAG reflow=${which == 1}" }
+                host.setReflowMode(which == 1)
+            }))
+        }
+        container.addView(settingRow("Line Spacing", segmented(DisplayPrefs.LINE_SPACING_LABELS, prefs.lineSpacingIndex()) { which ->
+            prefs.lineSpacingMult = DisplayPrefs.LINE_SPACINGS[which]
+            host.diag { "DIAG line spacing=${DisplayPrefs.LINE_SPACINGS[which]}" }
+            applyReflow { NativeBridge.nativeSetLineSpacing(host.docHandle, DisplayPrefs.LINE_SPACINGS[which]) }
+        }))
+        container.addView(settingRow("Alignment", segmented(listOf("Left", "Justify", "Center", "Right"), prefs.alignment) { which ->
+            prefs.alignment = which
+            host.diag { "DIAG alignment=$which" }
+            applyReflow { NativeBridge.nativeSetAlignment(host.docHandle, which) }
+        }))
+        return container
+    }
+
+    /** The "Zoom" tab: the Fit segmented row + a live zoom −/+ stepper (zoom moved off the bar). */
+    private fun zoomPanel(): View {
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val zlabel = TextView(activity).apply {
+            textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
+        }
+        fun refresh() { zlabel.text = "${host.zoomPercent}%" }
+        refresh()
+        fun pill(t: String, on: () -> Unit) = TextView(activity).apply {
+            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
+            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
+            background = GradientDrawable().apply {
+                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
+            }
+            setOnClickListener { on() }
+        }
+        val zoomControl = LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            addView(pill("−") { host.zoomOut(); refresh() })
+            addView(zlabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                val m = dp(10); setMargins(m, 0, m, 0)
+            })
+            addView(pill("+") { host.zoomIn(); refresh() })
+        }
+        return LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(fitPanel())
+            addView(settingRow("Zoom", zoomControl))
+        }
+    }
+
+    private fun displayPanel(): View {
+        val container = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        container.addView(settingRow("Contrast", cellBar(DisplayPrefs.CONTRAST_MAX, prefs.contrast) { level ->
+            prefs.contrast = level
+            host.diag { "DIAG contrast step=$level" }
+            host.engineExecute {
+                try { NativeBridge.nativeSetContrast(host.docHandle, level) } catch (e: RuntimeException) {}
+                host.repaintPanel()
+            }
+        }))
+        container.addView(settingRow("Quality", segmented(listOf("Low", "Default", "High"), prefs.renderQuality) { which ->
+            prefs.renderQuality = which
+            host.diag { "DIAG render quality=$which" }
+            host.engineExecute {
+                try { NativeBridge.nativeSetRenderQuality(host.docHandle, which) } catch (e: RuntimeException) {}
+                host.repaintPanel()
+            }
+        }))
+        return container
+    }
+
+    /** A reading style preset (1.10): a bundle of (text scale, line-spacing index, contrast step,
+     *  night). Font/spacing are no-ops on fixed-layout PDFs; contrast/night apply to both. */
+    private data class StyleSpec(val scale: Float, val spacing: Float, val contrast: Int, val night: Boolean)
+
+    private fun styleSpec(name: String): StyleSpec = when (name) {
+        "Bold" -> StyleSpec(1.0f, DisplayPrefs.DEFAULT_LINE_SPACING, 4, false) // darker text (heavier ink)
+        "Night" -> StyleSpec(1.0f, DisplayPrefs.DEFAULT_LINE_SPACING, 0, true) // inverted (light on dark)
+        "Outdoor" -> StyleSpec(1.0f, DisplayPrefs.DEFAULT_LINE_SPACING, DisplayPrefs.CONTRAST_MAX, false) // maximum contrast
+        "Relaxed" -> StyleSpec(1.15f, 1.7f, 0, false) // larger + airier
+        else -> StyleSpec(1.0f, DisplayPrefs.DEFAULT_LINE_SPACING, 0, false) // Original — defaults
+    }
+
+    /** The "Style" tab: one-tap presets that bundle font size, spacing, contrast, and night. */
+    private fun stylePanel(): View {
+        val container = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        container.addView(
+            settingRow(
+                "Preset",
+                segmented(DisplayPrefs.STYLE_PRESETS, DisplayPrefs.STYLE_PRESETS.indexOf(prefs.stylePreset).coerceAtLeast(0)) { which ->
+                    applyStylePreset(DisplayPrefs.STYLE_PRESETS[which])
+                },
+            ),
+        )
+        return container
+    }
+
+    /** Apply + persist a style preset: set every knob, then repaginate/re-render. */
+    private fun applyStylePreset(name: String) {
+        val s = styleSpec(name)
+        prefs.stylePreset = name
+        prefs.textScale = s.scale
+        prefs.lineSpacingMult = s.spacing
+        prefs.contrast = s.contrast
+        prefs.night = s.night
+        host.engineExecute {
+            try {
+                NativeBridge.nativeSetTextScale(host.docHandle, s.scale)
+                NativeBridge.nativeSetLineSpacing(host.docHandle, s.spacing)
+                NativeBridge.nativeSetContrast(host.docHandle, s.contrast)
+                NativeBridge.nativeSetNight(host.docHandle, s.night)
+                host.refreshPageCount()
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "style preset apply failed: ${e.message}")
+            }
+            host.repaintPanel()
+        }
+    }
+
+    private fun fontPanel(): View {
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        var idx = DisplayPrefs.nearestScaleIndex(prefs.textScale)
+        val value = TextView(activity).apply {
+            textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
+        }
+        fun refresh() { value.text = "${(DisplayPrefs.TEXT_SCALES[idx] * 100).toInt()}%" }
+        refresh()
+        fun apply() { refresh(); applyReflowScale(idx, warnIfFixed = true) }
+        fun pill(t: String, on: () -> Unit) = TextView(activity).apply {
+            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
+            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
+            background = GradientDrawable().apply {
+                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
+            }
+            setOnClickListener { on() }
+        }
+        val control = LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
+            addView(pill("A−") { if (idx > 0) { idx--; apply() } })
+            addView(value, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                val m = dp(10); setMargins(m, 0, m, 0)
+            })
+            addView(pill("A+") { if (idx < DisplayPrefs.TEXT_SCALES.size - 1) { idx++; apply() } })
+            // Quick presets next to the steppers: jump straight to default / largest (#55).
+            fun preset(p: View) = addView(p, LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
+            ).apply { leftMargin = dp(8) })
+            preset(pill("100%") { idx = DisplayPrefs.nearestScaleIndex(1.0f); apply() })
+            preset(pill("XL") { idx = DisplayPrefs.TEXT_SCALES.size - 1; apply() })
+        }
+        val container = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        // Typeface picker — the bundled reading faces (EPUB/reflow; a toast on fixed-layout PDF).
+        val faces = try {
+            NativeBridge.nativeFontNames().split("\n").filter { it.isNotBlank() }
+        } catch (e: RuntimeException) { emptyList() }
+        if (faces.isNotEmpty()) {
+            container.addView(settingRow("Typeface", segmented(faces, prefs.font.coerceIn(0, faces.size - 1)) { which ->
+                prefs.font = which
+                host.engineExecute {
+                    val np = try { NativeBridge.nativeSetFont(host.docHandle, which) } catch (e: RuntimeException) { -1 }
+                    if (np >= 0) { host.refreshPageCount(); host.repaintPanel() }
+                    else activity.runOnUiThread {
+                        Toast.makeText(activity, "Typeface adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }))
+        }
+        container.addView(settingRow("Font Size", control))
+        return container
+    }
+
+    /** Apply reflow font-size preset [rawIdx] (clamped): persist, repaginate off-thread, repaint.
+     *  Pinch-zoom on a reflowable view and the Font panel's A-/A+ both route here (DRY).
+     *  [announce] toasts the new size (pinch feedback); [warnIfFixed] toasts when the doc is
+     *  fixed-layout so the size can't change (Font panel feedback). */
+    fun applyReflowScale(rawIdx: Int, announce: Boolean = false, warnIfFixed: Boolean = false) {
+        val idx = rawIdx.coerceIn(0, DisplayPrefs.TEXT_SCALES.size - 1)
+        prefs.textScale = DisplayPrefs.TEXT_SCALES[idx]
+        if (announce) activity.runOnUiThread {
+            Toast.makeText(activity, "Font ${(DisplayPrefs.TEXT_SCALES[idx] * 100).toInt()}%", Toast.LENGTH_SHORT).show()
+        }
+        host.engineExecute {
+            val np = try { NativeBridge.nativeSetTextScale(host.docHandle, DisplayPrefs.TEXT_SCALES[idx]) } catch (e: RuntimeException) { -1 }
+            if (np >= 0) { host.refreshPageCount(); host.repaintPanel() }
+            else if (warnIfFixed) activity.runOnUiThread {
+                Toast.makeText(activity, "Font size adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "AdjustSheet"
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -340,6 +340,20 @@ class AdjustSheetController(private val host: Host) {
         return container
     }
 
+    /** A white rounded stepper pill (shared by the Zoom and Font tabs). */
+    private fun pill(t: String, on: () -> Unit): TextView {
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        return TextView(activity).apply {
+            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
+            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
+            background = GradientDrawable().apply {
+                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
+            }
+            setOnClickListener { on() }
+        }
+    }
+
     /** The "Zoom" tab: the Fit segmented row + a live zoom −/+ stepper (zoom moved off the bar). */
     private fun zoomPanel(): View {
         val d = activity.resources.displayMetrics.density
@@ -349,14 +363,6 @@ class AdjustSheetController(private val host: Host) {
         }
         fun refresh() { zlabel.text = "${host.zoomPercent}%" }
         refresh()
-        fun pill(t: String, on: () -> Unit) = TextView(activity).apply {
-            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
-            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
-            background = GradientDrawable().apply {
-                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
-            }
-            setOnClickListener { on() }
-        }
         val zoomControl = LinearLayout(activity).apply {
             orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
             addView(pill("−") { host.zoomOut(); refresh() })
@@ -451,14 +457,6 @@ class AdjustSheetController(private val host: Host) {
         fun refresh() { value.text = "${(DisplayPrefs.TEXT_SCALES[idx] * 100).toInt()}%" }
         refresh()
         fun apply() { refresh(); applyReflowScale(idx, warnIfFixed = true) }
-        fun pill(t: String, on: () -> Unit) = TextView(activity).apply {
-            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
-            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
-            background = GradientDrawable().apply {
-                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
-            }
-            setOnClickListener { on() }
-        }
         val control = LinearLayout(activity).apply {
             orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
             addView(pill("A−") { if (idx > 0) { idx--; apply() } })

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -18,14 +18,13 @@ import android.widget.ScrollView
 import android.widget.SeekBar
 import android.widget.TextView
 import android.widget.Toast
-import java.io.File
 
 /**
  * The reader's bottom control bar + the navigation panels it opens (RR16/RR25), extracted from
  * `ReaderActivity` (SRP): the KOReader-style bar (page slider, chapter jumps, control row), the
  * go-to-page entry, bookmarks (toggle + list), Contents (TOC), the handwritten-annotations list,
- * the library picker, and go-home. Sub-surfaces owned by other controllers (Search / Export /
- * Dicts / Adjust) open through [Host] callbacks.
+ * and go-home. Sub-surfaces owned by other controllers (Search / Export / Dicts / Adjust) open
+ * through [Host] callbacks.
  *
  * Threading mirrors the original inline code: panels are built on the UI thread; document state
  * (TOC, bookmarks, ink pages) is fetched on the engine thread via [Host.engineExecute].
@@ -64,9 +63,6 @@ class BottomBarController(private val host: Host) {
         fun repaintPanel()
 
         fun openPicker()
-
-        /** Open a Library book in place (engine thread inside). */
-        fun openFromLibrary(file: File)
 
         /** Wrap dialog content so a resting palm can't tap through it. */
         fun palmGuard(content: View): View
@@ -487,20 +483,6 @@ class BottomBarController(private val host: Host) {
             setBackgroundDrawable(Ink.cardBg())
         }
         dialog.show()
-    }
-
-    /** The on-device library (RR17): pick a stored book to open it in place. */
-    private fun showLibraryDialog() {
-        val books = Books.list(activity)
-        if (books.isEmpty()) {
-            Toast.makeText(activity, "No books yet — open a PDF first", Toast.LENGTH_SHORT).show()
-            return
-        }
-        val labels = books.map { Books.title(it) }.toTypedArray()
-        AlertDialog.Builder(activity, R.style.InkDialog)
-            .setTitle("Library")
-            .setItems(labels) { _, which -> host.openFromLibrary(books[which]) }
-            .show()
     }
 
     /** Return to the home screen (RR16), leaving the reader. */

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -1,0 +1,518 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Intent
+import android.graphics.drawable.GradientDrawable
+import android.text.InputType
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.SeekBar
+import android.widget.TextView
+import android.widget.Toast
+import java.io.File
+
+/**
+ * The reader's bottom control bar + the navigation panels it opens (RR16/RR25), extracted from
+ * `ReaderActivity` (SRP): the KOReader-style bar (page slider, chapter jumps, control row), the
+ * go-to-page entry, bookmarks (toggle + list), Contents (TOC), the handwritten-annotations list,
+ * the library picker, and go-home. Sub-surfaces owned by other controllers (Search / Export /
+ * Dicts / Adjust) open through [Host] callbacks.
+ *
+ * Threading mirrors the original inline code: panels are built on the UI thread; document state
+ * (TOC, bookmarks, ink pages) is fetched on the engine thread via [Host.engineExecute].
+ */
+class BottomBarController(private val host: Host) {
+
+    /** What the bar + panels need from the reader shell. */
+    interface Host {
+        /** Context for dialogs/toasts/resources, `runOnUiThread`, `startActivity`, `finish`. */
+        val activity: Activity
+
+        /** The open document handle (`0` = none); read live per call. */
+        val docHandle: Long
+
+        /** Cached page state, so showing the bar needs no engine round-trip. */
+        val pageCount: Int
+
+        val currentPage: Int
+
+        /** Chapters as (start page, title), sorted; empty = no TOC. */
+        val chapters: List<Pair<Int, String>>
+
+        /** Per-book bookmarks store (engine thread only); null until a book is open. */
+        val bookmarks: Bookmarks?
+
+        /** Filesystem path of the open document (Daily issues live under `/daily/`). */
+        val requestedPath: String?
+
+        /** Run [block] on the single engine thread (serializes native access). */
+        fun engineExecute(block: () -> Unit)
+
+        /** Queue a jump to a 0-based page (render + refresh + persist position). */
+        fun postJump(page: Int)
+
+        /** Re-render + blit the current page (any thread). */
+        fun repaintPanel()
+
+        fun openPicker()
+
+        /** Open a Library book in place (engine thread inside). */
+        fun openFromLibrary(file: File)
+
+        /** Wrap dialog content so a resting palm can't tap through it. */
+        fun palmGuard(content: View): View
+
+        /** Quick zoom from the bar (the shell owns the zoom model + step constant). */
+        fun zoomIn()
+
+        fun zoomOut()
+
+        // Sub-surfaces owned by sibling controllers.
+        fun openSearch()
+
+        fun openExport()
+
+        fun openDicts()
+
+        fun openAdjust()
+    }
+
+    private val activity: Activity get() = host.activity
+    private fun runOnUiThread(block: () -> Unit) = activity.runOnUiThread(block)
+
+    /**
+     * The reader's bottom control bar (RR16/RR25), KOReader-style: a thin panel **hugging the
+     * bottom edge** — a page slider with a tappable page indicator, above a flat row of controls
+     * (Home · Library · Bookmark · Marks · Contents · Open). Built programmatically, high-contrast
+     * for e-ink; uses the cached page state so showing it needs no engine round-trip.
+     */
+    fun showBottomBar() {
+        if (host.docHandle == 0L) {
+            host.openPicker()
+            return
+        }
+        val total = host.pageCount.coerceAtLeast(1)
+        val cur = host.currentPage.coerceIn(0, total - 1)
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+
+        val dialog = Dialog(activity).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+        val container = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Ink.paper)
+        }
+        // A crisp black keyline up top so the bar reads as a docked surface, not a floating box.
+        container.addView(
+            View(activity).apply { setBackgroundColor(Ink.ink) },
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
+        )
+
+        // Page-slider row:  [N / Total]  ────────●────────  (grayscale, tap the chip to type a page)
+        val pageLabel = TextView(activity).apply {
+            text = "${cur + 1} / $total"
+            setTextColor(Ink.ink)
+            textSize = 12f
+            typeface = Ink.mono
+            letterSpacing = 0.04f
+            gravity = Gravity.CENTER
+            setPadding(dp(12), dp(6), dp(12), dp(6))
+            background = GradientDrawable().apply {
+                setColor(Ink.fill)
+                cornerRadius = Ink.dpf(40)
+            }
+            setOnClickListener { dialog.dismiss(); showPageEntry(total) }
+        }
+        // A refined, thin grayscale track + small round thumb (the default SeekBar reads clunky).
+        val trackH = dp(3).coerceAtLeast(2)
+        fun bar(c: Int) = GradientDrawable().apply { setColor(c); cornerRadius = trackH.toFloat(); setSize(0, trackH) }
+        val track = android.graphics.drawable.LayerDrawable(
+            arrayOf(
+                bar(Ink.hairline),
+                android.graphics.drawable.ClipDrawable(bar(Ink.ink), Gravity.START, android.graphics.drawable.ClipDrawable.HORIZONTAL),
+            ),
+        ).apply { setId(0, android.R.id.background); setId(1, android.R.id.progress) }
+        val knob = GradientDrawable().apply { shape = GradientDrawable.OVAL; setColor(Ink.ink); setSize(dp(16), dp(16)) }
+        val seek = SeekBar(activity).apply {
+            max = total - 1
+            progress = cur
+            progressDrawable = track
+            thumb = knob
+            splitTrack = false
+            setPadding(dp(10), dp(4), dp(10), dp(4))
+            setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(sb: SeekBar, p: Int, fromUser: Boolean) {
+                    if (fromUser) pageLabel.text = "${p + 1} / $total"
+                }
+                override fun onStartTrackingTouch(sb: SeekBar) {}
+                override fun onStopTrackingTouch(sb: SeekBar) { dialog.dismiss(); host.postJump(sb.progress) }
+            })
+        }
+        // Double-chevron chapter jumps flank the scrubber (distinct from single-page edge taps),
+        // shown only when the document has a table of contents (1.7).
+        fun chapterBtn(glyph: String, dir: Int) = TextView(activity).apply {
+            text = glyph; setTextColor(Ink.ink); textSize = 20f; typeface = Ink.serifBold
+            gravity = Gravity.CENTER; setPadding(dp(8), dp(2), dp(8), dp(2)); isClickable = true
+            setOnClickListener { dialog.dismiss(); chapterJump(dir) }
+        }
+        container.addView(
+            LinearLayout(activity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(dp(16), dp(12), dp(16), dp(6))
+                if (host.chapters.isNotEmpty()) addView(chapterBtn("‹‹", -1))
+                addView(seek, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                if (host.chapters.isNotEmpty()) addView(chapterBtn("››", +1))
+                addView(pageLabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply { marginStart = dp(12) })
+            },
+        )
+        // Current-chapter line under the scrubber: orients the reader and makes the ‹‹/›› obvious.
+        // Left = "Ch i/n · Title" (ellipsized); right = in-chapter "p/q" (stays visible). Tap → the
+        // full Contents sheet. Shown only when the document has chapters.
+        currentChapterLabel()?.let { lbl ->
+            container.addView(LinearLayout(activity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(dp(24), 0, dp(24), dp(8))
+                isClickable = true
+                setOnClickListener { dialog.dismiss(); showContentsLazy() }
+                addView(TextView(activity).apply {
+                    text = lbl; setTextColor(Ink.inkSoft); textSize = 12f; typeface = Ink.serif
+                    maxLines = 1; ellipsize = android.text.TextUtils.TruncateAt.END
+                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                inChapterPosition()?.let { pos ->
+                    addView(TextView(activity).apply {
+                        text = pos; setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
+                        setPadding(dp(10), 0, 0, 0)
+                    })
+                }
+            })
+        }
+
+        // Control row: flat, evenly-weighted icon+label cells.
+        val controls = LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setPadding(dp(2), dp(6), dp(2), dp(12))
+        }
+        // One control = a line icon over a small label (Boox/NeoReader bottom-bar style, frame 069).
+        fun control(iconRes: Int, label: String, onClick: () -> Unit) {
+            val cell = LinearLayout(activity).apply {
+                orientation = LinearLayout.VERTICAL
+                gravity = Gravity.CENTER
+                setPadding(dp(2), dp(8), dp(2), dp(8))
+                isClickable = true
+                setOnClickListener { dialog.dismiss(); onClick() }
+            }
+            cell.addView(
+                ImageView(activity).apply {
+                    setImageResource(iconRes); setColorFilter(Ink.ink)
+                },
+                LinearLayout.LayoutParams(dp(39), dp(39)),
+            )
+            cell.addView(TextView(activity).apply {
+                text = label; setTextColor(Ink.inkSoft); textSize = 11f
+                typeface = Ink.mono; letterSpacing = 0.02f
+                gravity = Gravity.CENTER; setPadding(0, dp(5), 0, 0)
+            })
+            controls.addView(cell, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        }
+        // Reading a compiled Daily issue → a back-to-the-front-page control (DailyActivity is the
+        // parent in the back stack, so finishing returns to the article list).
+        if (host.requestedPath?.contains("/daily/") == true) {
+            control(R.drawable.ic_menu_contents, "Daily") { activity.finish() }
+        }
+        // "Home" already opens the library home, so a separate Library item here is redundant.
+        control(R.drawable.ic_menu_home, "Home") { goHome() }
+        // (Bookmark toggle moved to the top-right corner dog-ear; "Marks" lists them.)
+        control(R.drawable.ic_menu_marks, "Marks") { showBookmarks() }
+        control(R.drawable.ic_tool_pen, "Notes") { showAnnotations() }
+        control(R.drawable.ic_menu_contents, "Contents") { showContentsLazy() }
+        control(R.drawable.ic_menu_search, "Search") { host.openSearch() }
+        // Quick zoom (circle −/+ icons — not magnifiers, which are reserved for Search). Also in Adjust → Zoom.
+        control(R.drawable.ic_menu_zoom_out, "Zoom −") { host.zoomOut() }
+        control(R.drawable.ic_menu_zoom_in, "Zoom +") { host.zoomIn() }
+        control(R.drawable.ic_menu_export, "Export") { host.openExport() }
+        control(R.drawable.ic_menu_dict, "Dicts") { host.openDicts() }
+        // Document controls consolidated into one KOReader-style tabbed sheet (Rotate/Fit/Font/Display).
+        control(R.drawable.ic_menu_adjust, "Adjust") { host.openAdjust() }
+        control(R.drawable.ic_menu_open, "Open") { host.openPicker() }
+        container.addView(controls)
+
+        // Palm guard: a hand resting on the bottom-anchored bar must not press a control (esp. Home).
+        dialog.setContentView(host.palmGuard(container))
+        dialog.window?.apply {
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            setGravity(Gravity.BOTTOM)
+            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Ink.paper))
+        }
+        dialog.show()
+    }
+
+    /** Jump to the previous (`dir<0`) / next (`dir>0`) chapter start relative to the current page
+     *  (1.7). No-op with a brief toast at the document ends or when the doc has no chapters. */
+    private fun chapterJump(dir: Int) {
+        val starts = host.chapters.map { it.first }
+        if (starts.isEmpty()) {
+            Toast.makeText(activity, "No chapters in this document", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val cur = host.currentPage
+        val target = if (dir > 0) starts.firstOrNull { it > cur } else starts.lastOrNull { it < cur }
+        if (target != null) {
+            host.postJump(target)
+        } else {
+            Toast.makeText(activity, if (dir > 0) "Last chapter" else "First chapter", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    /** "Ch 2/9 · The Crossing" for the chapter the current page sits in, or null if the doc has no
+     *  chapters. The current chapter is the last one whose start page is ≤ the current page. */
+    private fun currentChapterLabel(): String? {
+        val ch = host.chapters
+        if (ch.isEmpty()) return null
+        val idx = ch.indexOfLast { it.first <= host.currentPage }.coerceAtLeast(0)
+        return "Ch ${idx + 1}/${ch.size} · ${ch[idx].second}"
+    }
+
+    /** In-chapter position "3/24" — the current page within the current chapter (this chapter's start
+     *  → the next chapter's start; the last chapter runs to the end of the document). Null with no
+     *  chapters, or before the first chapter start (front matter). */
+    private fun inChapterPosition(): String? {
+        val ch = host.chapters
+        if (ch.isEmpty()) return null
+        val idx = ch.indexOfLast { it.first <= host.currentPage }
+        if (idx < 0) return null
+        val start = ch[idx].first
+        val end = if (idx + 1 < ch.size) ch[idx + 1].first else host.pageCount
+        val total = (end - start).coerceAtLeast(1)
+        return "${host.currentPage - start + 1}/$total"
+    }
+
+    /** A "go to page" text-entry dialog (RR11-FR1): type a 1-based page number to jump. */
+    private fun showPageEntry(total: Int) {
+        val input = EditText(activity).apply {
+            inputType = InputType.TYPE_CLASS_NUMBER
+            hint = "1 – $total"
+        }
+        AlertDialog.Builder(activity, R.style.InkDialog)
+            .setTitle("Go to page")
+            .setView(input)
+            .setPositiveButton("Go") { _, _ ->
+                val n = input.text.toString().toIntOrNull()
+                if (n != null && n in 1..total) {
+                    host.postJump(n - 1)
+                } else {
+                    Toast.makeText(activity, "Enter a page from 1 to $total", Toast.LENGTH_SHORT).show()
+                }
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    /** Toggle a bookmark on the current page (RR16); redraw so the dog-ear appears/disappears. */
+    fun toggleBookmark() {
+        host.engineExecute {
+            val bm = host.bookmarks ?: return@engineExecute
+            val page = host.currentPage
+            val now = bm.toggle(page)
+            runOnUiThread {
+                val msg = if (now) "Bookmarked page ${page + 1}" else "Bookmark removed"
+                Toast.makeText(activity, msg, Toast.LENGTH_SHORT).show()
+            }
+            host.repaintPanel()
+        }
+    }
+
+    /** List the bookmarked pages (RR16); tap one to jump. */
+    private fun showBookmarks() {
+        host.engineExecute {
+            val marks = host.bookmarks?.pages() ?: emptyList()
+            runOnUiThread {
+                if (marks.isEmpty()) {
+                    Toast.makeText(activity, "No bookmarks yet — tap Bookmark to add one", Toast.LENGTH_SHORT).show()
+                    return@runOnUiThread
+                }
+                val labels = marks.map { "Page ${it + 1}" }.toTypedArray()
+                AlertDialog.Builder(activity, R.style.InkDialog)
+                    .setTitle("Bookmarks")
+                    .setItems(labels) { _, which -> host.postJump(marks[which]) }
+                    .show()
+            }
+        }
+    }
+
+    /** Fetch the TOC on the engine thread, then show it (RR11-FR2). */
+    private fun showContentsLazy() {
+        host.engineExecute {
+            if (host.docHandle == 0L) return@engineExecute
+            val toc = try {
+                WireCodec.decodeToc(NativeBridge.nativeToc(host.docHandle))
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "toc failed: ${e.message}")
+                emptyList()
+            }
+            runOnUiThread {
+                if (toc.isEmpty()) {
+                    Toast.makeText(activity, "No contents in this document", Toast.LENGTH_SHORT).show()
+                } else {
+                    showContents(toc)
+                }
+            }
+        }
+    }
+
+    /** Handwritten-notes annotations list (1.5): fetch inked pages + their stroke counts off-thread,
+     *  then show a tap-to-jump list. */
+    private fun showAnnotations() {
+        host.engineExecute {
+            if (host.docHandle == 0L) return@engineExecute
+            val pages = try {
+                NativeBridge.nativeInkPages(host.docHandle)
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "ink pages failed: ${e.message}"); IntArray(0)
+            }
+            val items = pages.map { p ->
+                val count = try {
+                    WireCodec.decodeStrokes(NativeBridge.nativeInkStrokesForDraw(host.docHandle, p)).size
+                } catch (e: RuntimeException) { 0 }
+                p to count
+            }
+            runOnUiThread {
+                if (items.isEmpty()) {
+                    Toast.makeText(activity, "No handwritten notes yet", Toast.LENGTH_SHORT).show()
+                } else {
+                    showAnnotationsList(items)
+                }
+            }
+        }
+    }
+
+    /** The inked pages as a scrollable "Page N · M notes" list; tap a row to jump there. */
+    private fun showAnnotationsList(items: List<Pair<Int, Int>>) {
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val dialog = Dialog(activity).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+        val outer = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(24), dp(22), dp(24), dp(14))
+        }
+        outer.addView(Ink.eyebrow(activity, "Annotations"))
+        outer.addView(Ink.gap(activity, 10))
+        outer.addView(Ink.rule(activity))
+        outer.addView(Ink.gap(activity, 4))
+        val list = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        items.forEachIndexed { i, (page, count) ->
+            if (i > 0) list.addView(View(activity).apply { setBackgroundColor(Ink.hairline) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()))
+            list.addView(LinearLayout(activity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(dp(4), dp(14), dp(4), dp(14))
+                isClickable = true
+                setOnClickListener { dialog.dismiss(); host.postJump(page) }
+                addView(TextView(activity).apply {
+                    text = "Page ${page + 1}"
+                    setTextColor(Ink.ink); textSize = 17f; typeface = Ink.serifBold
+                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                addView(TextView(activity).apply {
+                    text = if (count == 1) "1 note" else "$count notes"
+                    setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
+                })
+            })
+        }
+        outer.addView(ScrollView(activity).apply { addView(list) },
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, (activity.resources.displayMetrics.heightPixels * 0.7f).toInt()))
+        dialog.setContentView(outer)
+        dialog.window?.apply {
+            setLayout((activity.resources.displayMetrics.widthPixels * 0.82f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
+            setBackgroundDrawable(Ink.cardBg())
+        }
+        dialog.show()
+    }
+
+    /** The document's table of contents (RR11-FR2), shown as a scrollable list from the popup. */
+    private fun showContents(toc: List<TocItem>) {
+        if (toc.isEmpty()) return
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val dialog = Dialog(activity).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
+
+        val outer = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(24), dp(22), dp(24), dp(14))
+        }
+        outer.addView(Ink.eyebrow(activity, "Contents"))
+        outer.addView(Ink.gap(activity, 10))
+        outer.addView(Ink.rule(activity))
+        outer.addView(Ink.gap(activity, 4))
+        val list = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        toc.forEachIndexed { i, item ->
+            if (i > 0) list.addView(View(activity).apply { setBackgroundColor(Ink.hairline) },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()))
+            list.addView(LinearLayout(activity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(dp(4) + item.depth * dp(18), dp(14), dp(4), dp(14))
+                isClickable = true
+                setOnClickListener { dialog.dismiss(); item.targetPage?.let { host.postJump(it) } }
+                addView(TextView(activity).apply {
+                    text = item.title
+                    setTextColor(if (item.targetPage != null) Ink.ink else Ink.muted)
+                    textSize = if (item.depth == 0) 17f else 15f
+                    typeface = if (item.depth == 0) Ink.serifBold else Ink.serif
+                    maxLines = 2
+                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                item.targetPage?.let { p ->
+                    addView(TextView(activity).apply {
+                        text = "${p + 1}"; setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
+                        setPadding(dp(12), 0, 0, 0)
+                    })
+                }
+            })
+        }
+        outer.addView(ScrollView(activity).apply { addView(list) },
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, (activity.resources.displayMetrics.heightPixels * 0.7f).toInt()))
+
+        dialog.setContentView(outer)
+        dialog.window?.apply {
+            setLayout((activity.resources.displayMetrics.widthPixels * 0.82f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
+            setBackgroundDrawable(Ink.cardBg())
+        }
+        dialog.show()
+    }
+
+    /** The on-device library (RR17): pick a stored book to open it in place. */
+    private fun showLibraryDialog() {
+        val books = Books.list(activity)
+        if (books.isEmpty()) {
+            Toast.makeText(activity, "No books yet — open a PDF first", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val labels = books.map { Books.title(it) }.toTypedArray()
+        AlertDialog.Builder(activity, R.style.InkDialog)
+            .setTitle("Library")
+            .setItems(labels) { _, which -> host.openFromLibrary(books[which]) }
+            .show()
+    }
+
+    /** Return to the home screen (RR16), leaving the reader. */
+    private fun goHome() {
+        activity.startActivity(
+            Intent(activity, HomeActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+        )
+        activity.finish()
+    }
+
+    companion object {
+        private const val TAG = "BottomBar"
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
@@ -1,0 +1,112 @@
+package dev.jraghavan.inkread
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.ActivityInfo
+
+/**
+ * Persisted display + typography settings (RR4), extracted from `ReaderActivity` (SRP). Two
+ * stores mirror the original prefs files — `"display"` (contrast/night/fit/crop/quality/
+ * orientation/style preset) and `"typography"` (text scale/typeface/line spacing/alignment) —
+ * with unchanged keys, so existing installs keep their settings.
+ *
+ * `SharedPreferences` is thread-safe; these are read on the engine thread when a document
+ * (re)opens and written from the settings-sheet UI.
+ */
+class DisplayPrefs(private val context: Context) {
+
+    private val display: SharedPreferences
+        get() = context.getSharedPreferences("display", Context.MODE_PRIVATE)
+    private val typography: SharedPreferences
+        get() = context.getSharedPreferences("typography", Context.MODE_PRIVATE)
+
+    // ---- "display" store ----
+
+    var contrast: Int
+        get() = display.getInt("contrast", 0).coerceIn(0, CONTRAST_MAX)
+        set(step) = display.edit().putInt("contrast", step).apply()
+
+    var night: Boolean
+        get() = display.getBoolean("night", false)
+        set(on) = display.edit().putBoolean("night", on).apply()
+
+    var cropAuto: Boolean
+        get() = display.getBoolean("crop_auto", false)
+        set(v) = display.edit().putBoolean("crop_auto", v).apply()
+
+    var cropMargin: Int
+        get() = display.getInt("crop_margin", 1).coerceIn(0, 8)
+        set(v) = display.edit().putInt("crop_margin", v).apply()
+
+    /** Page fit mode; the index mirrors the core `FitMode` code (0 = Page/contain). */
+    var fit: Int
+        get() = display.getInt("fit", 0)
+        set(mode) = display.edit().putInt("fit", mode).apply()
+
+    var orientation: Int
+        get() = display.getInt("orientation", ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
+        set(o) = display.edit().putInt("orientation", o).apply()
+
+    var stylePreset: String
+        get() = display.getString("style_preset", "Original") ?: "Original"
+        set(name) = display.edit().putString("style_preset", name).apply()
+
+    var renderQuality: Int
+        get() = display.getInt("render_quality", 1).coerceIn(0, 2)
+        set(q) = display.edit().putInt("render_quality", q).apply()
+
+    // ---- "typography" store ----
+
+    var textScale: Float
+        get() = typography.getFloat("scale", 1.0f)
+        set(scale) = typography.edit().putFloat("scale", scale).apply()
+
+    var font: Int
+        get() = typography.getInt("font_id", 0)
+        set(id) = typography.edit().putInt("font_id", id).apply()
+
+    /** The saved line-spacing multiplier (value-based; new key, so a changed option set never
+     *  mis-maps an old index). Defaults to the core default 1.4. */
+    var lineSpacingMult: Float
+        get() = typography.getInt("line_spacing_x100", (DEFAULT_LINE_SPACING * 100).toInt()) / 100f
+        set(m) = typography.edit().putInt("line_spacing_x100", Math.round(m * 100)).apply()
+
+    var alignment: Int
+        get() = typography.getInt("alignment", 0).coerceIn(0, 3)
+        set(i) = typography.edit().putInt("alignment", i).apply()
+
+    /** The segmented index for the saved multiplier (nearest [LINE_SPACINGS] entry; default Medium). */
+    fun lineSpacingIndex(): Int {
+        val m = lineSpacingMult
+        val i = LINE_SPACINGS.indexOfFirst { kotlin.math.abs(it - m) < 0.001f }
+        return if (i >= 0) i else {
+            LINE_SPACINGS.indexOfFirst { kotlin.math.abs(it - DEFAULT_LINE_SPACING) < 0.001f }.coerceAtLeast(0)
+        }
+    }
+
+    companion object {
+        const val CONTRAST_MAX = 8 // mirrors reader-core render::contrast::MAX_CONTRAST_STEP (RR4).
+
+        // Line-spacing multipliers (RR4), tight → loose. Stored as the value (not the index) so this
+        // set can grow without corrupting saved prefs. 1.4 = the core default.
+        val LINE_SPACINGS = floatArrayOf(1.0f, 1.1f, 1.2f, 1.4f, 1.7f)
+        val LINE_SPACING_LABELS = listOf("Tightest", "Tighter", "Small", "Medium", "Large")
+        const val DEFAULT_LINE_SPACING = 1.4f
+
+        val STYLE_PRESETS = listOf("Original", "Bold", "Night", "Outdoor", "Relaxed") // 1.10
+
+        /** Reflow font-size steps (multiples of the core's base body size); 1.0 = default. */
+        val TEXT_SCALES = floatArrayOf(0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.15f, 1.3f, 1.5f, 1.75f, 2.0f, 2.5f, 3.0f)
+
+        /** Index of the [TEXT_SCALES] entry nearest to [scale]. */
+        fun nearestScaleIndex(scale: Float): Int {
+            var best = 0
+            var bestDist = Float.MAX_VALUE
+            TEXT_SCALES.forEachIndexed { i, v ->
+                val dist = kotlin.math.abs(v - scale)
+                if (dist < bestDist) { bestDist = dist; best = i }
+            }
+            return best
+        }
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -236,7 +236,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun postJump(page: Int) = this@ReaderActivity.postJump(page)
         override fun repaintPanel() = this@ReaderActivity.repaintPanel()
         override fun openPicker() = this@ReaderActivity.openPicker()
-        override fun openFromLibrary(file: File) = this@ReaderActivity.openFromLibrary(file)
         override fun palmGuard(content: View) = this@ReaderActivity.palmGuard(content)
         override fun zoomIn() = zoomBy(ZOOM_STEP)
         override fun zoomOut() = zoomBy(1f / ZOOM_STEP)
@@ -902,11 +901,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         drawLoading()
         openBook(path, id)
         repaintPanel() // the new book's first page has no command stream → refresh
-    }
-
-    /** Open a Library book in place (invoked from the reader popup; engine thread). */
-    private fun openFromLibrary(file: File) {
-        engine.execute { openSwap(file.absolutePath, file.name) }
     }
 
     /**

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -24,17 +24,12 @@ import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.widget.Toast
 import android.app.Dialog
-import android.text.InputType
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
-import android.widget.EditText
 import android.widget.FrameLayout
-import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.ScrollView
-import android.widget.SeekBar
 import android.widget.TextView
 import dev.jraghavan.inkread.eink.EinkAdapter
 import java.net.HttpURLConnection
@@ -227,6 +222,30 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun diag(msg: () -> String) = this@ReaderActivity.diag(msg)
     })
 
+    /** Bottom control bar + the nav panels it opens (RR16/RR25) — page slider, chapter jumps,
+     *  bookmarks, Contents, annotations list, library, go-home (SRP). */
+    private val bottomBar = BottomBarController(object : BottomBarController.Host {
+        override val activity get() = this@ReaderActivity
+        override val docHandle get() = this@ReaderActivity.docHandle
+        override val pageCount get() = this@ReaderActivity.pageCount
+        override val currentPage get() = this@ReaderActivity.currentPage
+        override val chapters get() = this@ReaderActivity.chapters
+        override val bookmarks get() = this@ReaderActivity.bookmarks
+        override val requestedPath get() = this@ReaderActivity.requestedPath
+        override fun engineExecute(block: () -> Unit) { engine.execute(block) }
+        override fun postJump(page: Int) = this@ReaderActivity.postJump(page)
+        override fun repaintPanel() = this@ReaderActivity.repaintPanel()
+        override fun openPicker() = this@ReaderActivity.openPicker()
+        override fun openFromLibrary(file: File) = this@ReaderActivity.openFromLibrary(file)
+        override fun palmGuard(content: View) = this@ReaderActivity.palmGuard(content)
+        override fun zoomIn() = zoomBy(ZOOM_STEP)
+        override fun zoomOut() = zoomBy(1f / ZOOM_STEP)
+        override fun openSearch() = search.showSearchDialog()
+        override fun openExport() = export.showExportDialog()
+        override fun openDicts() = dict.showDictionariesDialog()
+        override fun openAdjust() = adjust.show()
+    })
+
     /** The in-progress stroke as interleaved view-px x,y; UI-thread only. */
     private val strokeBuf = ArrayList<Float>()
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -292,7 +311,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private var lastCentreTapY = 0f
     /** A centre single-tap's action (open the bottom bar), deferred [DOUBLE_TAP_MS] so it can be
      *  cancelled if a second tap turns it into a double-tap-zoom. Edge taps stay immediate (#54). */
-    private val pendingCentreMenu = Runnable { showBottomBar() }
+    private val pendingCentreMenu = Runnable { bottomBar.showBottomBar() }
     private val fingerLongPress = Runnable {
         // A genuine 500ms hold (UP cancels this for a tap; a beyond-slop MOVE cancels it for a
         // swipe). Mark it a long-press FIRST so the eventual UP never falls through to a page flip —
@@ -1480,7 +1499,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
         // Top-right corner → toggle the bookmark dog-ear (Kindle/KOReader convention).
         if (w > 0f && h > 0f && x > w * 0.86f && y < h * 0.08f) {
-            toggleBookmark()
+            bottomBar.toggleBookmark()
             return
         }
         val third = w / 3f
@@ -1586,46 +1605,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
     }
 
-    /** Jump to the previous (`dir<0`) / next (`dir>0`) chapter start relative to the current page
-     *  (1.7). No-op with a brief toast at the document ends or when the doc has no chapters. */
-    private fun chapterJump(dir: Int) {
-        val starts = chapters.map { it.first }
-        if (starts.isEmpty()) {
-            Toast.makeText(this, "No chapters in this document", Toast.LENGTH_SHORT).show()
-            return
-        }
-        val cur = currentPage
-        val target = if (dir > 0) starts.firstOrNull { it > cur } else starts.lastOrNull { it < cur }
-        if (target != null) {
-            postJump(target)
-        } else {
-            Toast.makeText(this, if (dir > 0) "Last chapter" else "First chapter", Toast.LENGTH_SHORT).show()
-        }
-    }
-
-    /** "Ch 2/9 · The Crossing" for the chapter the current page sits in, or null if the doc has no
-     *  chapters. The current chapter is the last one whose start page is ≤ the current page. */
-    private fun currentChapterLabel(): String? {
-        val ch = chapters
-        if (ch.isEmpty()) return null
-        val idx = ch.indexOfLast { it.first <= currentPage }.coerceAtLeast(0)
-        return "Ch ${idx + 1}/${ch.size} · ${ch[idx].second}"
-    }
-
-    /** In-chapter position "3/24" — the current page within the current chapter (this chapter's start
-     *  → the next chapter's start; the last chapter runs to the end of the document). Null with no
-     *  chapters, or before the first chapter start (front matter). */
-    private fun inChapterPosition(): String? {
-        val ch = chapters
-        if (ch.isEmpty()) return null
-        val idx = ch.indexOfLast { it.first <= currentPage }
-        if (idx < 0) return null
-        val start = ch[idx].first
-        val end = if (idx + 1 < ch.size) ch[idx + 1].first else pageCount
-        val total = (end - start).coerceAtLeast(1)
-        return "${currentPage - start + 1}/$total"
-    }
-
     /** Drop any lasso selection when the page changes — the ids belong to the old page (engine). */
     private fun dropSelectionForPageChange() {
         if (selectedIds.isEmpty()) return
@@ -1645,389 +1624,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             canvas.drawRect(l, t, r, btm, searchFillPaint)
             canvas.drawRect(l, t, r, btm, searchBoxPaint)
         }
-    }
-
-    /**
-     * The reader's bottom control bar (RR16/RR25), KOReader-style: a thin panel **hugging the
-     * bottom edge** — a page slider with a tappable page indicator, above a flat row of controls
-     * (Home · Library · Bookmark · Marks · Contents · Open). Built programmatically, high-contrast
-     * for e-ink; uses the cached page state so showing it needs no engine round-trip.
-     */
-    private fun showBottomBar() {
-        if (docHandle == 0L) {
-            openPicker()
-            return
-        }
-        val total = pageCount.coerceAtLeast(1)
-        val cur = currentPage.coerceIn(0, total - 1)
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-
-        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
-        val container = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Ink.paper)
-        }
-        // A crisp black keyline up top so the bar reads as a docked surface, not a floating box.
-        container.addView(
-            View(this).apply { setBackgroundColor(Ink.ink) },
-            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
-        )
-
-        // Page-slider row:  [N / Total]  ────────●────────  (grayscale, tap the chip to type a page)
-        val pageLabel = TextView(this).apply {
-            text = "${cur + 1} / $total"
-            setTextColor(Ink.ink)
-            textSize = 12f
-            typeface = Ink.mono
-            letterSpacing = 0.04f
-            gravity = Gravity.CENTER
-            setPadding(dp(12), dp(6), dp(12), dp(6))
-            background = GradientDrawable().apply {
-                setColor(Ink.fill)
-                cornerRadius = Ink.dpf(40)
-            }
-            setOnClickListener { dialog.dismiss(); showPageEntry(total) }
-        }
-        // A refined, thin grayscale track + small round thumb (the default SeekBar reads clunky).
-        val trackH = dp(3).coerceAtLeast(2)
-        fun bar(c: Int) = GradientDrawable().apply { setColor(c); cornerRadius = trackH.toFloat(); setSize(0, trackH) }
-        val track = android.graphics.drawable.LayerDrawable(
-            arrayOf(
-                bar(Ink.hairline),
-                android.graphics.drawable.ClipDrawable(bar(Ink.ink), Gravity.START, android.graphics.drawable.ClipDrawable.HORIZONTAL),
-            ),
-        ).apply { setId(0, android.R.id.background); setId(1, android.R.id.progress) }
-        val knob = GradientDrawable().apply { shape = GradientDrawable.OVAL; setColor(Ink.ink); setSize(dp(16), dp(16)) }
-        val seek = SeekBar(this).apply {
-            max = total - 1
-            progress = cur
-            progressDrawable = track
-            thumb = knob
-            splitTrack = false
-            setPadding(dp(10), dp(4), dp(10), dp(4))
-            setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
-                override fun onProgressChanged(sb: SeekBar, p: Int, fromUser: Boolean) {
-                    if (fromUser) pageLabel.text = "${p + 1} / $total"
-                }
-                override fun onStartTrackingTouch(sb: SeekBar) {}
-                override fun onStopTrackingTouch(sb: SeekBar) { dialog.dismiss(); postJump(sb.progress) }
-            })
-        }
-        // Double-chevron chapter jumps flank the scrubber (distinct from single-page edge taps),
-        // shown only when the document has a table of contents (1.7).
-        fun chapterBtn(glyph: String, dir: Int) = TextView(this).apply {
-            text = glyph; setTextColor(Ink.ink); textSize = 20f; typeface = Ink.serifBold
-            gravity = Gravity.CENTER; setPadding(dp(8), dp(2), dp(8), dp(2)); isClickable = true
-            setOnClickListener { dialog.dismiss(); chapterJump(dir) }
-        }
-        container.addView(
-            LinearLayout(this).apply {
-                orientation = LinearLayout.HORIZONTAL
-                gravity = Gravity.CENTER_VERTICAL
-                setPadding(dp(16), dp(12), dp(16), dp(6))
-                if (chapters.isNotEmpty()) addView(chapterBtn("‹‹", -1))
-                addView(seek, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-                if (chapters.isNotEmpty()) addView(chapterBtn("››", +1))
-                addView(pageLabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply { marginStart = dp(12) })
-            },
-        )
-        // Current-chapter line under the scrubber: orients the reader and makes the ‹‹/›› obvious.
-        // Left = "Ch i/n · Title" (ellipsized); right = in-chapter "p/q" (stays visible). Tap → the
-        // full Contents sheet. Shown only when the document has chapters.
-        currentChapterLabel()?.let { lbl ->
-            container.addView(LinearLayout(this).apply {
-                orientation = LinearLayout.HORIZONTAL
-                gravity = Gravity.CENTER_VERTICAL
-                setPadding(dp(24), 0, dp(24), dp(8))
-                isClickable = true
-                setOnClickListener { dialog.dismiss(); showContentsLazy() }
-                addView(TextView(this@ReaderActivity).apply {
-                    text = lbl; setTextColor(Ink.inkSoft); textSize = 12f; typeface = Ink.serif
-                    maxLines = 1; ellipsize = android.text.TextUtils.TruncateAt.END
-                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-                inChapterPosition()?.let { pos ->
-                    addView(TextView(this@ReaderActivity).apply {
-                        text = pos; setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
-                        setPadding(dp(10), 0, 0, 0)
-                    })
-                }
-            })
-        }
-
-        // Control row: flat, evenly-weighted icon+label cells.
-        val controls = LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL
-            setPadding(dp(2), dp(6), dp(2), dp(12))
-        }
-        // One control = a line icon over a small label (Boox/NeoReader bottom-bar style, frame 069).
-        fun control(iconRes: Int, label: String, onClick: () -> Unit) {
-            val cell = LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL
-                gravity = Gravity.CENTER
-                setPadding(dp(2), dp(8), dp(2), dp(8))
-                isClickable = true
-                setOnClickListener { dialog.dismiss(); onClick() }
-            }
-            cell.addView(
-                ImageView(this).apply {
-                    setImageResource(iconRes); setColorFilter(Ink.ink)
-                },
-                LinearLayout.LayoutParams(dp(39), dp(39)),
-            )
-            cell.addView(TextView(this).apply {
-                text = label; setTextColor(Ink.inkSoft); textSize = 11f
-                typeface = Ink.mono; letterSpacing = 0.02f
-                gravity = Gravity.CENTER; setPadding(0, dp(5), 0, 0)
-            })
-            controls.addView(cell, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-        }
-        // Reading a compiled Daily issue → a back-to-the-front-page control (DailyActivity is the
-        // parent in the back stack, so finishing returns to the article list).
-        if (requestedPath?.contains("/daily/") == true) {
-            control(R.drawable.ic_menu_contents, "Daily") { finish() }
-        }
-        // "Home" already opens the library home, so a separate Library item here is redundant.
-        control(R.drawable.ic_menu_home, "Home") { goHome() }
-        // (Bookmark toggle moved to the top-right corner dog-ear; "Marks" lists them.)
-        control(R.drawable.ic_menu_marks, "Marks") { showBookmarks() }
-        control(R.drawable.ic_tool_pen, "Notes") { showAnnotations() }
-        control(R.drawable.ic_menu_contents, "Contents") { showContentsLazy() }
-        control(R.drawable.ic_menu_search, "Search") { search.showSearchDialog() }
-        // Quick zoom (circle −/+ icons — not magnifiers, which are reserved for Search). Also in Adjust → Zoom.
-        control(R.drawable.ic_menu_zoom_out, "Zoom −") { zoomBy(1f / ZOOM_STEP) }
-        control(R.drawable.ic_menu_zoom_in, "Zoom +") { zoomBy(ZOOM_STEP) }
-        control(R.drawable.ic_menu_export, "Export") { export.showExportDialog() }
-        control(R.drawable.ic_menu_dict, "Dicts") { dict.showDictionariesDialog() }
-        // Document controls consolidated into one KOReader-style tabbed sheet (Rotate/Fit/Font/Display).
-        control(R.drawable.ic_menu_adjust, "Adjust") { adjust.show() }
-        control(R.drawable.ic_menu_open, "Open") { openPicker() }
-        container.addView(controls)
-
-        // Palm guard: a hand resting on the bottom-anchored bar must not press a control (esp. Home).
-        dialog.setContentView(palmGuard(container))
-        dialog.window?.apply {
-            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-            setGravity(Gravity.BOTTOM)
-            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Ink.paper))
-        }
-        dialog.show()
-    }
-
-    /** A "go to page" text-entry dialog (RR11-FR1): type a 1-based page number to jump. */
-    private fun showPageEntry(total: Int) {
-        val input = EditText(this).apply {
-            inputType = InputType.TYPE_CLASS_NUMBER
-            hint = "1 – $total"
-        }
-        AlertDialog.Builder(this, R.style.InkDialog)
-            .setTitle("Go to page")
-            .setView(input)
-            .setPositiveButton("Go") { _, _ ->
-                val n = input.text.toString().toIntOrNull()
-                if (n != null && n in 1..total) {
-                    postJump(n - 1)
-                } else {
-                    Toast.makeText(this, "Enter a page from 1 to $total", Toast.LENGTH_SHORT).show()
-                }
-            }
-            .setNegativeButton("Cancel", null)
-            .show()
-    }
-
-    /** Toggle a bookmark on the current page (RR16); redraw so the dog-ear appears/disappears. */
-    private fun toggleBookmark() {
-        engine.execute {
-            val bm = bookmarks ?: return@execute
-            val page = currentPage
-            val now = bm.toggle(page)
-            runOnUiThread {
-                val msg = if (now) "Bookmarked page ${page + 1}" else "Bookmark removed"
-                Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
-            }
-            repaintPanel()
-        }
-    }
-
-    /** List the bookmarked pages (RR16); tap one to jump. */
-    private fun showBookmarks() {
-        engine.execute {
-            val marks = bookmarks?.pages() ?: emptyList()
-            runOnUiThread {
-                if (marks.isEmpty()) {
-                    Toast.makeText(this, "No bookmarks yet — tap Bookmark to add one", Toast.LENGTH_SHORT).show()
-                    return@runOnUiThread
-                }
-                val labels = marks.map { "Page ${it + 1}" }.toTypedArray()
-                AlertDialog.Builder(this, R.style.InkDialog)
-                    .setTitle("Bookmarks")
-                    .setItems(labels) { _, which -> postJump(marks[which]) }
-                    .show()
-            }
-        }
-    }
-
-    /** Fetch the TOC on the engine thread, then show it (RR11-FR2). */
-    private fun showContentsLazy() {
-        engine.execute {
-            if (docHandle == 0L) return@execute
-            val toc = try {
-                WireCodec.decodeToc(NativeBridge.nativeToc(docHandle))
-            } catch (e: RuntimeException) {
-                Log.e(TAG, "toc failed: ${e.message}")
-                emptyList()
-            }
-            runOnUiThread {
-                if (toc.isEmpty()) {
-                    Toast.makeText(this, "No contents in this document", Toast.LENGTH_SHORT).show()
-                } else {
-                    showContents(toc)
-                }
-            }
-        }
-    }
-
-    /** Handwritten-notes annotations list (1.5): fetch inked pages + their stroke counts off-thread,
-     *  then show a tap-to-jump list. */
-    private fun showAnnotations() {
-        engine.execute {
-            if (docHandle == 0L) return@execute
-            val pages = try {
-                NativeBridge.nativeInkPages(docHandle)
-            } catch (e: RuntimeException) {
-                Log.e(TAG, "ink pages failed: ${e.message}"); IntArray(0)
-            }
-            val items = pages.map { p ->
-                val count = try {
-                    WireCodec.decodeStrokes(NativeBridge.nativeInkStrokesForDraw(docHandle, p)).size
-                } catch (e: RuntimeException) { 0 }
-                p to count
-            }
-            runOnUiThread {
-                if (items.isEmpty()) {
-                    Toast.makeText(this, "No handwritten notes yet", Toast.LENGTH_SHORT).show()
-                } else {
-                    showAnnotationsList(items)
-                }
-            }
-        }
-    }
-
-    /** The inked pages as a scrollable "Page N · M notes" list; tap a row to jump there. */
-    private fun showAnnotationsList(items: List<Pair<Int, Int>>) {
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
-        val outer = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            setPadding(dp(24), dp(22), dp(24), dp(14))
-        }
-        outer.addView(Ink.eyebrow(this, "Annotations"))
-        outer.addView(Ink.gap(this, 10))
-        outer.addView(Ink.rule(this))
-        outer.addView(Ink.gap(this, 4))
-        val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
-        items.forEachIndexed { i, (page, count) ->
-            if (i > 0) list.addView(View(this).apply { setBackgroundColor(Ink.hairline) },
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()))
-            list.addView(LinearLayout(this).apply {
-                orientation = LinearLayout.HORIZONTAL
-                gravity = Gravity.CENTER_VERTICAL
-                setPadding(dp(4), dp(14), dp(4), dp(14))
-                isClickable = true
-                setOnClickListener { dialog.dismiss(); postJump(page) }
-                addView(TextView(this@ReaderActivity).apply {
-                    text = "Page ${page + 1}"
-                    setTextColor(Ink.ink); textSize = 17f; typeface = Ink.serifBold
-                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-                addView(TextView(this@ReaderActivity).apply {
-                    text = if (count == 1) "1 note" else "$count notes"
-                    setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
-                })
-            })
-        }
-        outer.addView(ScrollView(this).apply { addView(list) },
-            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, (resources.displayMetrics.heightPixels * 0.7f).toInt()))
-        dialog.setContentView(outer)
-        dialog.window?.apply {
-            setLayout((resources.displayMetrics.widthPixels * 0.82f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
-            setBackgroundDrawable(Ink.cardBg())
-        }
-        dialog.show()
-    }
-
-    /** The document's table of contents (RR11-FR2), shown as a scrollable list from the popup. */
-    private fun showContents(toc: List<TocItem>) {
-        if (toc.isEmpty()) return
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
-
-        val outer = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            setPadding(dp(24), dp(22), dp(24), dp(14))
-        }
-        outer.addView(Ink.eyebrow(this, "Contents"))
-        outer.addView(Ink.gap(this, 10))
-        outer.addView(Ink.rule(this))
-        outer.addView(Ink.gap(this, 4))
-        val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
-        toc.forEachIndexed { i, item ->
-            if (i > 0) list.addView(View(this).apply { setBackgroundColor(Ink.hairline) },
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()))
-            list.addView(LinearLayout(this).apply {
-                orientation = LinearLayout.HORIZONTAL
-                gravity = Gravity.CENTER_VERTICAL
-                setPadding(dp(4) + item.depth * dp(18), dp(14), dp(4), dp(14))
-                isClickable = true
-                setOnClickListener { dialog.dismiss(); item.targetPage?.let { postJump(it) } }
-                addView(TextView(this@ReaderActivity).apply {
-                    text = item.title
-                    setTextColor(if (item.targetPage != null) Ink.ink else Ink.muted)
-                    textSize = if (item.depth == 0) 17f else 15f
-                    typeface = if (item.depth == 0) Ink.serifBold else Ink.serif
-                    maxLines = 2
-                }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-                item.targetPage?.let { p ->
-                    addView(TextView(this@ReaderActivity).apply {
-                        text = "${p + 1}"; setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
-                        setPadding(dp(12), 0, 0, 0)
-                    })
-                }
-            })
-        }
-        outer.addView(ScrollView(this).apply { addView(list) },
-            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, (resources.displayMetrics.heightPixels * 0.7f).toInt()))
-
-        dialog.setContentView(outer)
-        dialog.window?.apply {
-            setLayout((resources.displayMetrics.widthPixels * 0.82f).toInt(), ViewGroup.LayoutParams.WRAP_CONTENT)
-            setBackgroundDrawable(Ink.cardBg())
-        }
-        dialog.show()
-    }
-
-    /** The on-device library (RR17): pick a stored book to open it in place. */
-    private fun showLibraryDialog() {
-        val books = Books.list(this)
-        if (books.isEmpty()) {
-            Toast.makeText(this, "No books yet — open a PDF first", Toast.LENGTH_SHORT).show()
-            return
-        }
-        val labels = books.map { Books.title(it) }.toTypedArray()
-        AlertDialog.Builder(this, R.style.InkDialog)
-            .setTitle("Library")
-            .setItems(labels) { _, which -> openFromLibrary(books[which]) }
-            .show()
-    }
-
-    /** Return to the home screen (RR16), leaving the reader. */
-    private fun goHome() {
-        startActivity(
-            Intent(this, HomeActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
-        )
-        finish()
     }
 
     // ===== Tool model (ADR-INKREAD-0010) =====

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -3,7 +3,6 @@ package dev.jraghavan.inkread
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
@@ -206,6 +205,28 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun openPicker() = this@ReaderActivity.openPicker()
     })
 
+    /** Persisted display + typography settings (RR4); shared by openBook and the Adjust sheet. */
+    private val displayPrefs = DisplayPrefs(this)
+
+    /** Document-settings sheet (RR4) — owns the tabbed panels + widgets + presets (SRP). The
+     *  shell keeps the page geometry: reflow toggle + zoom mutate through the Host. */
+    private val adjust = AdjustSheetController(object : AdjustSheetController.Host {
+        override val activity get() = this@ReaderActivity
+        override val docHandle get() = this@ReaderActivity.docHandle
+        override val prefs get() = displayPrefs
+        override val reflowOn get() = this@ReaderActivity.reflowOn
+        override val zoomPercent get() = (zoom * 100).toInt()
+        override fun engineExecute(block: () -> Unit) { engine.execute(block) }
+        override fun repaintPanel() = this@ReaderActivity.repaintPanel()
+        override fun refreshPageCount() { pageCount = NativeBridge.nativePageCount(docHandle) }
+        override fun setReflowMode(on: Boolean) = this@ReaderActivity.setReflowMode(on)
+        override fun zoomIn() = zoomBy(ZOOM_STEP)
+        override fun zoomOut() = zoomBy(1f / ZOOM_STEP)
+        override fun openPicker() = this@ReaderActivity.openPicker()
+        override fun palmGuard(content: View) = this@ReaderActivity.palmGuard(content)
+        override fun diag(msg: () -> String) = this@ReaderActivity.diag(msg)
+    })
+
     /** The in-progress stroke as interleaved view-px x,y; UI-thread only. */
     private val strokeBuf = ArrayList<Float>()
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -377,7 +398,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         super.onCreate(savedInstanceState)
         // Re-apply the saved page rotation (RR4) before the surface is created so the first render
         // is at the right orientation. configChanges=orientation keeps us from recreating.
-        requestedOrientation = orientationPref()
+        requestedOrientation = displayPrefs.orientation
         // Prove the JNI boundary up front (RR1-AC2). Cheap; fine on the UI thread.
         Log.i(TAG, "core: ${NativeBridge.nativeHello()}")
 
@@ -768,31 +789,31 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             // A fixed-layout PDF magnifies; EPUB (always reflowed) does not (#61, RR25-FR3).
             magnifiable = try { NativeBridge.nativeIsMagnifiable(docHandle) } catch (e: RuntimeException) { false }
             // Re-apply the saved reflow text scale (EPUB); a no-op (-1) on fixed-layout PDF.
-            val savedScale = textScalePref()
+            val savedScale = displayPrefs.textScale
             if (savedScale != 1.0f) {
                 val np = try { NativeBridge.nativeSetTextScale(docHandle, savedScale) } catch (e: RuntimeException) { -1 }
                 if (np >= 0) Log.i(TAG, "applied text scale $savedScale → page $np")
             }
             // Re-apply the saved reflow typeface (EPUB); default face 0 (a no-op on fixed-layout PDF).
-            if (fontPref() != 0) {
-                try { NativeBridge.nativeSetFont(docHandle, fontPref()) } catch (e: RuntimeException) {}
+            if (displayPrefs.font != 0) {
+                try { NativeBridge.nativeSetFont(docHandle, displayPrefs.font) } catch (e: RuntimeException) {}
             }
             // Re-apply the saved display contrast (RR4); 0 = off (a no-op in the core).
-            try { NativeBridge.nativeSetContrast(docHandle, contrastPref()) } catch (e: RuntimeException) {}
+            try { NativeBridge.nativeSetContrast(docHandle, displayPrefs.contrast) } catch (e: RuntimeException) {}
             // Re-apply night mode (invert); default off (RR4 / style presets).
-            try { NativeBridge.nativeSetNight(docHandle, nightPref()) } catch (e: RuntimeException) {}
+            try { NativeBridge.nativeSetNight(docHandle, displayPrefs.night) } catch (e: RuntimeException) {}
             // Re-apply the saved page fit mode (RR4); default Page/contain.
-            try { NativeBridge.nativeSetFit(docHandle, fitPref()) } catch (e: RuntimeException) {}
+            try { NativeBridge.nativeSetFit(docHandle, displayPrefs.fit) } catch (e: RuntimeException) {}
             // Re-apply the saved auto-crop + margin (RR4); default off.
-            try { NativeBridge.nativeSetCrop(docHandle, if (cropAutoPref()) 1 else 0, cropMarginPref()) } catch (e: RuntimeException) {}
+            try { NativeBridge.nativeSetCrop(docHandle, if (displayPrefs.cropAuto) 1 else 0, displayPrefs.cropMargin) } catch (e: RuntimeException) {}
             // Re-apply the saved render quality (RR4); default 1.
-            try { NativeBridge.nativeSetRenderQuality(docHandle, renderQualityPref()) } catch (e: RuntimeException) {}
+            try { NativeBridge.nativeSetRenderQuality(docHandle, displayPrefs.renderQuality) } catch (e: RuntimeException) {}
             // Re-apply saved reflow line-spacing + alignment (RR4; EPUB only — PDF returns -1).
-            if (kotlin.math.abs(lineSpacingMult() - DEFAULT_LINE_SPACING) > 0.001f) {
-                try { NativeBridge.nativeSetLineSpacing(docHandle, lineSpacingMult()) } catch (e: RuntimeException) {}
+            if (kotlin.math.abs(displayPrefs.lineSpacingMult - DisplayPrefs.DEFAULT_LINE_SPACING) > 0.001f) {
+                try { NativeBridge.nativeSetLineSpacing(docHandle, displayPrefs.lineSpacingMult) } catch (e: RuntimeException) {}
             }
-            if (alignmentPref() != 0) {
-                try { NativeBridge.nativeSetAlignment(docHandle, alignmentPref()) } catch (e: RuntimeException) {}
+            if (displayPrefs.alignment != 0) {
+                try { NativeBridge.nativeSetAlignment(docHandle, displayPrefs.alignment) } catch (e: RuntimeException) {}
             }
             pageCount = NativeBridge.nativePageCount(docHandle)
             Books.pushRecent(this, bookId, path)
@@ -1779,7 +1800,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         control(R.drawable.ic_menu_export, "Export") { export.showExportDialog() }
         control(R.drawable.ic_menu_dict, "Dicts") { dict.showDictionariesDialog() }
         // Document controls consolidated into one KOReader-style tabbed sheet (Rotate/Fit/Font/Display).
-        control(R.drawable.ic_menu_adjust, "Adjust") { showAdjustSheet() }
+        control(R.drawable.ic_menu_adjust, "Adjust") { adjust.show() }
         control(R.drawable.ic_menu_open, "Open") { openPicker() }
         container.addView(controls)
 
@@ -2223,11 +2244,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 if (pinchFont) {
                     // Map the pinch ratio onto the font scale: pinch out 1.3x ≈ font 1.3x, snapped to
                     // the nearest preset. A small/accidental pinch leaves the size unchanged.
-                    val cur = nearestScaleIndex(textScalePref())
-                    val target = nearestScaleIndex(
-                        (textScalePref() * liveScale).coerceIn(TEXT_SCALES.first(), TEXT_SCALES.last())
+                    val cur = DisplayPrefs.nearestScaleIndex(displayPrefs.textScale)
+                    val target = DisplayPrefs.nearestScaleIndex(
+                        (displayPrefs.textScale * liveScale).coerceIn(DisplayPrefs.TEXT_SCALES.first(), DisplayPrefs.TEXT_SCALES.last())
                     )
-                    if (target != cur) applyReflowScale(target, announce = true)
+                    if (target != cur) adjust.applyReflowScale(target, announce = true)
                     return
                 }
                 val newZoom = (gestureStartZoom * liveScale).coerceIn(1f, MAX_ZOOM_UI)
@@ -2776,284 +2797,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
     }
 
-    private fun contrastPref(): Int =
-        getSharedPreferences("display", MODE_PRIVATE).getInt("contrast", 0).coerceIn(0, CONTRAST_MAX)
-
-    private fun setContrastPref(step: Int) =
-        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("contrast", step).apply()
-
-    // ---- Document settings sheet (RR4 — KOReader-style tabbed controls) ----
-
-    /**
-     * A KOReader-style tabbed settings sheet that consolidates the document controls
-     * (Rotate / Fit / Font / Display) behind one bottom-bar entry — matching KOReader's bottom
-     * sheet structure. Each tab swaps an inline control panel; changes apply live + persist.
-     */
-    private fun showAdjustSheet() {
-        if (docHandle == 0L) { openPicker(); return }
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        val dialog = Dialog(this).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
-        val content = android.widget.FrameLayout(this)
-
-        val panels: List<Triple<String, Int, () -> View>> = listOf(
-            Triple("Style", R.drawable.ic_menu_adjust) { stylePanel() },
-            Triple("Rotate", R.drawable.ic_menu_rotate) { rotationPanel() },
-            Triple("Crop", R.drawable.ic_menu_crop) { cropPanel() },
-            Triple("Zoom", R.drawable.ic_menu_fit) { zoomPanel() },
-            Triple("Page", R.drawable.ic_menu_page) { pagePanel() },
-            Triple("Font", R.drawable.ic_menu_font) { fontPanel() },
-            Triple("Display", R.drawable.ic_menu_display) { displayPanel() },
-        )
-        val cells = ArrayList<LinearLayout>()
-        fun select(i: Int) {
-            content.removeAllViews()
-            content.addView(panels[i].third())
-            cells.forEachIndexed { j, c ->
-                // Active tab: white, boxed (connected to the panel) + bold label. Inactive: flat gray.
-                if (j == i) {
-                    c.background = GradientDrawable().apply {
-                        setColor(Ink.paper); setStroke(Ink.keyline(), Ink.ink)
-                    }
-                } else {
-                    c.background = null
-                    c.setBackgroundColor(Ink.fill)
-                }
-                val tab = c.getChildAt(1) as? TextView
-                tab?.setTypeface(Ink.mono, if (j == i) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
-                tab?.setTextColor(if (j == i) Ink.ink else Ink.inkSoft)
-            }
-        }
-        val tabRow = LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL
-            setBackgroundColor(Ink.fill)
-        }
-        panels.forEachIndexed { i, (label, icon, _) ->
-            val cell = LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL; gravity = Gravity.CENTER
-                setPadding(dp(4), dp(10), dp(4), dp(10)); isClickable = true
-                setOnClickListener { select(i) }
-                addView(
-                    ImageView(this@ReaderActivity).apply { setImageResource(icon); setColorFilter(Ink.ink) },
-                    LinearLayout.LayoutParams(dp(24), dp(24)),
-                )
-                addView(TextView(this@ReaderActivity).apply {
-                    text = label; textSize = 10f; setTextColor(Ink.inkSoft); typeface = Ink.mono
-                    gravity = Gravity.CENTER; setPadding(0, dp(3), 0, 0)
-                })
-            }
-            cells.add(cell)
-            tabRow.addView(cell, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-        }
-        val container = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Ink.paper)
-            // Black keyline up top so the sheet reads as a docked surface (bottom-bar template).
-            addView(
-                View(this@ReaderActivity).apply { setBackgroundColor(Ink.ink) },
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
-            )
-            // Active tab's panel — WRAP_CONTENT so the sheet GROWS UP per tab (KOReader-style),
-            // bottom-anchored, instead of a fixed box with dead space.
-            addView(
-                content,
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT),
-            )
-            addView(
-                View(this@ReaderActivity).apply { setBackgroundColor(Ink.hairline) },
-                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, Ink.hair()),
-            )
-            addView(tabRow)
-        }
-        select(0)
-        dialog.setContentView(palmGuard(container)) // same palm guard as the bottom bar
-        dialog.window?.apply {
-            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-            setGravity(Gravity.BOTTOM)
-            setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Ink.paper))
-        }
-        dialog.show()
-    }
-
-    /** A KOReader-style **segmented control**: a rounded pill of [options] with the [selected]
-     *  segment filled dark. Updates its own highlight on tap, then calls [onSelect]. */
-    private fun segmented(options: List<String>, selected: Int, onSelect: (Int) -> Unit): View {
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        val radius = dp(20).toFloat()
-        var sel = selected
-        val segs = ArrayList<TextView>()
-        fun style(tv: TextView, on: Boolean) {
-            if (on) {
-                tv.setTextColor(Ink.paper)
-                tv.setTypeface(null, android.graphics.Typeface.BOLD)
-                tv.background = GradientDrawable().apply { setColor(Ink.ink); cornerRadius = radius }
-            } else {
-                tv.setTextColor(Ink.ink)
-                tv.setTypeface(null, android.graphics.Typeface.NORMAL)
-                tv.background = null
-            }
-        }
-        return LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL
-            background = GradientDrawable().apply {
-                setColor(Ink.paper); cornerRadius = radius
-                setStroke(Ink.hair(), Ink.ringSoft)
-            }
-            val p = dp(3); setPadding(p, p, p, p)
-            options.forEachIndexed { i, opt ->
-                val tv = TextView(this@ReaderActivity).apply {
-                    text = opt; textSize = 15f; gravity = Gravity.CENTER
-                    setPadding(dp(6), dp(10), dp(6), dp(10)); isClickable = true
-                    setOnClickListener { sel = i; segs.forEachIndexed { j, t -> style(t, j == sel) }; onSelect(i) }
-                }
-                style(tv, i == sel)
-                segs.add(tv)
-                addView(tv, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
-            }
-        }
-    }
-
-    /** A KOReader-style **cell bar**: [count] boxes filled up to the current level; tapping box i
-     *  sets level i+1 (tapping the current top cell turns it off → 0). Repaints on tap. */
-    private fun cellBar(count: Int, initial: Int, onSet: (Int) -> Unit): View {
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        var filled = initial
-        val draws = ArrayList<GradientDrawable>()
-        fun repaint() = draws.forEachIndexed { i, g ->
-            g.setColor(if (i < filled) Ink.ink else Ink.paper)
-        }
-        return LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
-            for (i in 0 until count) {
-                val g = GradientDrawable().apply { setStroke(Ink.hair(), Ink.ringSoft) }
-                draws.add(g)
-                addView(View(this@ReaderActivity).apply {
-                    background = g; isClickable = true
-                    setOnClickListener {
-                        filled = if (i + 1 == filled) 0 else i + 1
-                        repaint(); invalidate()
-                        onSet(filled)
-                    }
-                }, LinearLayout.LayoutParams(0, dp(30), 1f).apply { val m = dp(2); setMargins(m, 0, m, 0) })
-            }
-            repaint()
-        }
-    }
-
-    /** A KOReader-style settings row: a right-aligned [label] on the left, the [control] on the right. */
-    private fun settingRow(label: String, control: View): View {
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        return LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
-            setPadding(dp(16), dp(14), dp(16), dp(14))
-            addView(TextView(this@ReaderActivity).apply {
-                text = label; textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.END
-            }, LinearLayout.LayoutParams(dp(96), ViewGroup.LayoutParams.WRAP_CONTENT))
-            addView(control, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
-                marginStart = dp(14)
-            })
-        }
-    }
-
-    private fun rotationPanel(): View {
-        val orients = intArrayOf(
-            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
-            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
-            ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT,
-            ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
-        )
-        val sel = orients.indexOf(orientationPref()).coerceAtLeast(0)
-        return settingRow("Rotation", segmented(listOf("0°", "90°", "180°", "270°"), sel) { which ->
-            diag { "DIAG rotation -> $which" }
-            applyOrientation(orients[which])
-        })
-    }
-
-    private fun fitPanel(): View {
-        val sel = fitPref().coerceIn(0, 2) // index = core FitMode code
-        return settingRow("Fit", segmented(listOf("Full", "Width", "Height"), sel) { which ->
-            setFitPref(which)
-            diag { "DIAG fit -> mode=$which" }
-            engine.execute {
-                try { NativeBridge.nativeSetFit(docHandle, which) } catch (e: RuntimeException) {}
-                repaintPanel()
-            }
-        })
-    }
-
-    /** The "Crop" tab: Page Crop (None/Auto) + a Margin cell bar (margin kept around the content). */
-    private fun cropPanel(): View {
-        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
-        container.addView(settingRow("Page Crop", segmented(listOf("None", "Auto"), if (cropAutoPref()) 1 else 0) { which ->
-            setCropAutoPref(which == 1)
-            diag { "DIAG crop auto=${which == 1}" }
-            engine.execute {
-                try { NativeBridge.nativeSetCrop(docHandle, which, cropMarginPref()) } catch (e: RuntimeException) {}
-                repaintPanel()
-            }
-        }))
-        container.addView(settingRow("Margin", cellBar(8, cropMarginPref()) { level ->
-            setCropMarginPref(level)
-            diag { "DIAG crop margin=$level" }
-            engine.execute {
-                try { NativeBridge.nativeSetCrop(docHandle, if (cropAutoPref()) 1 else 0, level) } catch (e: RuntimeException) {}
-                repaintPanel()
-            }
-        }))
-        return container
-    }
-
-    private fun cropAutoPref(): Boolean =
-        getSharedPreferences("display", MODE_PRIVATE).getBoolean("crop_auto", false)
-
-    private fun setCropAutoPref(v: Boolean) =
-        getSharedPreferences("display", MODE_PRIVATE).edit().putBoolean("crop_auto", v).apply()
-
-    private fun cropMarginPref(): Int =
-        getSharedPreferences("display", MODE_PRIVATE).getInt("crop_margin", 1).coerceIn(0, 8)
-
-    private fun setCropMarginPref(v: Int) =
-        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("crop_margin", v).apply()
-
-    /** The "Page" tab: reflow Line Spacing + Alignment (EPUB; a toast on fixed-layout PDF). */
-    private fun pagePanel(): View {
-        fun applyReflow(call: () -> Int) {
-            engine.execute {
-                val np = try { call() } catch (e: RuntimeException) { -1 }
-                if (np >= 0) {
-                    pageCount = NativeBridge.nativePageCount(docHandle)
-                    repaintPanel()
-                } else {
-                    runOnUiThread { Toast.makeText(this, "Page layout adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show() }
-                }
-            }
-        }
-        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
-        // Reflow toggle — only for a text-layer PDF (EPUB is always reflowable; a scanned PDF can't).
-        // It gates whether the Line Spacing / Alignment / Font Size controls take effect on a PDF.
-        val supportsReflow = try { NativeBridge.nativeSupportsReflow(docHandle) } catch (e: RuntimeException) { false }
-        if (supportsReflow) {
-            container.addView(settingRow("Reflow", segmented(listOf("Off", "On"), if (reflowOn) 1 else 0) { which ->
-                diag { "DIAG reflow=${which == 1}" }
-                setReflowMode(which == 1)
-            }))
-        }
-        container.addView(settingRow("Line Spacing", segmented(LINE_SPACING_LABELS, lineSpacingIndex()) { which ->
-            setLineSpacingMult(LINE_SPACINGS[which])
-            diag { "DIAG line spacing=${LINE_SPACINGS[which]}" }
-            applyReflow { NativeBridge.nativeSetLineSpacing(docHandle, LINE_SPACINGS[which]) }
-        }))
-        container.addView(settingRow("Alignment", segmented(listOf("Left", "Justify", "Center", "Right"), alignmentPref()) { which ->
-            setAlignmentPref(which)
-            diag { "DIAG alignment=$which" }
-            applyReflow { NativeBridge.nativeSetAlignment(docHandle, which) }
-        }))
-        return container
-    }
-
     /** Toggle PDF reflow (ADR-INKREAD-0011). On enable, re-apply the saved typography so the
      *  reflowed PDF respects the user's font size / spacing / alignment; the page count and position
      *  change across the toggle, so refresh both. A `-1` means no text layer (scanned PDF). */
@@ -3074,14 +2817,14 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 magnifiable = try { NativeBridge.nativeIsMagnifiable(docHandle) } catch (e: RuntimeException) { !on }
                 if (!magnifiable && zoom != 1f) { zoom = 1f; panX = 0f; panY = 0f }
                 if (on) {
-                    if (textScalePref() != 1.0f) {
-                        try { NativeBridge.nativeSetTextScale(docHandle, textScalePref()) } catch (e: RuntimeException) {}
+                    if (displayPrefs.textScale != 1.0f) {
+                        try { NativeBridge.nativeSetTextScale(docHandle, displayPrefs.textScale) } catch (e: RuntimeException) {}
                     }
-                    if (kotlin.math.abs(lineSpacingMult() - DEFAULT_LINE_SPACING) > 0.001f) {
-                        try { NativeBridge.nativeSetLineSpacing(docHandle, lineSpacingMult()) } catch (e: RuntimeException) {}
+                    if (kotlin.math.abs(displayPrefs.lineSpacingMult - DisplayPrefs.DEFAULT_LINE_SPACING) > 0.001f) {
+                        try { NativeBridge.nativeSetLineSpacing(docHandle, displayPrefs.lineSpacingMult) } catch (e: RuntimeException) {}
                     }
-                    if (alignmentPref() != 0) {
-                        try { NativeBridge.nativeSetAlignment(docHandle, alignmentPref()) } catch (e: RuntimeException) {}
+                    if (displayPrefs.alignment != 0) {
+                        try { NativeBridge.nativeSetAlignment(docHandle, displayPrefs.alignment) } catch (e: RuntimeException) {}
                     }
                 }
                 pageCount = NativeBridge.nativePageCount(docHandle)
@@ -3099,261 +2842,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         reflowProgressDialog?.let { runCatching { it.dismiss() } }
         reflowProgressDialog = null
         reflowInProgress = false
-    }
-
-    /** The saved line-spacing multiplier (value-based; new key, so a changed option set never
-     *  mis-maps an old index). Defaults to the core default 1.4. */
-    private fun lineSpacingMult(): Float =
-        getSharedPreferences("typography", MODE_PRIVATE)
-            .getInt("line_spacing_x100", (DEFAULT_LINE_SPACING * 100).toInt()) / 100f
-
-    private fun setLineSpacingMult(m: Float) =
-        getSharedPreferences("typography", MODE_PRIVATE)
-            .edit().putInt("line_spacing_x100", Math.round(m * 100)).apply()
-
-    /** The segmented index for the saved multiplier (nearest [LINE_SPACINGS] entry; default Medium). */
-    private fun lineSpacingIndex(): Int {
-        val m = lineSpacingMult()
-        val i = LINE_SPACINGS.indexOfFirst { kotlin.math.abs(it - m) < 0.001f }
-        return if (i >= 0) i else {
-            LINE_SPACINGS.indexOfFirst { kotlin.math.abs(it - DEFAULT_LINE_SPACING) < 0.001f }.coerceAtLeast(0)
-        }
-    }
-
-    private fun alignmentPref(): Int =
-        getSharedPreferences("typography", MODE_PRIVATE).getInt("alignment", 0).coerceIn(0, 3)
-
-    private fun setAlignmentPref(i: Int) =
-        getSharedPreferences("typography", MODE_PRIVATE).edit().putInt("alignment", i).apply()
-
-    /** The "Zoom" tab: the Fit segmented row + a live zoom −/+ stepper (zoom moved off the bar). */
-    private fun zoomPanel(): View {
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        val zlabel = TextView(this).apply {
-            textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
-        }
-        fun refresh() { zlabel.text = "${(zoom * 100).toInt()}%" }
-        refresh()
-        fun pill(t: String, on: () -> Unit) = TextView(this).apply {
-            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
-            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
-            background = GradientDrawable().apply {
-                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
-            }
-            setOnClickListener { on() }
-        }
-        val zoomControl = LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
-            addView(pill("−") { zoomBy(1f / ZOOM_STEP); refresh() })
-            addView(zlabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
-                val m = dp(10); setMargins(m, 0, m, 0)
-            })
-            addView(pill("+") { zoomBy(ZOOM_STEP); refresh() })
-        }
-        return LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            addView(fitPanel())
-            addView(settingRow("Zoom", zoomControl))
-        }
-    }
-
-    private fun displayPanel(): View {
-        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
-        container.addView(settingRow("Contrast", cellBar(CONTRAST_MAX, contrastPref()) { level ->
-            setContrastPref(level)
-            diag { "DIAG contrast step=$level" }
-            engine.execute {
-                try { NativeBridge.nativeSetContrast(docHandle, level) } catch (e: RuntimeException) {}
-                repaintPanel()
-            }
-        }))
-        container.addView(settingRow("Quality", segmented(listOf("Low", "Default", "High"), renderQualityPref()) { which ->
-            setRenderQualityPref(which)
-            diag { "DIAG render quality=$which" }
-            engine.execute {
-                try { NativeBridge.nativeSetRenderQuality(docHandle, which) } catch (e: RuntimeException) {}
-                repaintPanel()
-            }
-        }))
-        return container
-    }
-
-    /** A reading style preset (1.10): a bundle of (text scale, line-spacing index, contrast step,
-     *  night). Font/spacing are no-ops on fixed-layout PDFs; contrast/night apply to both. */
-    private data class StyleSpec(val scale: Float, val spacing: Float, val contrast: Int, val night: Boolean)
-
-    private fun styleSpec(name: String): StyleSpec = when (name) {
-        "Bold" -> StyleSpec(1.0f, DEFAULT_LINE_SPACING, 4, false) // darker text (heavier ink)
-        "Night" -> StyleSpec(1.0f, DEFAULT_LINE_SPACING, 0, true) // inverted (light on dark)
-        "Outdoor" -> StyleSpec(1.0f, DEFAULT_LINE_SPACING, CONTRAST_MAX, false) // maximum contrast
-        "Relaxed" -> StyleSpec(1.15f, 1.7f, 0, false) // larger + airier
-        else -> StyleSpec(1.0f, DEFAULT_LINE_SPACING, 0, false) // Original — defaults
-    }
-
-    /** The "Style" tab: one-tap presets that bundle font size, spacing, contrast, and night. */
-    private fun stylePanel(): View {
-        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
-        container.addView(
-            settingRow(
-                "Preset",
-                segmented(STYLE_PRESETS, STYLE_PRESETS.indexOf(stylePresetPref()).coerceAtLeast(0)) { which ->
-                    applyStylePreset(STYLE_PRESETS[which])
-                },
-            ),
-        )
-        return container
-    }
-
-    /** Apply + persist a style preset: set every knob, then repaginate/re-render. */
-    private fun applyStylePreset(name: String) {
-        val s = styleSpec(name)
-        setStylePresetPref(name)
-        setTextScalePref(s.scale)
-        setLineSpacingMult(s.spacing)
-        setContrastPref(s.contrast)
-        setNightPref(s.night)
-        engine.execute {
-            try {
-                NativeBridge.nativeSetTextScale(docHandle, s.scale)
-                NativeBridge.nativeSetLineSpacing(docHandle, s.spacing)
-                NativeBridge.nativeSetContrast(docHandle, s.contrast)
-                NativeBridge.nativeSetNight(docHandle, s.night)
-                pageCount = NativeBridge.nativePageCount(docHandle)
-            } catch (e: RuntimeException) {
-                Log.e(TAG, "style preset apply failed: ${e.message}")
-            }
-            repaintPanel()
-        }
-    }
-
-    private fun nightPref(): Boolean =
-        getSharedPreferences("display", MODE_PRIVATE).getBoolean("night", false)
-
-    private fun setNightPref(on: Boolean) =
-        getSharedPreferences("display", MODE_PRIVATE).edit().putBoolean("night", on).apply()
-
-    private fun stylePresetPref(): String =
-        getSharedPreferences("display", MODE_PRIVATE).getString("style_preset", "Original") ?: "Original"
-
-    private fun setStylePresetPref(name: String) =
-        getSharedPreferences("display", MODE_PRIVATE).edit().putString("style_preset", name).apply()
-
-    private fun renderQualityPref(): Int =
-        getSharedPreferences("display", MODE_PRIVATE).getInt("render_quality", 1).coerceIn(0, 2)
-
-    private fun setRenderQualityPref(q: Int) =
-        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("render_quality", q).apply()
-
-    private fun fontPanel(): View {
-        val d = resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        var idx = nearestScaleIndex(textScalePref())
-        val value = TextView(this).apply {
-            textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
-        }
-        fun refresh() { value.text = "${(TEXT_SCALES[idx] * 100).toInt()}%" }
-        refresh()
-        fun apply() { refresh(); applyReflowScale(idx, warnIfFixed = true) }
-        fun pill(t: String, on: () -> Unit) = TextView(this).apply {
-            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
-            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
-            background = GradientDrawable().apply {
-                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
-            }
-            setOnClickListener { on() }
-        }
-        val control = LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
-            addView(pill("A−") { if (idx > 0) { idx--; apply() } })
-            addView(value, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
-                val m = dp(10); setMargins(m, 0, m, 0)
-            })
-            addView(pill("A+") { if (idx < TEXT_SCALES.size - 1) { idx++; apply() } })
-            // Quick presets next to the steppers: jump straight to default / largest (#55).
-            fun preset(p: View) = addView(p, LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
-            ).apply { leftMargin = dp(8) })
-            preset(pill("100%") { idx = nearestScaleIndex(1.0f); apply() })
-            preset(pill("XL") { idx = TEXT_SCALES.size - 1; apply() })
-        }
-        val container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
-        // Typeface picker — the bundled reading faces (EPUB/reflow; a toast on fixed-layout PDF).
-        val faces = try {
-            NativeBridge.nativeFontNames().split("\n").filter { it.isNotBlank() }
-        } catch (e: RuntimeException) { emptyList() }
-        if (faces.isNotEmpty()) {
-            container.addView(settingRow("Typeface", segmented(faces, fontPref().coerceIn(0, faces.size - 1)) { which ->
-                setFontPref(which)
-                engine.execute {
-                    val np = try { NativeBridge.nativeSetFont(docHandle, which) } catch (e: RuntimeException) { -1 }
-                    if (np >= 0) { pageCount = NativeBridge.nativePageCount(docHandle); repaintPanel() }
-                    else runOnUiThread { Toast.makeText(this, "Typeface adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show() }
-                }
-            }))
-        }
-        container.addView(settingRow("Font Size", control))
-        return container
-    }
-
-    private fun fontPref(): Int =
-        getSharedPreferences("typography", MODE_PRIVATE).getInt("font_id", 0)
-
-    private fun setFontPref(id: Int) =
-        getSharedPreferences("typography", MODE_PRIVATE).edit().putInt("font_id", id).apply()
-
-    /** Set + persist the screen orientation; the resize re-renders the page (engine via surfaceChanged). */
-    private fun applyOrientation(orientation: Int) {
-        setOrientationPref(orientation)
-        requestedOrientation = orientation
-    }
-
-    private fun fitPref(): Int =
-        getSharedPreferences("display", MODE_PRIVATE).getInt("fit", 0)
-
-    private fun setFitPref(mode: Int) =
-        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("fit", mode).apply()
-
-    private fun orientationPref(): Int =
-        getSharedPreferences("display", MODE_PRIVATE)
-            .getInt("orientation", ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
-
-    private fun setOrientationPref(orientation: Int) =
-        getSharedPreferences("display", MODE_PRIVATE).edit().putInt("orientation", orientation).apply()
-
-    /** Apply reflow font-size preset [rawIdx] (clamped): persist, repaginate off-thread, repaint.
-     *  Pinch-zoom on a reflowable view and the Font panel's A-/A+ both route here (DRY).
-     *  [announce] toasts the new size (pinch feedback); [warnIfFixed] toasts when the doc is
-     *  fixed-layout so the size can't change (Font panel feedback). */
-    private fun applyReflowScale(rawIdx: Int, announce: Boolean = false, warnIfFixed: Boolean = false) {
-        val idx = rawIdx.coerceIn(0, TEXT_SCALES.size - 1)
-        setTextScalePref(TEXT_SCALES[idx])
-        if (announce) runOnUiThread {
-            Toast.makeText(this, "Font ${(TEXT_SCALES[idx] * 100).toInt()}%", Toast.LENGTH_SHORT).show()
-        }
-        engine.execute {
-            val np = try { NativeBridge.nativeSetTextScale(docHandle, TEXT_SCALES[idx]) } catch (e: RuntimeException) { -1 }
-            if (np >= 0) { pageCount = NativeBridge.nativePageCount(docHandle); repaintPanel() }
-            else if (warnIfFixed) runOnUiThread {
-                Toast.makeText(this, "Font size adjusts reflowable books (EPUB)", Toast.LENGTH_SHORT).show()
-            }
-        }
-    }
-
-    private fun textScalePref(): Float =
-        getSharedPreferences("typography", MODE_PRIVATE).getFloat("scale", 1.0f)
-
-    private fun setTextScalePref(scale: Float) =
-        getSharedPreferences("typography", MODE_PRIVATE).edit().putFloat("scale", scale).apply()
-
-    private fun nearestScaleIndex(scale: Float): Int {
-        var best = 0
-        var bestDist = Float.MAX_VALUE
-        TEXT_SCALES.forEachIndexed { i, v ->
-            val dist = kotlin.math.abs(v - scale)
-            if (dist < bestDist) { bestDist = dist; best = i }
-        }
-        return best
     }
 
     /** Persist the current reading position (RR12-FR3 / RR27); store-less / closed = no-op. */
@@ -3414,13 +2902,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val SELECTION_HANDLE_PX = 8f // half-size of the square corner handles on the selection box.
         const val MULTILINE_DRAG_FRAC = 0.045f // drag vertical span (frac of height) above which it's a multi-line → line-span select.
         const val OPEN_DRAG_FRAC = 0.08f // lasso: start-to-lift distance (normalized) above which the gesture is an open drag (vs a closed loop).
-        const val CONTRAST_MAX = 8 // mirrors reader-core render::contrast::MAX_CONTRAST_STEP (RR4).
-        // Line-spacing multipliers (RR4), tight → loose. Stored as the value (not the index) so this
-        // set can grow without corrupting saved prefs. 1.4 = the core default.
-        val LINE_SPACINGS = floatArrayOf(1.0f, 1.1f, 1.2f, 1.4f, 1.7f)
-        val LINE_SPACING_LABELS = listOf("Tightest", "Tighter", "Small", "Medium", "Large")
-        const val DEFAULT_LINE_SPACING = 1.4f
-        val STYLE_PRESETS = listOf("Original", "Bold", "Night", "Outdoor", "Relaxed") // 1.10
         const val HIGHLIGHT_WIDTH_PX = 30f // wide marker band (vs INK_STROKE_WIDTH for the pen).
         const val STROKE_PAUSE_MS = 600L // commit a stroke after this pen-pause (swallowed-UP net).
         const val INK_FLUSH_MS = 1500L // trailing-edge delay before the deferred ink autosave fsyncs.
@@ -3430,8 +2911,6 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val ERASE_RADIUS_PX = 22f // eraser hit radius (px): a stroke within this of the path goes.
 
         // Core ink seam constants (ADR-INKREAD-0010). Tool codes mirror `inkread_ink::Tool::code`.
-        /** Reflow font-size steps (multiples of the core's base body size); 1.0 = default. */
-        val TEXT_SCALES = floatArrayOf(0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.15f, 1.3f, 1.5f, 1.75f, 2.0f, 2.5f, 3.0f)
         const val CORE_TOOL_PEN = 0
         const val CORE_TOOL_HIGHLIGHTER = 1
         const val CORE_TOOL_ERASER = 2

--- a/docs/EINK-LIMITS.md
+++ b/docs/EINK-LIMITS.md
@@ -1,0 +1,56 @@
+# E-ink refresh & pen latency on Supernote: what a sideloaded app can and cannot do
+
+Short version: **pen latency is firmware-fast and refresh tuning is platform-capped.** Where
+inkread differs from KOReader-on-Kobo or the native Supernote reader on refresh behavior, it is a
+device-policy boundary, not missing code. This page states those limits plainly so you can tell a
+platform constraint apart from an unbuilt feature.
+
+## What the platform gives a sideloaded app
+
+The Supernote family (RK3566, Android 11) exposes different display capabilities to **system**
+apps (the firmware reader, Notes) than to **sideloaded** apps like inkread:
+
+| Capability | System apps | Sideloaded apps |
+|---|---|---|
+| Waveform selection (A2/DU-class fast modes vs quality modes) | Yes | **No** — no public API, and the privileged paths are blocked by SELinux for third-party apps |
+| Partial (dirty-rect) refresh | Yes | **No** — the panel path a sideloaded app can reach performs full-screen updates only |
+| Full-screen refresh | Yes | Yes — the firmware auto-refreshes on drawing, and a full flash can be requested |
+| Live pen ink | Firmware overlay | **Yes, same firmware overlay** — see below |
+
+## Pen latency: solved by the platform, kept by design
+
+inkread does **not** render live pen strokes itself. The firmware's ink service draws the wet ink
+on its overlay at sub-frame latency — the same path the vendor's own Notes app uses — and inkread
+feeds it stroke geometry and consumes the results into its own Rust ink model (undo, persistence,
+export, lasso all run on our side). This is recorded as a deliberate design decision
+(spec amendment S-2, ADR-INKREAD-0004): on this hardware, a firmware overlay beats any app-side
+render path, and the portable Rust stroke model is unchanged beneath it.
+
+So "pen latency work" is not deferred — nib-to-ink is already at the native app's latency. What
+an app-side path would add is nothing; what it would risk (fighting the EPD controller from
+userspace) is real.
+
+## Refresh: what inkread does within the cap
+
+- **Policy over waveforms.** The Rust core runs a content-aware refresh policy (RR3 / spec
+  amendment S-1) that emits vendor-neutral intents — flash here, avoid flashing there, clear
+  ghosts after N partials, night-mode handling. On Supernote the adapter maps these onto what the
+  platform allows: cooperate with the firmware's auto-refresh, and issue full refreshes at policy
+  boundaries. On a future device with real waveform control, the same policy drives it with no
+  core change.
+- **Ghosting** is managed by full-refresh cadence, not per-region waveform tricks — the platform
+  offers nothing finer to a sideloaded app.
+- **Page-turn speed** is won in software instead: a pagination cache plus next-page read-ahead
+  keeps the render off the critical path, so a page turn costs roughly one panel update.
+
+## What this means for feature requests
+
+- *"Add A2/fast mode like KOReader on Kobo"* — not possible sideloaded on this device; KOReader's
+  own Supernote port has the same ceiling (full-refresh via the public path).
+- *"Partial refresh for the ink/UI"* — same answer; the firmware pen overlay already covers the
+  case that matters most.
+- *"Configurable full-refresh interval"* (every N pages, manual refresh) — possible within the
+  cap and planned (#99).
+
+If Ratta exposes finer refresh control to third-party apps in a future firmware, the adapter is
+the only layer that changes (IR-7: the core names no vendor and speaks intents).

--- a/docs/RELEASE-SMOKE-CHECKLIST.md
+++ b/docs/RELEASE-SMOKE-CHECKLIST.md
@@ -51,7 +51,7 @@ Tick a step only when the expected result is observed. Any failure blocks the ta
 | 4.3 | Copy, then paste | Duplicate lands slightly offset beside the source | primary |
 | 4.4 | Delete the selection | Selected strokes gone; undo restores them | primary |
 | 4.5 | Lasso over printed text (Smart mode) | Text selection result with Copy/Define/Digest actions | primary |
-| 4.6 | Exit the Lasso tool | EMR ink re-enabled: the pen writes again immediately (binder writable restored) | both |
+| 4.6 | Exit the Lasso tool | The pen writes again immediately | both |
 
 ## 5. Reading tools
 

--- a/docs/RELEASE-SMOKE-CHECKLIST.md
+++ b/docs/RELEASE-SMOKE-CHECKLIST.md
@@ -1,0 +1,95 @@
+# Release smoke checklist (on-device)
+
+Run this pass on a real Supernote before tagging a release. Device behavior is the product and
+cannot be simulated: a generic AVD has no EMR pen, no EPD, and `adb screencap` returns black on
+this panel (EPD compositing), so every step below is verified **by eye on the device** — there is
+no screenshot automation to lean on.
+
+**Devices:** run the full list on one primary device (Nomad or Manta); when a step is marked
+*both*, repeat it on the second device — those steps have per-panel behavior (touch metrics,
+panel size).
+
+**Setup:** `./buildApk.sh --install` (or sideload the release-candidate APK), with at least one
+PDF with a text layer, one scanned PDF, and one EPUB on the device.
+
+Tick a step only when the expected result is observed. Any failure blocks the tag.
+
+## 1. Open & render
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 1.1 | Launch inkread → Home shows the shelf; open a text-layer PDF | Page renders crisp; no loading freeze (a "Loading…" frame at worst) | primary |
+| 1.2 | Kill the app (swipe away), relaunch | Reopens the same book at the same page (RR27) | primary |
+| 1.3 | Open an EPUB from Home | Renders reflowed; TOC available from the bottom bar | primary |
+
+## 2. Page turn & navigation
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 2.1 | Tap right / left page edges repeatedly (10+ pages) | Page turns keep up (prefetch); no stuck refresh, no ghost pile-up | both |
+| 2.2 | Centre-tap → bottom bar; drag the page slider, release | Jumps to the page; slider label tracked the drag | primary |
+| 2.3 | Bottom bar → Contents; tap a chapter | Jumps to the chapter start | primary |
+| 2.4 | Tap an internal PDF link (TOC page or cross-reference) | Follows the link — single tap, on finger-DOWN feel (no double-tap needed) | primary |
+
+## 3. Ink (firmware pen path)
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 3.1 | With Pen tool active, write a few words | Ink appears under the nib at firmware latency (no visible lag) | both |
+| 3.2 | Turn the page and come back | Strokes persisted and re-render baked on the page | primary |
+| 3.3 | Undo, then redo from the selection toolbar / palette | Last stroke disappears, then returns | primary |
+| 3.4 | Eraser tool: scrub across a stroke | Stroke vanishes; surrounding strokes untouched | primary |
+| 3.5 | Rest a palm while writing | No stray finger input fires (palm rejection); writing unaffected | both |
+| 3.6 | Kill the app right after a stroke; relaunch | The stroke survived (autosave + crash-safe sidecar, RR20) | primary |
+
+## 4. Lasso & selection
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 4.1 | Lasso tool: circle some strokes | **Dashed** marching-ants loop draws (no stray firmware ink); selection box + toolbar appear | both |
+| 4.2 | Drag the selection to a new spot | Strokes move; nothing left behind | primary |
+| 4.3 | Copy, then paste | Duplicate lands slightly offset beside the source | primary |
+| 4.4 | Delete the selection | Selected strokes gone; undo restores them | primary |
+| 4.5 | Lasso over printed text (Smart mode) | Text selection result with Copy/Define/Digest actions | primary |
+| 4.6 | Exit the Lasso tool | EMR ink re-enabled: the pen writes again immediately (binder writable restored) | both |
+
+## 5. Reading tools
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 5.1 | Hold the pen still on a word | Definition card pops (on-device corpus); no stroke committed | primary |
+| 5.2 | Bottom bar → Search; search a word; step through hits | Hits highlight on-page; jump lands on the right page | primary |
+| 5.3 | Tap the top-right corner | Dog-ear bookmark toggles; Marks lists it; tap the entry to jump | primary |
+| 5.4 | Highlighter tool: drag across a paragraph | Translucent band bakes over the text lines; persists after a page turn | primary |
+| 5.5 | Adjust sheet: Font size A+ on the EPUB | Repaginates at the larger size; position roughly held | primary |
+| 5.6 | Adjust sheet: Reflow **On** for the text-layer PDF; then on the scanned PDF | Text PDF reflows ("Reflowing…" only if slow); scanned PDF toasts "no text layer" and stays put | primary |
+| 5.7 | Pinch on a fixed-layout PDF; double-tap | Live zoom preview, crisp re-render on release; double-tap toggles zoom | both |
+
+## 6. Export & integrations
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 6.1 | Export → editable annotations; open the PDF in the Supernote firmware reader | Ink visible as annotations in the other app (written into the PDF, not a sidecar) | primary |
+| 6.2 | Export → flattened; reopen the exported file | Ink baked into the page image | primary |
+| 6.3 | Lasso a passage → Digest | Entry appears in the firmware Digest app (Knowledge provider write-through) | primary |
+
+## 7. Daily & self-update
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 7.1 | Daily screen → compile today's issue (needs Wi-Fi) | "Compiling…" notice, then the issue opens; articles interleaved across sources | primary |
+| 7.2 | Open a Daily article → bottom bar → "Daily" | Returns to the issue's front page | primary |
+| 7.3 | Settings → check for updates (on a production-signed install) | Finds/declines the latest release correctly; a debug-signed build reports the updater inert (signer gate fails closed) | primary |
+
+## 8. Lifecycle & stability
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 8.1 | Rotate the device (Adjust → Rotate 90°) | Re-renders at the new orientation; ink/highlights anchored correctly | primary |
+| 8.2 | Sleep the device mid-book (cover / power), wake | Reader resumes where it was; pen still writes | both |
+| 8.3 | Background inkread, open the firmware Notes app, ink there, return | inkread unaffected; its pen path re-claims correctly | primary |
+
+---
+
+*When a release ships with a step intentionally skipped (e.g. only one device on hand), note it
+in the release PR under "How it was tested".*

--- a/docs/SPEC-INDEX.md
+++ b/docs/SPEC-INDEX.md
@@ -1,0 +1,176 @@
+# Spec index (public)
+
+The canonical design documents live in `spec/`, which is **gitignored** — it contains private
+on-device research that is not distributable. Source comments, commits, and PRs cite those
+documents by ID. This index is the public, redacted map of every citable ID, so an external
+contributor can resolve any citation without access to `spec/`. If a summary here is too thin for
+the change you're making, ask in the issue/PR — a maintainer will quote the relevant contract.
+
+## How to read a citation
+
+- **`RRn`** — a top-level requirement. `RRn-FRm` is a functional requirement inside it, `RRn-ACm`
+  an acceptance criterion, `RRn-NFRm` a non-functional requirement.
+- **Two RR series exist** (a historical hazard, load-bearing for every reader of this codebase):
+  the **golden spec** (`SPEC-INKREAD.md`, RR1–RR23) is the canonical product spec, and the
+  **device annex** (`SPEC-RUST-READER.md`, RR1–RR29) is the older Supernote-first spec whose
+  numbering does **not** match. **In-code `RR…` citations refer to the device annex** unless
+  prefixed `IR-RR…`, which marks a golden-spec reference (per ADR-INKREAD-0000, Decision 1).
+- **`IR-n`** — an invariant (see below). **`S-n`** — a superiority amendment. **`W-n`** — an
+  owner waiver. **`Amendment n`** — an M0 JNI-boundary review decision (see below).
+- **`ADR-INKREAD-nnnn`** (often shortened to `ADR-nnnn`) — an architecture decision record.
+
+## Golden spec — `SPEC-INKREAD.md` (RR1–RR23)
+
+Statuses are coarse (per the ADR-0000 conformance ledger) and dated 2026-06; the ledger is the
+authority and moves with the code.
+
+| RR | Title | One-line summary | Status |
+|----|-------|------------------|--------|
+| RR1 | Project scaffold & build system | Cargo workspace + Android shell + JNI bridge; core builds and tests host-only. | Partial (desktop emulator waived, W-1) |
+| RR2 | Document model & format backends | `Document` trait; PDF/EPUB shipped, search shipped; CBZ/TXT partial, MD/HTML pending. | Partial |
+| RR3 | E-ink display & refresh policy | Content-aware refresh decisions as vendor-neutral intents/commands. | Conformant+ (S-1) |
+| RR4 | Rendering pipeline | `PixelBuffer`, grayscale, dithering, bounded caches, streaming render. | Conformant |
+| RR5 | Input, stylus & palm rejection | Normalized input events, pen samples, palm rejection. | Partial (palm filter is shell-side) |
+| RR6 | Ink engine & low-latency handwriting | Rust vector-stroke model: smoothing, undo, eraser, pressure-width. | Partial (live render is platform fast-path, S-2) |
+| RR7 | PDF annotation | Ink + highlights on PDF with autosave, persistence, and export. | Partial |
+| RR8 | EPUB highlights, notes & linked handwriting | Reflow-anchored annotations that survive typography changes. | Partial |
+| RR9 | Native notebooks | Standalone ink notebooks with templates. | Planned |
+| RR10 | Annotation storage & sidecars | `.inkread/` sidecar, binary ink codec, document identity, atomic writes. | Conformant |
+| RR11 | Export system | MD/JSON/PDF/SVG/PNG export of annotations and notes. | Planned (PDF export shipped) |
+| RR12 | Rust-native built-in workflows | Reading progress, dictionary, vocabulary, export as core services. | Partial |
+| RR13 | Lua plugin runtime | Embedded Lua for user plugins (L1 shipped: logging API). | Partial |
+| RR14 | KOReader compatibility shim | Loader for selected `.koplugin` plugins. | Planned |
+| RR15 | Plugin security & permissions | Capability manifest + per-plugin storage sandbox. | Planned |
+| RR16 | Reader, annotation, notebook & plugin UI | Reader view, tool palette (ADR-0010), notebook/plugin surfaces. | Partial |
+| RR17 | Library, metadata & reading progress | Library browser, metadata, resume-where-you-left. | Partial |
+| RR18 | Sync & interoperability | Sync-friendly sidecar layout; external tool interop. | Planned |
+| RR19 | Performance & resource budgets | Bounded caches, memory ceiling, trim hooks, no busy loops. | Conformant |
+| RR20 | Reliability & data safety | Autosave, atomic crash-safe writes, original document never modified. | Conformant |
+| RR21 | Accessibility & usability | High-contrast e-ink UI, handedness, hardware buttons, font scaling. | Partial |
+| RR22 | Licensing & dependency policy | AGPL-3.0 product, license-gated dependencies, DRM detected but never bypassed. | Conformant |
+| RR23 | Testing & observability | Host unit + golden-image tests, CI gates, coverage. | Conformant |
+
+## Device annex — `SPEC-RUST-READER.md` (RR1–RR29)
+
+The Supernote-first spec. **This is the series in-code `RR…` comments cite.** Retained for its
+device contracts; its scope and numbering are superseded by the golden spec.
+
+| RR | Title / summary |
+|----|-----------------|
+| RR1 | Project scaffold: Android shell + Rust `cdylib` + JNI bridge; host-only core build (RR1-AC3). |
+| RR2 | `RefreshCommand` + `DeviceCapabilities` contract; one Kotlin `EinkAdapter` behind a kept interface. |
+| RR3 | Content-aware refresh-mode policy state machine. |
+| RR4 | Rendering pipeline: `PixelBuffer`, Surface handoff, grayscale + dithering. |
+| RR5 | Fixed-layout PDF backend (`pdfium-render`). |
+| RR6 | Position model: `PinPosition` + page ranges. |
+| RR7 | Reflowable engine integration (EPUB) + the license gate. |
+| RR8 | Reflowable pagination (fork-and-walk) + disk pagination cache. |
+| RR9 | Typesetting: `ReaderTextStyle` + `GlobalConfig` contract. |
+| RR10 | Text shaping & fonts + CJK/fallback. |
+| RR11 | Navigation, TOC, search, selection & hit-testing. |
+| RR12 | Annotations, bookmarks, reading-position persistence (SQLite). |
+| RR13 | Library, metadata, storage layers. |
+| RR14 | Input & gestures. |
+| RR15 | Supernote device adapter: e-ink execution path. |
+| RR16 | Settings & reader UI. |
+| RR17 | Test strategy, golden images, e-ink metrics. |
+| RR18 | Clean-room / licensing compliance: reimplement from documented contracts only; never copy decompiled code. |
+| RR19 | Stylus capture & low-latency ink path (`PenAdapter`). |
+| RR20 | Ink annotation layer: model, anchoring, persistence, export. |
+| RR21 | Threading, JNI boundary & Android lifecycle contract (RR21-FR3: never panic across JNI). |
+| RR22 | Storage layout, file import & scoped storage. |
+| RR23 | Settings & config schema. |
+| RR24 | Performance & resource budget (bounded caches, memory trim). |
+| RR25 | Reader UX & interaction model. |
+| RR26 | Library, home & import UX. |
+| RR27 | Session restore & crash recovery. |
+| RR28 | Fonts & i18n shipping. |
+| RR29 | Build, packaging, signing, CI & observability. |
+
+> **`RR30` is a stale alias**: a few annex FRs and one code comment cite “RR30” for logging; it
+> resolves to **RR29-FR4** (the observability/logging facade). There is no RR30.
+
+## Invariants (`IR-n`)
+
+Like the RRs, **both specs define an IR series and code comments cite both**. The collision is
+mostly harmless — the load-bearing ideas (core purity, vendor-neutrality, host-testability) appear
+in each — but check both tables when resolving a citation.
+
+Golden spec (`SPEC-INKREAD.md`):
+
+| ID | Invariant |
+|----|-----------|
+| IR-1 | An ADR must select the first hardware target before implementation begins. |
+| IR-2 | The target must expose enough input/display control for reading and basic handwriting. |
+| IR-3 | A desktop emulator backend for dev/CI. **Waived (W-1)** — the host-test half of its intent is kept. |
+| IR-4 | No framebuffer, JNI, vendor SDK, or raw device APIs leak into the core crates. |
+| IR-5 | Platform-specific display and input code lives in platform adapters. |
+| IR-6 | The Rust core is unit-testable without physical hardware. |
+
+Device annex (`SPEC-RUST-READER.md`):
+
+| ID | Invariant |
+|----|-----------|
+| IR-1 | The core renders into a `PixelBuffer` and never knows which panel it is on; refresh commands are plain data; the core holds no device/JNI handle. |
+| IR-2 | The refresh **policy** (decide) is pure Rust and identical across devices; only the adapter **execution** (map to panel) differs. Host-testable via the mock recorder. |
+| IR-3 | Positions, annotations, and ink anchor to `PinPosition` (reflow) or page+rect (fixed) — never bare pixels — so they survive re-layout. |
+| IR-4 | Pagination is invalidated iff a layout-affecting setting changes (the `layout_digest`); color/theme changes don't re-paginate. |
+| IR-5 | No DRM circumvention and no copied decompiled code — clean-room, distributable under the chosen license. |
+| IR-6 | Single target v1 (Supernote), device-agnostic core retained; degrade, don't disable, when a capability is absent. |
+| IR-7 | **No vendor name in `reader-core`** — all device code lives in the Kotlin adapters + JNI bridge. Adding a device = adding an adapter, never editing the core. |
+| IR-8 | Every milestone gate is hardware-validated on the device; "works in the mock" is necessary, not sufficient. |
+| IR-9 | Handwriting is first-class and vendor-neutral: the core consumes normalized ink points via a peer adapter path; low-latency feel is capability-gated. |
+
+## M0 JNI-boundary decisions (`Amendment n`)
+
+Decisions from the M0 boundary review, cited directly in `reader-core` comments:
+
+| # | Decision |
+|---|----------|
+| 1 | The `jni` dependency is feature-gated (`jni-bridge`); the default host build never resolves it (RR1-AC3). |
+| 2 | Handle model: the JNI `long` points at the `ReaderSession`; created by `open`, freed only by `close`; every entry point null/range-checks the handle. |
+| 3 | Pixel channel order is fixed and locked by a golden test (byte order across the JNI buffer). |
+| 4 | M0 scope fence: the `Document` trait is metadata + page count + render-page only; everything else arrives with its own RR. |
+| 5 | Render writes into a caller-provided direct `ByteBuffer`; the session never stores a `PixelBuffer`. |
+| 6 | One wire codec for commands/gestures — no hand-rolled byte streams; gestures delegate to the refresh policy. |
+
+## Superiority amendments (`S-n`) and waivers (`W-n`)
+
+Recorded in ADR-INKREAD-0000. An **amendment** = the implementation exceeds the golden spec; a
+**waiver** = the owner chose not to implement part of it. Neither is silent drift.
+
+| ID | Summary |
+|----|---------|
+| S-1 | Refresh: intent/command split instead of the spec's core-side `EinkDisplay` I/O trait — keeps the policy pure and host-testable. |
+| S-2 | Ink fast path: the platform may render live ink (firmware overlay) as a valid realization of RR6-FR4/FR5; the Rust stroke model is unchanged. |
+| S-3 | Host-testability hardened: platform deps are feature-gated out of the default build, not merely "host-buildable". |
+| S-4 | Persistence: SQLite WAL behind a `ReaderStore` port with versioned migrations — a concrete realization of "atomic or journaled writes". |
+| W-1 | Desktop emulator de-scoped; host tests + CI keep IR-3's intent. |
+| W-2 | Single target family: Supernote (Manta / A5 X / Nomad / A6 X). Platform seams are kept so other devices remain drop-in later. |
+
+## ADRs
+
+| ID | Title |
+|----|-------|
+| ADR-INKREAD-0000 | Golden spec adoption, ADR governance, naming, and the RR conformance ledger. |
+| ADR-INKREAD-0001 | First hardware target & the platform boundary. |
+| ADR-INKREAD-0002 | Crate decomposition roadmap. |
+| ADR-INKREAD-0003 | E-ink refresh & rendering architecture (intent/command over `EinkDisplay`). |
+| ADR-INKREAD-0004 | Normalized input, the Rust ink engine, and the firmware fast-path. |
+| ADR-INKREAD-0005 | Annotation storage, sidecars, reliability, and the export engine. |
+| ADR-INKREAD-0006 | Extensibility: Lua runtime, plugin security, native built-ins, KOReader shim. |
+| ADR-INKREAD-0007 | Document model trait & format-backend roadmap. |
+| ADR-INKREAD-0008 | UI architecture, portability, and accessibility. |
+| ADR-INKREAD-0009 | Dictionary, thesaurus & text selection. |
+| ADR-INKREAD-0010 | Annotation tool model & the floating tool palette. |
+| ADR-INKREAD-0011 | PDF reflow over the existing reflow layout engine. |
+| ADR-INKREAD-0012 | Threading a source anchor through the EPUB pipeline to mint `PinPosition`s. |
+| ADR-INKREAD-0013 | Reflow pagination: layout digest, `PageRange` boundaries, disk cache. |
+| ADR-INKREAD-0014 | In-app GitHub self-update. |
+| ADR-INKREAD-0015 | Any-script text rendering (system-font fallback + line breaking; shaping/BiDi next). |
+| ADR-RUST-READER | Reflow engine, product license, and distribution model (annex ADR). |
+| ADR-SUPERNOTE-INK | Handwriting ink path & the Rust-vs-Lua architecture question (annex ADR). |
+
+---
+
+*If an ID you encounter in code or a PR is missing here, open an issue — that's an index bug.*

--- a/docs/SPEC-INDEX.md
+++ b/docs/SPEC-INDEX.md
@@ -38,7 +38,7 @@ authority and moves with the code.
 | RR10 | Annotation storage & sidecars | `.inkread/` sidecar, binary ink codec, document identity, atomic writes. | Conformant |
 | RR11 | Export system | MD/JSON/PDF/SVG/PNG export of annotations and notes. | Planned (PDF export shipped) |
 | RR12 | Rust-native built-in workflows | Reading progress, dictionary, vocabulary, export as core services. | Partial |
-| RR13 | Lua plugin runtime | Embedded Lua for user plugins (L1 shipped: logging API). | Partial |
+| RR13 | Lua plugin runtime | Embedded Lua for user plugins. | Planned (Lua L1 shipped) |
 | RR14 | KOReader compatibility shim | Loader for selected `.koplugin` plugins. | Planned |
 | RR15 | Plugin security & permissions | Capability manifest + per-plugin storage sandbox. | Planned |
 | RR16 | Reader, annotation, notebook & plugin UI | Reader view, tool palette (ADR-0010), notebook/plugin surfaces. | Partial |


### PR DESCRIPTION
## What & why

Delivers milestone **Review Feedback R2** — the actionable items from the July 2026 external code review.

Closes #113, closes #114, closes #116, closes #117. Progress on #115 (stays open).

## Changes

**Public spec index (#113).** `docs/SPEC-INDEX.md` gives external contributors a redacted map of every citable design ID: both RR series with the ADR-0000 numbering-collision rule (in-code `RR…` = device annex; `IR-RR…` = golden spec), both IR invariant series, the M0 JNI-boundary Amendments 1–6, the S-n superiority amendments, W-n waivers, and all 18 ADRs. Notes the stale RR30 citation (resolves to RR29-FR4). CONTRIBUTING now points citation resolution at the index and no longer links gitignored `spec/` paths.

**CI packaging check (#114).** New `apk-assemble` job runs the canonical `./buildApk.sh --debug` pipeline (cargo-ndk → pinned libpdfium → `assembleDebug`, debug-keystore signed, no release secrets) and asserts the APK contains `lib/arm64-v8a/libreader.so` and `libpdfium.so` — a jniLibs/packaging regression now fails CI instead of surfacing as a `loadLibrary` crash in a release build.

**ReaderActivity decomposition (#115, first two slices).** Behavior-preserving extractions on the established controller + `Host` pattern:
- `DisplayPrefs` — all display/typography SharedPreferences behind typed properties (same files/keys; existing installs keep their settings) plus the scale/spacing tables.
- `AdjustSheetController` — the tabbed settings sheet, seven panels, segmented/cell-bar/row widgets, style presets, reflow-scale application. Page geometry (reflow toggle, zoom) stays in the shell behind the Host seam.
- `BottomBarController` — the bottom bar, page slider + chapter jumps, go-to-page, bookmarks, Contents, annotations list, go-home.
- Removed the long-dead `showLibraryDialog`/`openFromLibrary` chain (the bar's Library control was superseded by Home).

`ReaderActivity.kt`: 3,475 → ~2,510 lines. The remaining slices (lasso/selection, stylus capture, zoom/pan) are the device-sensitive pen paths and will land as separate PRs, one on-device pass each.

**Release smoke checklist (#116).** `docs/RELEASE-SMOKE-CHECKLIST.md` — a step-by-step on-device pass (render, page turn, ink, lasso, reading tools, export/Digest, Daily, self-update, lifecycle) with expected results and per-panel steps for Nomad/Manta; referenced from the PR template and the release workflow header. `adb screencap` composites black on this panel, so this checklist is the release verification surface.

**E-ink platform limits (#117).** `docs/EINK-LIMITS.md` separates platform constraints from unbuilt features: sideloaded apps get no waveform selection or partial refresh on the RK3566 Supernote, while live pen ink rides the firmware's sub-frame overlay (S-2 / ADR-INKREAD-0004) — so nib-to-ink latency is native-level by design. README's comparison table links it.

## Requirements / design refs

RR4, RR16/RR25, RR27, RR29 (annex); ADR-INKREAD-0000 D1 (citation rule), ADR-INKREAD-0008, ADR-INKREAD-0004/S-2; IR-7 untouched (Kotlin-only refactor, no core changes).

## How it was tested

- `./scripts/gate.sh` green after every commit: `cargo fmt --check`, `clippy -D warnings`, `cargo test --workspace`, aarch64 JNI cross-check, `:app:testReleaseUnitTest`.
- `DisplayPrefs` keeps the exact pref files, keys, defaults, and coercions, verified against the pre-refactor source.
- Workflow YAML validated; the debug-APK output path matches `buildApk.sh --debug` (`app/build/outputs/apk/debug`).

**Device test needed before merge:** a quick on-device pass of the two extracted surfaces — Adjust sheet (all seven tabs apply + persist), bottom bar (slider, chapter jumps, each control), bookmarks toggle/list, Contents, annotations list. Host tests cannot cover these.