### PR TITLE
feat(reader): add page thumbnail grid

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -80,6 +80,8 @@ class BottomBarController(private val host: Host) {
         fun openDicts()
 
         fun openAdjust()
+
+        fun openPages()
     }
 
     private val activity: Activity get() = host.activity
@@ -231,6 +233,7 @@ class BottomBarController(private val host: Host) {
         control(R.drawable.ic_menu_marks, "Marks") { showBookmarks() }
         control(R.drawable.ic_tool_pen, "Notes") { showAnnotations() }
         control(R.drawable.ic_menu_contents, "Contents") { showContentsLazy() }
+        control(R.drawable.ic_menu_page, "Pages") { host.openPages() }
         control(R.drawable.ic_menu_search, "Search") { host.openSearch() }
         // Quick zoom (circle −/+ icons — not magnifiers, which are reserved for Search). Also in Adjust → Zoom.
         control(R.drawable.ic_menu_zoom_out, "Zoom −") { host.zoomOut() }

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -100,6 +100,17 @@ object NativeBridge {
      */
     external fun nativeRenderPage(handle: Long, directBuffer: ByteBuffer)
 
+    /** Fit-render [page] for a thumbnail without changing the current page, zoom, pan, refresh
+     *  policy, or render-cache state. Fixed-layout documents may use a smaller target; reflowable
+     *  documents must retain the session viewport dimensions. */
+    external fun nativeRenderPagePreview(
+        handle: Long,
+        page: Int,
+        directBuffer: ByteBuffer,
+        width: Int,
+        height: Int,
+    )
+
     /**
      * Apply a navigation gesture (code per [Gesture]); returns the encoded RefreshCommand
      * stream (Fork 2). Decode with [WireCodec.decodeCommands].

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -82,6 +82,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private var docHandle: Long = 0L
     private var bitmap: Bitmap? = null
     private var renderBuffer: ByteBuffer? = null
+    private var thumbnailBitmap: Bitmap? = null
+    private var thumbnailRenderBuffer: ByteBuffer? = null
     private var viewW = 0
     private var viewH = 0
 
@@ -193,8 +195,27 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun zoomIn() = zoomBy(ZOOM_STEP)
         override fun zoomOut() = zoomBy(1f / ZOOM_STEP)
         override fun openPicker() = this@ReaderActivity.openPicker()
-        override fun palmGuard(content: View) = this@ReaderActivity.palmGuard(content)
+        override fun palmGuard(content: View) = this@ReaderActivity.palmGuard(content, fillParent = true)
         override fun diag(msg: () -> String) = this@ReaderActivity.diag(msg)
+    })
+
+    /** Page-thumbnail navigation (#100): renders complete 3×3 batches on [engine], then presents
+     *  each batch in one e-ink-friendly update. */
+    private val thumbnails = ThumbnailGridController(object : ThumbnailGridController.Host {
+        override val activity get() = this@ReaderActivity
+        override val docHandle get() = this@ReaderActivity.docHandle
+        override val pageCount get() = this@ReaderActivity.pageCount
+        override val currentPage get() = this@ReaderActivity.currentPage
+        override fun engineExecute(block: () -> Unit) { engine.execute(block) }
+        override fun renderPageThumbnails(
+            pages: List<Int>,
+            maxWidth: Int,
+            maxHeight: Int,
+            isCancelled: () -> Boolean,
+        ) = this@ReaderActivity.renderPageThumbnails(pages, maxWidth, maxHeight, isCancelled)
+        override fun postJump(page: Int) = this@ReaderActivity.postJump(page)
+        override fun refreshPanel() = this@ReaderActivity.refreshPanel()
+        override fun palmGuardFullScreen(content: View) = this@ReaderActivity.palmGuard(content)
     })
 
     /** Bottom control bar + the nav panels it opens (RR16/RR25) — page slider, chapter jumps,
@@ -218,6 +239,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun openExport() = export.showExportDialog()
         override fun openDicts() = dict.showDictionariesDialog()
         override fun openAdjust() = adjust.show()
+        override fun openPages() = thumbnails.show()
     })
 
     /** Lasso selection + Define-tool text selection (ADR-INKREAD-0010) — owns the selection
@@ -585,6 +607,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         if (::toolPalette.isInitialized) toolPalette.dismiss() // close any open palette popup
         if (::selectionToolbar.isInitialized) selectionToolbar.dismiss()
         if (::colorPalette.isInitialized) colorPalette.dismiss()
+        thumbnails.dismiss()
         mainHandler.removeCallbacks(fingerLongPress) // drop any pending finger gesture on leaving
         mainHandler.removeCallbacks(pendingCentreMenu) // don't pop the bar on a paused/finishing activity (#54)
         dismissReflowProgress() // don't leak the "Reflowing…" dialog if backgrounded mid-reflow (#55)
@@ -678,6 +701,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         // A direct, tightly-packed RGBA buffer the core renders into (Fork 4 / Amendment 5).
         renderBuffer = ByteBuffer.allocateDirect(width * height * 4).order(ByteOrder.LITTLE_ENDIAN)
+        thumbnailBitmap?.recycle()
+        thumbnailBitmap = null
+        thumbnailRenderBuffer = null
 
         drawLoading() // quick feedback while the (slow) open runs
         val wasOpen = docHandle != 0L
@@ -955,6 +981,71 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         if (!deferLinks) refreshCurrentLinks()
     }
 
+    /**
+     * Render a complete thumbnail batch on the engine thread. The native preview seam fit-renders
+     * arbitrary pages without changing navigation, zoom, or refresh-policy state. Shell page state
+     * and the visible surface are untouched until the user chooses a thumbnail.
+     */
+    private fun renderPageThumbnails(
+        pages: List<Int>,
+        maxWidth: Int,
+        maxHeight: Int,
+        isCancelled: () -> Boolean,
+    ): List<ThumbnailGridController.PageThumbnail> {
+        val handle = docHandle
+        if (handle == 0L || viewW <= 0 || viewH <= 0 || pages.isEmpty()) return emptyList()
+        val size = ThumbnailGridModel.fitSize(viewW, viewH, maxWidth, maxHeight)
+        if (size.width <= 0 || size.height <= 0) return emptyList()
+
+        // Fixed-layout backends can rasterize directly at thumbnail resolution. Reflowable
+        // documents retain the reader viewport so previewing cannot repaginate the book.
+        val renderWidth = if (magnifiable) size.width else viewW
+        val renderHeight = if (magnifiable) size.height else viewH
+        val requiredBytes = renderWidth * renderHeight * 4
+        val scratchBuffer =
+            thumbnailRenderBuffer?.takeIf { it.capacity() == requiredBytes }
+                ?: ByteBuffer.allocateDirect(requiredBytes)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .also { thumbnailRenderBuffer = it }
+        val scratchBitmap =
+            thumbnailBitmap?.takeIf {
+                !it.isRecycled && it.width == renderWidth && it.height == renderHeight
+            } ?: Bitmap.createBitmap(renderWidth, renderHeight, Bitmap.Config.ARGB_8888).also {
+                thumbnailBitmap?.recycle()
+                thumbnailBitmap = it
+            }
+        val result = ArrayList<ThumbnailGridController.PageThumbnail>(pages.size)
+
+        for (page in pages) {
+            if (isCancelled()) break
+            try {
+                scratchBuffer.clear()
+                NativeBridge.nativeRenderPagePreview(
+                    handle,
+                    page,
+                    scratchBuffer,
+                    renderWidth,
+                    renderHeight,
+                )
+                scratchBuffer.rewind()
+                scratchBitmap.copyPixelsFromBuffer(scratchBuffer)
+                val thumbnail =
+                    if (renderWidth == size.width && renderHeight == size.height) {
+                        checkNotNull(scratchBitmap.copy(Bitmap.Config.ARGB_8888, false))
+                    } else {
+                        Bitmap.createScaledBitmap(scratchBitmap, size.width, size.height, true)
+                    }
+                result += ThumbnailGridController.PageThumbnail(
+                    page,
+                    thumbnail,
+                )
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "thumbnail render failed for page $page: ${e.message}")
+            }
+        }
+        return result
+    }
+
     /** Cache the current page's links for tap hit-testing (RR11-FR3). Off the page-turn critical path
      *  (postJump calls this after the flash); links are only needed for the next tap. */
     private fun refreshCurrentLinks() {
@@ -1213,7 +1304,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
      * A palm-like DOWN is intercepted (swallowed) before it reaches any child; a real finger/stylus
      * tap passes straight through.
      */
-    private fun palmGuard(content: View): View =
+    private fun palmGuard(content: View, fillParent: Boolean = false): View =
         object : FrameLayout(this) {
             override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
                 if (ev.actionMasked == MotionEvent.ACTION_DOWN && isPalmTouch(ev)) {
@@ -1223,7 +1314,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 return super.onInterceptTouchEvent(ev)
             }
         }.apply {
-            addView(content, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+            addView(
+                content,
+                FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    if (fillParent) ViewGroup.LayoutParams.MATCH_PARENT else ViewGroup.LayoutParams.WRAP_CONTENT,
+                ),
+            )
         }
 
     private fun onFingerDown(e: MotionEvent) {

--- a/app/src/main/java/dev/jraghavan/inkread/ThumbnailGridController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ThumbnailGridController.kt
@@ -1,0 +1,325 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.app.Dialog
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.widget.Toast
+
+/**
+ * Nine-page visual navigation for the reader. Native rendering stays on the serialized engine
+ * thread; the UI receives a complete batch and replaces the grid once, avoiding an e-ink flicker
+ * loop while thumbnails arrive.
+ */
+class ThumbnailGridController(private val host: Host) {
+
+    interface Host {
+        val activity: Activity
+        val docHandle: Long
+        val pageCount: Int
+        val currentPage: Int
+
+        fun engineExecute(block: () -> Unit)
+        fun renderPageThumbnails(
+            pages: List<Int>,
+            maxWidth: Int,
+            maxHeight: Int,
+            isCancelled: () -> Boolean,
+        ): List<PageThumbnail>
+        fun postJump(page: Int)
+        fun refreshPanel()
+        fun palmGuardFullScreen(content: View): View
+    }
+
+    data class PageThumbnail(val page: Int, val bitmap: Bitmap)
+
+    private val activity get() = host.activity
+    private var dialog: Dialog? = null
+    private var gridHost: LinearLayout? = null
+    private var rangeLabel: TextView? = null
+    private var prevButton: TextView? = null
+    private var nextButton: TextView? = null
+    private var windowStart = 0
+    @Volatile private var requestGeneration = 0
+    private var bitmaps: List<Bitmap> = emptyList()
+
+    fun show() {
+        if (host.docHandle == 0L || host.pageCount <= 0) return
+        windowStart = ThumbnailGridModel.windowFor(host.currentPage, host.pageCount).start
+        load(windowStart, opening = true)
+    }
+
+    fun dismiss() {
+        requestGeneration++
+        dialog?.dismiss()
+        dialog = null
+        gridHost = null
+        rangeLabel = null
+        prevButton = null
+        nextButton = null
+        recycleBitmaps()
+    }
+
+    private fun load(start: Int, opening: Boolean) {
+        val total = host.pageCount
+        val window = ThumbnailGridModel.windowAt(start, total)
+        val metrics = activity.resources.displayMetrics
+        val maxWidth = (metrics.widthPixels - dp(40)) / ThumbnailGridModel.COLUMNS
+        val maxHeight = (metrics.heightPixels - dp(160)) / ThumbnailGridModel.ROWS
+        val generation = ++requestGeneration
+
+        setNavigationEnabled(false)
+        host.engineExecute {
+            val rendered =
+                host.renderPageThumbnails(window.pages, maxWidth, maxHeight) {
+                    generation != requestGeneration
+                }
+            activity.runOnUiThread {
+                if (generation != requestGeneration || activity.isFinishing) {
+                    rendered.forEach { it.bitmap.recycle() }
+                    return@runOnUiThread
+                }
+                if (rendered.isEmpty()) {
+                    setNavigationEnabled(true)
+                    Toast.makeText(activity, "Couldn't render page previews", Toast.LENGTH_SHORT).show()
+                    return@runOnUiThread
+                }
+                windowStart = window.start
+                if (opening || dialog == null) showDialog(window, rendered) else installBatch(window, rendered)
+                setNavigationEnabled(true)
+                host.refreshPanel()
+            }
+        }
+    }
+
+    private fun showDialog(window: ThumbnailGridModel.Window, rendered: List<PageThumbnail>) {
+        val sheet = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Ink.paper)
+            setPadding(dp(14), dp(12), dp(14), dp(12))
+        }
+
+        val title = Ink.title(activity, "Pages", 20f)
+        val close = iconButton("×", "Close page thumbnails") { dialog?.dismiss() }
+        sheet.addView(
+            LinearLayout(activity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                addView(title, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+                addView(close, LinearLayout.LayoutParams(dp(52), dp(52)))
+            },
+        )
+        sheet.addView(Ink.rule(activity))
+
+        gridHost = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+        sheet.addView(gridHost, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
+
+        prevButton = iconButton("‹", "Previous nine pages") {
+            val previous = ThumbnailGridModel.shift(windowStart, -1, host.pageCount)
+            if (previous != windowStart) load(previous, opening = false)
+        }
+        rangeLabel = TextView(activity).apply {
+            setTextColor(Ink.inkSoft)
+            textSize = 12f
+            typeface = Ink.mono
+            gravity = Gravity.CENTER
+        }
+        nextButton = iconButton("›", "Next nine pages") {
+            val next = ThumbnailGridModel.shift(windowStart, 1, host.pageCount)
+            if (next != windowStart) load(next, opening = false)
+        }
+        sheet.addView(Ink.rule(activity))
+        sheet.addView(
+            LinearLayout(activity).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(0, dp(8), 0, 0)
+                addView(prevButton, LinearLayout.LayoutParams(dp(64), dp(52)))
+                addView(rangeLabel, LinearLayout.LayoutParams(0, dp(52), 1f))
+                addView(nextButton, LinearLayout.LayoutParams(dp(64), dp(52)))
+            },
+        )
+
+        val created = Dialog(activity).apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setContentView(host.palmGuardFullScreen(sheet))
+            setOnDismissListener {
+                if (dialog === this) {
+                    requestGeneration++
+                    dialog = null
+                    gridHost = null
+                    rangeLabel = null
+                    prevButton = null
+                    nextButton = null
+                    recycleBitmaps()
+                }
+            }
+            show()
+            this.window?.apply {
+                setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+                setGravity(Gravity.CENTER)
+                setBackgroundDrawable(ColorDrawable(Ink.paper))
+            }
+        }
+        dialog = created
+        installBatch(window, rendered)
+    }
+
+    private fun installBatch(window: ThumbnailGridModel.Window, rendered: List<PageThumbnail>) {
+        val byPage = rendered.associateBy { it.page }
+        val current = host.currentPage
+        val oldBitmaps = bitmaps
+        bitmaps = rendered.map { it.bitmap }
+
+        gridHost?.apply {
+            removeAllViews()
+            repeat(ThumbnailGridModel.ROWS) { rowIndex ->
+                val row = LinearLayout(activity).apply { orientation = LinearLayout.HORIZONTAL }
+                addView(
+                    row,
+                    LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
+                )
+                repeat(ThumbnailGridModel.COLUMNS) { columnIndex ->
+                    val index = rowIndex * ThumbnailGridModel.COLUMNS + columnIndex
+                    val page = window.pages.getOrNull(index)
+                    val cell = if (page == null) {
+                        View(activity)
+                    } else {
+                        thumbnailCell(page, byPage[page]?.bitmap, page == current)
+                    }
+                    row.addView(
+                        cell,
+                        LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f).apply {
+                            val gap = dp(4)
+                            setMargins(gap, gap, gap, gap)
+                        },
+                    )
+                }
+            }
+        }
+        rangeLabel?.text = "${window.start + 1}–${window.endExclusive} / ${window.total}"
+        prevButton?.isEnabled = window.start > 0
+        nextButton?.isEnabled = window.endExclusive < window.total
+        oldBitmaps.forEach { if (!it.isRecycled) it.recycle() }
+    }
+
+    private fun thumbnailCell(page: Int, bitmap: Bitmap?, selected: Boolean): View =
+        LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER
+            setPadding(dp(4), dp(4), dp(4), dp(4))
+            background = GradientDrawable().apply {
+                setColor(Ink.paper)
+                cornerRadius = Ink.dpf(4)
+                setStroke(if (selected) dp(3) else Ink.hair(), if (selected) Ink.ink else Ink.hairline)
+            }
+            isClickable = true
+            isFocusable = true
+            contentDescription = if (selected) "Page ${page + 1}, current page" else "Page ${page + 1}"
+            setOnClickListener {
+                dialog?.dismiss()
+                host.postJump(page)
+            }
+            addView(
+                ImageView(activity).apply {
+                    setImageBitmap(bitmap)
+                    scaleType = ImageView.ScaleType.FIT_CENTER
+                    setBackgroundColor(Color.WHITE)
+                    importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
+            )
+            addView(
+                TextView(activity).apply {
+                    text = "Page ${page + 1}"
+                    setTextColor(if (selected) Ink.ink else Ink.inkSoft)
+                    textSize = 11f
+                    typeface = Ink.mono
+                    gravity = Gravity.CENTER
+                    setPadding(0, dp(3), 0, 0)
+                    importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                },
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(24)),
+            )
+        }
+
+    private fun iconButton(glyph: String, description: String, onClick: () -> Unit): TextView =
+        TextView(activity).apply {
+            text = glyph
+            contentDescription = description
+            setTextColor(Ink.ink)
+            textSize = 30f
+            typeface = Ink.serif
+            gravity = Gravity.CENTER
+            isClickable = true
+            isFocusable = true
+            setOnClickListener { onClick() }
+        }
+
+    private fun setNavigationEnabled(enabled: Boolean) {
+        prevButton?.isEnabled = enabled && windowStart > 0
+        nextButton?.isEnabled =
+            enabled && ThumbnailGridModel.windowAt(windowStart, host.pageCount).endExclusive < host.pageCount
+    }
+
+    private fun recycleBitmaps() {
+        bitmaps.forEach { if (!it.isRecycled) it.recycle() }
+        bitmaps = emptyList()
+    }
+
+    private fun dp(value: Int) = Ink.dp(value)
+}
+
+/** Pure grid/window and thumbnail-sizing rules, host-tested without Android rendering. */
+internal object ThumbnailGridModel {
+    const val COLUMNS = 3
+    const val ROWS = 3
+    const val PAGE_SIZE = COLUMNS * ROWS
+
+    data class Window(
+        val start: Int,
+        val endExclusive: Int,
+        val total: Int,
+        val pages: List<Int>,
+    )
+
+    data class Size(val width: Int, val height: Int)
+
+    fun windowFor(currentPage: Int, total: Int): Window {
+        if (total <= 0) return Window(0, 0, 0, emptyList())
+        val current = currentPage.coerceIn(0, total - 1)
+        return windowAt((current / PAGE_SIZE) * PAGE_SIZE, total)
+    }
+
+    fun windowAt(start: Int, total: Int): Window {
+        if (total <= 0) return Window(0, 0, 0, emptyList())
+        val lastStart = ((total - 1) / PAGE_SIZE) * PAGE_SIZE
+        val clampedStart = start.coerceIn(0, lastStart)
+        val end = (clampedStart + PAGE_SIZE).coerceAtMost(total)
+        return Window(clampedStart, end, total, (clampedStart until end).toList())
+    }
+
+    fun shift(start: Int, direction: Int, total: Int): Int {
+        if (total <= 0 || direction == 0) return 0
+        val delta = if (direction < 0) -PAGE_SIZE else PAGE_SIZE
+        return windowAt(start + delta, total).start
+    }
+
+    fun fitSize(sourceWidth: Int, sourceHeight: Int, maxWidth: Int, maxHeight: Int): Size {
+        if (sourceWidth <= 0 || sourceHeight <= 0 || maxWidth <= 0 || maxHeight <= 0) return Size(0, 0)
+        val scale = minOf(maxWidth.toDouble() / sourceWidth, maxHeight.toDouble() / sourceHeight)
+        return Size(
+            width = (sourceWidth * scale).toInt().coerceAtLeast(1),
+            height = (sourceHeight * scale).toInt().coerceAtLeast(1),
+        )
+    }
+}

--- a/app/src/test/java/dev/jraghavan/inkread/ThumbnailGridModelTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ThumbnailGridModelTest.kt
@@ -1,0 +1,67 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThumbnailGridModelTest {
+
+    @Test
+    fun currentPageOpensInsideItsNinePageWindow() {
+        val window = ThumbnailGridModel.windowFor(currentPage = 17, total = 30)
+
+        assertEquals(9, window.start)
+        assertEquals(18, window.endExclusive)
+        assertEquals((9 until 18).toList(), window.pages)
+        assertTrue(17 in window.pages)
+    }
+
+    @Test
+    fun finalWindowIsPartialAndClamped() {
+        val window = ThumbnailGridModel.windowAt(start = 27, total = 31)
+
+        assertEquals(27, window.start)
+        assertEquals(31, window.endExclusive)
+        assertEquals(listOf(27, 28, 29, 30), window.pages)
+    }
+
+    @Test
+    fun pagingMovesByOneGridWithoutLeavingDocument() {
+        assertEquals(9, ThumbnailGridModel.shift(start = 0, direction = 1, total = 20))
+        assertEquals(18, ThumbnailGridModel.shift(start = 9, direction = 1, total = 20))
+        assertEquals(18, ThumbnailGridModel.shift(start = 18, direction = 1, total = 20))
+        assertEquals(9, ThumbnailGridModel.shift(start = 18, direction = -1, total = 20))
+        assertEquals(0, ThumbnailGridModel.shift(start = 0, direction = -1, total = 20))
+    }
+
+    @Test
+    fun thumbnailSizingPreservesViewportAspectRatio() {
+        assertEquals(
+            ThumbnailGridModel.Size(width = 300, height = 400),
+            ThumbnailGridModel.fitSize(
+                sourceWidth = 1200,
+                sourceHeight = 1600,
+                maxWidth = 300,
+                maxHeight = 500,
+            ),
+        )
+        assertEquals(
+            ThumbnailGridModel.Size(width = 225, height = 300),
+            ThumbnailGridModel.fitSize(
+                sourceWidth = 1200,
+                sourceHeight = 1600,
+                maxWidth = 400,
+                maxHeight = 300,
+            ),
+        )
+    }
+
+    @Test
+    fun emptyDocumentsProduceNoWindowOrBitmapSize() {
+        assertEquals(emptyList<Int>(), ThumbnailGridModel.windowFor(currentPage = 0, total = 0).pages)
+        assertEquals(
+            ThumbnailGridModel.Size(0, 0),
+            ThumbnailGridModel.fitSize(0, 1600, 300, 400),
+        )
+    }
+}

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -740,6 +740,20 @@ impl Document for PdfBackend {
         })
     }
 
+    fn render_preview_fit(
+        &self,
+        index: usize,
+        buf: &mut PixelBuffer<'_>,
+        mode: FitMode,
+        pan_x: f32,
+        pan_y: f32,
+    ) -> CoreResult<()> {
+        let saved_viewport = self.last_viewport.get();
+        let rendered = self.render_fit(index, buf, mode, pan_x, pan_y);
+        self.last_viewport.set(saved_viewport);
+        rendered
+    }
+
     #[allow(clippy::too_many_arguments)] // mirrors the render params + the crop window
     fn page_fit_transform(
         &self,
@@ -885,6 +899,21 @@ impl Document for PdfBackend {
         self.composite_via_scratch(buf, tw, th, pan_x, pan_y, |tbuf| {
             self.render_region(index, tbuf, s, off_x, off_y)
         })
+    }
+
+    fn render_preview_cropped(
+        &self,
+        index: usize,
+        buf: &mut PixelBuffer<'_>,
+        crop: NormRect,
+        mode: FitMode,
+        pan_x: f32,
+        pan_y: f32,
+    ) -> CoreResult<()> {
+        let saved_viewport = self.last_viewport.get();
+        let rendered = self.render_cropped(index, buf, crop, mode, pan_x, pan_y);
+        self.last_viewport.set(saved_viewport);
+        rendered
     }
 
     fn render_zoom(

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -367,6 +367,19 @@ pub trait Document {
         self.render_page(index, buf)
     }
 
+    /// Fit-render a fixed-layout preview without committing backend viewport bookkeeping.
+    /// Backends without such bookkeeping can use the regular fit path.
+    fn render_preview_fit(
+        &self,
+        index: usize,
+        buf: &mut PixelBuffer<'_>,
+        mode: FitMode,
+        pan_x: f32,
+        pan_y: f32,
+    ) -> CoreResult<()> {
+        self.render_fit(index, buf, mode, pan_x, pan_y)
+    }
+
     /// The page's **content bounding box** in normalized page coords `[0,1]` (RR4 — KOReader's
     /// auto Crop): the tight rectangle around the non-white content, used to trim white margins.
     /// `None` if undetectable or not applicable (blank page / reflowable backend). Never panics.
@@ -410,6 +423,20 @@ pub trait Document {
         pan_y: f32,
     ) -> CoreResult<()> {
         self.render_fit(index, buf, mode, pan_x, pan_y)
+    }
+
+    /// Crop-render a fixed-layout preview without committing backend viewport bookkeeping.
+    /// Backends without such bookkeeping can use the regular cropped path.
+    fn render_preview_cropped(
+        &self,
+        index: usize,
+        buf: &mut PixelBuffer<'_>,
+        crop: NormRect,
+        mode: FitMode,
+        pan_x: f32,
+        pan_y: f32,
+    ) -> CoreResult<()> {
+        self.render_cropped(index, buf, crop, mode, pan_x, pan_y)
     }
 
     /// Adjust the reflow **text scale** (`1.0` = the backend default size) and repaginate (RR2-FR5

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -430,6 +430,69 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeRenderPage<
 }
 
 // =====================================================================================
+// nativeRenderPagePreview(handle, page, directBuffer, width, height) — fit-render an arbitrary page
+// for thumbnail navigation without changing the session's displayed page/zoom/policy/cache state.
+// =====================================================================================
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeRenderPagePreview<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    page: jint,
+    buffer: JByteBuffer<'local>,
+    width: jint,
+    height: jint,
+) {
+    env.with_env(|env| -> jni::errors::Result<()> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        let page = usize::try_from(page).map_err(|_| {
+            throw(
+                env,
+                &CoreError::InvalidArgument(format!("negative preview page {page}")),
+            )
+        })?;
+        let width = u32::try_from(width).map_err(|_| {
+            throw(
+                env,
+                &CoreError::InvalidArgument(format!("invalid preview width {width}")),
+            )
+        })?;
+        let height = u32::try_from(height).map_err(|_| {
+            throw(
+                env,
+                &CoreError::InvalidArgument(format!("invalid preview height {height}")),
+            )
+        })?;
+        if width == 0 || height == 0 {
+            return Err(throw(
+                env,
+                &CoreError::InvalidArgument(format!(
+                    "preview dimensions must be positive, got {width}x{height}"
+                )),
+            ));
+        }
+
+        let addr = env.get_direct_buffer_address(&buffer)?;
+        let cap = env.get_direct_buffer_capacity(&buffer)?;
+        if addr.is_null() {
+            return Err(throw(
+                env,
+                &CoreError::BufferMismatch("preview buffer is not a direct ByteBuffer".into()),
+            ));
+        }
+        // SAFETY: the direct buffer remains valid for this JNI call and is borrowed only until
+        // `render_page_preview()` returns.
+        let slice = unsafe { std::slice::from_raw_parts_mut(addr, cap) };
+        let mut pb = PixelBuffer::from_rgba(slice, width, height).map_err(|e| throw(env, &e))?;
+        session
+            .render_page_preview(page, &mut pb)
+            .map_err(|e| throw(env, &e))?;
+        Ok(())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// =====================================================================================
 // nativePrefetchPage(handle, page) — render `page` into the session's render cache WITHOUT
 // displaying it, so a turn to it is a cache hit (RR24 read-ahead). Best-effort: a prefetch
 // failure is swallowed (it must never disturb reading). Mutates the cache, so engine-thread only.

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -529,22 +529,60 @@ impl ReaderSession {
         Ok(())
     }
 
+    /// Render `page` as a fit-page preview without changing the reader's page, zoom, pan, ink
+    /// layer, refresh-policy state, or shared render cache.
+    pub fn render_page_preview(
+        &mut self,
+        page: usize,
+        buf: &mut PixelBuffer<'_>,
+    ) -> CoreResult<()> {
+        if page >= self.page_count() {
+            return Err(CoreError::PageOutOfRange {
+                requested: page,
+                available: self.page_count(),
+            });
+        }
+        if (buf.width() != self.viewport.width || buf.height() != self.viewport.height)
+            && !self.document.is_magnifiable()
+        {
+            return Err(CoreError::BufferMismatch(format!(
+                "reflow preview buffer {}x{} != viewport {}x{}",
+                buf.width(),
+                buf.height(),
+                self.viewport.width,
+                self.viewport.height
+            )));
+        }
+
+        let saved_page = self.page;
+        self.page = page;
+        let rendered = self.render_pixels(buf, true);
+        self.page = saved_page;
+        rendered
+    }
+
     /// Rasterize the current page's fit/crop pixels (honoring render-quality supersampling) and apply
     /// contrast, into `buf`. The shared core of [`Self::render_current`]'s non-magnified path and
     /// [`Self::prefetch_page`]; touches neither the cache nor zoom.
     fn render_fit_pixels(&self, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+        self.render_pixels(buf, false)
+    }
+
+    /// Render the fit/crop pixel pipeline, optionally through the backend's non-committing preview
+    /// seam. Preview targets may be smaller than the viewport for fixed-layout documents.
+    fn render_pixels(&self, buf: &mut PixelBuffer<'_>, preview: bool) -> CoreResult<()> {
         let q = render_quality_factor(self.render_quality);
         if (q - 1.0).abs() < 1e-3 {
-            self.render_fit_or_crop(buf)?;
+            self.render_fit_or_crop(buf, preview)?;
         } else {
             // Render at q× the panel resolution, then bilinear-resample down/up to the panel —
             // supersampling (high) smooths e-ink text; sub-sampling (low) is faster/softer.
-            let qw = ((self.viewport.width as f32 * q).round() as u32).clamp(1, 8000);
-            let qh = ((self.viewport.height as f32 * q).round() as u32).clamp(1, 8000);
+            let qw = ((buf.width() as f32 * q).round() as u32).clamp(1, 8000);
+            let qh = ((buf.height() as f32 * q).round() as u32).clamp(1, 8000);
             let mut tmp = vec![0u8; (qw as usize) * (qh as usize) * 4];
             {
                 let mut tbuf = PixelBuffer::from_rgba(&mut tmp, qw, qh)?;
-                self.render_fit_or_crop(&mut tbuf)?;
+                self.render_fit_or_crop(&mut tbuf, preview)?;
             }
             crate::render::resample::resample_bilinear(&tmp, qw, qh, buf);
         }
@@ -624,7 +662,7 @@ impl ReaderSession {
     /// Render the current page fit (or auto-cropped) into `buf` (RR4). With auto-crop on, the white
     /// margins are trimmed to the detected content box; otherwise an aspect-preserving fit. PDF
     /// honors both; reflowable backends fall back to a full-buffer render.
-    fn render_fit_or_crop(&self, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+    fn render_fit_or_crop(&self, buf: &mut PixelBuffer<'_>, preview: bool) -> CoreResult<()> {
         match self
             .crop_auto
             .then(|| self.cached_crop_bbox(self.page))
@@ -632,14 +670,29 @@ impl ReaderSession {
         {
             Some(b) => {
                 let crop = self.expand_crop(b);
-                self.document.render_cropped(
-                    self.page,
-                    buf,
-                    crop,
-                    self.fit_mode,
-                    self.pan_x,
-                    self.pan_y,
-                )
+                if preview {
+                    self.document.render_preview_cropped(
+                        self.page,
+                        buf,
+                        crop,
+                        self.fit_mode,
+                        0.0,
+                        0.0,
+                    )
+                } else {
+                    self.document.render_cropped(
+                        self.page,
+                        buf,
+                        crop,
+                        self.fit_mode,
+                        self.pan_x,
+                        self.pan_y,
+                    )
+                }
+            }
+            None if preview => {
+                self.document
+                    .render_preview_fit(self.page, buf, self.fit_mode, 0.0, 0.0)
             }
             None => self
                 .document

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -443,6 +443,64 @@ fn render_current_into_matching_buffer_ok() {
     assert!(s.render_current(&mut pb).is_ok());
 }
 
+#[test]
+fn page_preview_renders_requested_page_without_changing_navigation_state() {
+    struct PageColorDoc;
+    impl Document for PageColorDoc {
+        fn page_count(&self) -> usize {
+            4
+        }
+        fn metadata(&self) -> DocumentMetadata {
+            DocumentMetadata::default()
+        }
+        fn render_page(&self, index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
+            buf.fill_white();
+            buf.bytes_mut()[0] = index as u8;
+            Ok(())
+        }
+        fn is_magnifiable(&self) -> bool {
+            true
+        }
+    }
+
+    let mut s = ReaderSession::with_document(
+        Box::new(PageColorDoc),
+        DeviceCapabilities::supernote_full(),
+        Viewport::new(100, 120, 226),
+    );
+    s.jump_to_page(1);
+    s.set_zoom(2.0, 0.4, 0.7);
+    let mut bytes = vec![0u8; 20 * 24 * 4];
+    let mut pb = PixelBuffer::from_rgba(&mut bytes, 20, 24).unwrap();
+    let cached_before = s.caches().render().len();
+
+    s.render_page_preview(3, &mut pb).unwrap();
+
+    assert_eq!(pb.bytes()[0], 3, "preview rendered the requested page");
+    assert_eq!(
+        s.caches().render().len(),
+        cached_before,
+        "preview must not pollute the page-turn cache"
+    );
+    assert_eq!(s.current_page(), 1);
+    assert_eq!(s.zoom(), 2.0);
+    assert_eq!(s.pan_x(), 0.4);
+    assert_eq!(s.pan_y(), 0.7);
+}
+
+#[test]
+fn reflowable_page_preview_rejects_a_different_target_size() {
+    let mut s = session(2, DeviceCapabilities::supernote_full());
+    s.jump_to_page(1);
+    let mut bytes = vec![0u8; 20 * 24 * 4];
+    let mut pb = PixelBuffer::from_rgba(&mut bytes, 20, 24).unwrap();
+
+    let err = s.render_page_preview(0, &mut pb).unwrap_err();
+
+    assert!(matches!(err, CoreError::BufferMismatch(_)));
+    assert_eq!(s.current_page(), 1);
+}
+
 // RR4-FR6 / RR24: a revisited page (same view-settings) is served from the render cache without
 // re-rasterizing; a settings change keys a fresh render; a repagination/viewport change drops it.
 // RR11: a letterboxed page (page coords ≠ viewport coords) must have its text-selection boxes


### PR DESCRIPTION
## What & why

Adds a full-screen, e-ink-friendly 3x3 page thumbnail grid for quick visual navigation. The grid opens on the nine-page window containing the current page, pages backward/forward by nine, highlights the current page, and jumps to a tapped thumbnail before closing.

Thumbnail batches render on the existing serialized engine thread. A native preview seam renders arbitrary pages without changing the reader page, zoom/pan, ink layer, refresh-policy state, or shared page-turn cache. Superseded batches stop between pages, and their scratch bitmap/direct buffer are reused. Fixed-layout PDF/CBZ pages render directly at thumbnail resolution; reflowable documents retain the reader viewport so previewing cannot repaginate the book.

Closes #100

## Requirements / design refs

- Issue #100 acceptance criteria: 3x3 visual navigation, off-UI-thread rendering, one completed batch update, PDF and EPUB support.
- RR4 / RR21: borrowed render buffer and serialized engine access.

## How it was tested

- [x] `cargo test --workspace` is green (`reader-core`: 301 passed, 2 existing ignored visual dumps).
- [x] `cargo clippy --all -- -D warnings` is green.
- [x] Added host tests for grid windowing, paging bounds, aspect-preserving thumbnail sizing, cache-neutral/state-preserving fixed-layout previews, and rejection of resized reflow previews.
- [x] PDFium and EPUB parse/layout/render tests pass in the workspace suite.
- [ ] Verified on a device (Supernote) - no device or emulator was available.

## Pre-merge checklist

- [x] `cargo fmt --all` - no format diff
- [x] `cargo clippy --all -- -D warnings` - no warnings
- [x] `cargo test --workspace` - passes
- [x] `./scripts/check-licenses.sh` - no new dependencies; allowlist passes
- [x] The Rust core still builds host-only; `jni` is absent from its default dependency graph
- [x] The core names no vendor; UI/device behavior stays in `app/` and the JNI bridge
- [x] Commits follow Conventional Commits with no attribution trailers
- [x] No secrets, signing keys, private documents, or private research material

## Notes for the reviewer

- The Pages control sits beside Contents in the existing bottom bar.
- Opening renders a complete batch before showing the sheet, then requests one full panel refresh. Prev/next keeps the old batch visible until the replacement batch is complete, then swaps once and refreshes once.
- Each thumbnail is focusable and has a page-specific content description; the current page also has a heavier border.
- Android/JVM compilation is left to CI because this host has no JDK/Android toolchain; no SDK license was accepted on the user behalf.
- No visual artifact is attached because there was no runnable Android target; no synthetic document screenshot was fabricated.