### PR TITLE
chore(version): bump workspace to 1.0.0 and auto-sync it on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,10 +104,12 @@ jobs:
           echo "ANDROID_NDK_HOME=$ndk" >> "$GITHUB_ENV"
           echo "Using NDK: $ndk"
 
-      # --- Stamp the crate version from the tag (build-time only, not committed) ---
+      # --- Stamp the crate version from the tag (build-time, for THIS build's artifact) ---
       # reader-core reports CARGO_PKG_VERSION over JNI (jni.rs nativeHello), and env!() bakes
       # it at compile time — so the workspace version must be set BEFORE cargo-ndk runs.
       # All member crates inherit version.workspace, so the single root line drives everything.
+      # This edits the working tree only; the companion "Sync version to the default branch"
+      # step at the end records the same bump on master so the checked-in file tracks releases.
       - name: Stamp crate version from tag
         env:
           VERSION: ${{ steps.ver.outputs.version }}
@@ -204,3 +206,41 @@ jobs:
             > ${{ steps.signing.outputs.signed == 'true' && 'Production-signed with the inkread release key — installs and in-app updates verify against it. Verify the attached `.sha256` before installing.' || 'This build is DEBUG-signed for sideload bring-up; it cannot update an existing install in place. Verify the attached `.sha256` before installing.' }}
 
             ---
+
+      # --- Record the released version on the default branch (best-effort) ---
+      # The build-time stamp above only touched the working tree at the tag; this lands the same
+      # bump on master so the checked-in Cargo.toml/Cargo.lock track the latest release (the tagged
+      # commit itself is immutable and keeps whatever it had). Runs only on a green release and never
+      # fails it: if the push is rejected (branch protection, or master advanced mid-release) the
+      # release still stands — the repo just misses this cosmetic bump. `cargo update --workspace`
+      # rewrites only the workspace members in the lockfile, leaving dependency resolution untouched.
+      # `[skip ci]` keeps the bump commit from re-triggering CI.
+      - name: Sync version to the default branch
+        if: success()
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          git reset --hard HEAD               # drop the build-time working-tree stamp (we're detached at the tag)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          for attempt in 1 2 3; do
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            n="$(grep -c '^version = ' Cargo.toml)"
+            test "$n" -eq 1 || { echo "::warning::expected 1 workspace version line, found $n — skipping sync"; exit 0; }
+            sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+            cargo update --workspace          # sync the 10 workspace entries in Cargo.lock to $VERSION
+            if git diff --quiet -- Cargo.toml Cargo.lock; then
+              echo "$BRANCH already at $VERSION — nothing to sync."; exit 0
+            fi
+            git add Cargo.toml Cargo.lock
+            git commit -m "chore(release): set workspace version to $VERSION [skip ci]"
+            if git push origin "HEAD:$BRANCH"; then
+              echo "Synced version $VERSION to $BRANCH."; exit 0
+            fi
+            echo "::notice::push to $BRANCH rejected (attempt $attempt) — refetching and retrying."
+          done
+          echo "::warning::could not sync the version bump to $BRANCH after retries; the release is unaffected."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "build-dict"
-version = "0.1.0-m0"
+version = "1.0.0"
 dependencies = [
  "inkread-dict",
 ]
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "device-eink"
-version = "0.1.0-m0"
+version = "1.0.0"
 
 [[package]]
 name = "displaydoc"
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "inkread-daily"
-version = "0.1.0-m0"
+version = "1.0.0"
 dependencies = [
  "ego-tree",
  "feed-rs",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "inkread-dict"
-version = "0.1.0-m0"
+version = "1.0.0"
 dependencies = [
  "flate2",
  "rusqlite",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "inkread-epub"
-version = "0.1.0-m0"
+version = "1.0.0"
 dependencies = [
  "ab_glyph",
  "ego-tree",
@@ -671,25 +671,25 @@ dependencies = [
 
 [[package]]
 name = "inkread-ink"
-version = "0.1.0-m0"
+version = "1.0.0"
 
 [[package]]
 name = "inkread-lua"
-version = "0.1.0-m0"
+version = "1.0.0"
 dependencies = [
  "mlua",
 ]
 
 [[package]]
 name = "inkread-pdftext"
-version = "0.1.0-m0"
+version = "1.0.0"
 dependencies = [
  "inkread-epub",
 ]
 
 [[package]]
 name = "inkread-update"
-version = "0.1.0-m0"
+version = "1.0.0"
 dependencies = [
  "semver",
  "serde",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "reader-core"
-version = "0.1.0-m0"
+version = "1.0.0"
 dependencies = [
  "device-eink",
  "inkread-daily",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 members = ["build-dict", "device-eink", "inkread-daily", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "inkread-pdftext", "inkread-update", "reader-core"]
 
 [workspace.package]
-version = "0.1.0-m0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.88"
 license = "AGPL-3.0-only"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         // ORG_GRADLE_PROJECT_inkread* env vars, which Gradle maps to these project properties.
         // Local/dev builds fall back to a clearly-marked -dev version with code 1.
         versionCode = (project.findProperty("inkreadVersionCode") as String?)?.toInt() ?: 1
-        versionName = (project.findProperty("inkreadVersionName") as String?) ?: "0.1.0-m0"
+        versionName = (project.findProperty("inkreadVersionName") as String?) ?: "1.0.0-dev"
         ndk {
             // RK3566 is arm64; M0 ships arm64 only (RR29-FR1).
             abiFilters += "arm64-v8a"


### PR DESCRIPTION
## Why

The Rust workspace crates were stuck at the `0.1.0-m0` placeholder even though the project ships
**v1.0.0**. The release version has always been driven by the **git tag** — `release.yml` already
stamps it into the build (`versionName` for the APK, `CARGO_PKG_VERSION` for the `.so` diagnostic
banner) — so the checked-in `Cargo.toml` never reflected reality and read as stale/confusing.

## What

**One-time bump (makes the repo tell the truth today):**
- `Cargo.toml` `[workspace.package].version`: `0.1.0-m0` → `1.0.0`; all 10 workspace entries in
  `Cargo.lock` regenerated via `cargo update --workspace` (workspace members only — dependency
  resolution untouched).
- `app/build.gradle.kts` dev-build fallback: `0.1.0-m0` → `1.0.0-dev`. This matches the comment's
  own "clearly-marked -dev version" intent (which `0.1.0-m0` contradicted), and `1.0.0-dev` sorts
  **below** the `1.0.0` release, so the in-app updater still offers real releases to dev builds
  rather than a dev build masquerading as the release.

**Auto-sync on every future release (keeps it truthful going forward):**
- New best-effort `Sync version to the default branch` step in `release.yml`. After a **green**
  release it checks out `master`, sets the workspace version to the tag's version, runs
  `cargo update --workspace`, and commits `Cargo.toml`+`Cargo.lock` back with `[skip ci]`.
  - **Never fails the release:** `continue-on-error: true` + a 3-try push loop. If the push is
    rejected (branch protection or master advanced mid-release), the release still stands — the repo
    just misses that one cosmetic bump.
  - The build-time stamp step already handles the current build's artifact; this only updates the
    repo for the future. The tagged commit itself is immutable and keeps whatever it had.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all -- -D warnings` — clean (now builds `reader-core v1.0.0`)
- `cargo test --workspace` — all pass
- `release.yml` validated as well-formed YAML; the release-notes `body:` block is intact.

## Note

The new release step pushes to `master` from CI. `master` is currently unprotected, so this works.
If branch protection is added later, the step degrades gracefully (logs a warning, release
unaffected) — but you'd then want a PR-based bump flow instead.
