### PR TITLE
fix(reader): return to Home when the Open-Document picker is cancelled

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -642,7 +642,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     @Deprecated("startActivityForResult is fine for this single-Activity shell (no AndroidX).")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode != REQ_OPEN_DOC || resultCode != RESULT_OK) return
+        if (requestCode != REQ_OPEN_DOC) return
+        if (resultCode != RESULT_OK) {
+            // Picker cancelled. With no document open (e.g. launched straight into the picker from
+            // Home's "Open a Document"), there's nothing to show and the only tap action would
+            // re-open the picker — return to Home instead of stranding the reader on a blank page
+            // (#123). With a document already open (the "Open" bottom-bar control), stay on it.
+            if (docHandle == 0L) finish()
+            return
+        }
         val uri = data?.data ?: return
         // Best-effort: keep read access in case we re-import later (the open path copies bytes now).
         try {


### PR DESCRIPTION
## What & why

Reddit beta feedback: cancelling the system file picker left the reader on a blank page with no way back to the shelf. Closes #123.

## Root cause

From Home → *Open a Document* launches the reader and fires the picker. On cancel, `onActivityResult` returned early and did nothing, leaving a reader with no document open — and tapping the screen there only re-opens the picker (`showBottomBar()` early-returns to `openPicker()` when `docHandle == 0`). The only escape was the hardware back gesture.

## Fix

`onActivityResult` now `finish()`es back to Home on a cancelled pick when `docHandle == 0`. A cancel while a document is already open (the "Open" bottom-bar control) stays on the current book. `finish()` is reliable here — `ReaderActivity` is `exported="false"` and always launched on top of the Home launcher.

## How it was tested

- `./scripts/gate.sh` green: fmt, clippy `-D warnings`, `cargo test --workspace`, aarch64 JNI cross-check, `:app:testReleaseUnitTest`.
- Reviewed every `openPicker` call site against the `docHandle == 0` guard: no-doc entry points return to Home on cancel; the mid-reading "Open" control stays on the current book.

**Device check** (per `docs/RELEASE-SMOKE-CHECKLIST.md`): from Home tap Open then cancel → lands on Home; while reading, tap Open then cancel → stays on the book.