### PR TITLE
ci: fix flaky APK-lib assertion (pipefail vs grep -q EPIPE race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,11 @@ jobs:
           apk="$(find app/build/outputs/apk/debug -type f -name '*.apk' -print -quit)"
           test -n "$apk" || { echo "::error::No APK produced under app/build/outputs/apk/debug"; exit 1; }
           listing="$(unzip -l "$apk")"
+          # Pure-bash substring check — NOT `echo | grep -q`: grep -q exits on first match,
+          # which can EPIPE the echo mid-write, and pipefail then flunks a SUCCESSFUL match
+          # (bit us on the first master run: a green build reported libpdfium.so "missing").
           for lib in lib/arm64-v8a/libreader.so lib/arm64-v8a/libpdfium.so; do
-            echo "$listing" | grep -q "$lib" || { echo "::error::$lib missing from $apk"; exit 1; }
+            [[ "$listing" == *"$lib"* ]] || { echo "::error::$lib missing from $apk"; exit 1; }
           done
           echo "APK OK: $apk contains libreader.so + libpdfium.so (arm64-v8a)"
 


### PR DESCRIPTION
## What & why

The `apk-assemble` job's final assertion is flaky: `echo "$listing" | grep -q "$lib"` under `set -o pipefail`. `grep -q` exits as soon as it matches, which can EPIPE the `echo` mid-write; `pipefail` then fails the pipeline, so a **successful** match gets reported as a missing lib. Master run 28715809876 hit exactly this — `echo: write error: Broken pipe` followed by a spurious "libpdfium.so missing" — on the same commit whose PR run passed.

## Fix

Replace the pipe with a pure-bash substring check (`[[ "$listing" == *"$lib"* ]]`): no subprocesses, no pipe, no race. A comment in the step records why the obvious `grep -q` form is wrong here.

## How it was tested

- YAML validated; the substring check exercised locally against a sample listing (both libs match, a missing lib fails).
- The real proof is this PR's own `assemble debug APK (packaging check)` run.