### PR TITLE
Inkbridge boox integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         versionCode = (project.findProperty("inkreadVersionCode") as String?)?.toInt() ?: 1
         versionName = (project.findProperty("inkreadVersionName") as String?) ?: "1.0.0-dev"
         ndk {
-            // RK3566 is arm64; M0 ships arm64 only (RR29-FR1).
+            // RK3566 and current BOOX targets are arm64; M0 ships arm64 only (RR29-FR1).
             abiFilters += "arm64-v8a"
         }
     }
@@ -70,9 +70,11 @@ android {
         jvmTarget = "17"
     }
 
-    // Don't let Gradle strip/recompress the prebuilt .so (it is already stripped).
+    // Don't let Gradle strip/recompress the prebuilt .so (it is already stripped). Onyx's native
+    // pen stack and MMKV both bundle libc++_shared.so; package one ABI-equivalent copy per ABI.
     packaging {
         jniLibs.useLegacyPackaging = false
+        jniLibs.pickFirsts += setOf("**/libc++_shared.so")
     }
 }
 
@@ -85,6 +87,22 @@ dependencies {
     // Background scheduler for the daily auto-compile (#66). 2.9.x is the last line that builds
     // against compileSdk 34 (2.10+ needs SDK 35) — bump with compileSdk + AGP, not piecemeal.
     implementation("androidx.work:work-runtime-ktx:2.9.1")
+
+    // BOOX native pen path. Keep vendor dependencies at the Android shell boundary; the Rust core
+    // remains vendor-neutral. Exclude legacy support artifacts that collide with AndroidX.
+    implementation("com.onyx.android.sdk:onyxsdk-pen:1.5.4") {
+        exclude(group = "com.android.support", module = "support-compat")
+        exclude(group = "com.android.support", module = "appcompat-v7")
+        exclude(group = "com.onyx.android.sdk", module = "onyxsdk-geometry")
+    }
+    implementation("com.onyx.android.sdk:onyxsdk-device:1.3.5") {
+        exclude(group = "com.android.support", module = "support-compat")
+    }
+    implementation("com.onyx.android.sdk:onyxsdk-base:1.8.5") {
+        exclude(group = "com.android.support", module = "support-compat")
+        exclude(group = "com.android.support", module = "appcompat-v7")
+    }
+    implementation("org.lsposed.hiddenapibypass:hiddenapibypass:6.1")
 
     // Host JVM unit tests for pure logic (e.g. PalmFilter) — run via :app:testDebugUnitTest, no
     // emulator/device needed (an emulator can't simulate the Supernote EMR pen anyway).

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- inkread M0 Android shell (RR1-FR2). Storage permission per RR22 (M1a) is intentionally
      not requested yet for the M0 bring-up; M0 opens a path the user places on-device. -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Opt-in online dictionary fallback (Wiktionary) for non-bundled languages (RR12 / D4). -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -31,7 +32,8 @@
         android:label="InkRead"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        tools:replace="android:label">
 
         <!-- Home screen + launcher: brand and entry points (Open / Library / Continue). -->
         <activity

--- a/app/src/main/java/dev/jraghavan/inkread/eink/BooxInk.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/eink/BooxInk.kt
@@ -1,0 +1,198 @@
+package dev.jraghavan.inkread.eink
+
+import android.graphics.Rect
+import android.os.Build
+import android.view.SurfaceView
+import com.onyx.android.sdk.api.device.epd.EpdController
+import com.onyx.android.sdk.data.note.TouchPoint
+import com.onyx.android.sdk.pen.RawInputCallback
+import com.onyx.android.sdk.pen.TouchHelper
+import com.onyx.android.sdk.pen.data.TouchPointList
+import com.onyx.android.sdk.rx.RxManager
+import org.lsposed.hiddenapibypass.HiddenApiBypass
+
+/**
+ * BOOX firmware/native wet-ink client.
+ *
+ * [TouchHelper] owns the live stroke so handwriting follows the nib without waiting for the
+ * application's render loop. The same raw samples are copied out through [Listener] after pen-up;
+ * the reader can then map them into its vendor-neutral Rust ink model.
+ *
+ * Vendor code deliberately stays in the Android shell, matching [SupernoteInk].
+ */
+class BooxInk(
+    private val surfaceView: SurfaceView,
+    private val listener: Listener,
+) {
+    data class Sample(
+        val x: Float,
+        val y: Float,
+        val pressure: Float,
+    )
+
+    interface Listener {
+        fun onBooxPenStroke(samples: List<Sample>)
+        fun onBooxEraserGesture(samples: List<Sample>)
+        fun onBooxInkStatus(message: String) {}
+    }
+
+    private var touchHelper: TouchHelper? = null
+    private var started = false
+
+    private val pendingPenPoints = ArrayList<TouchPoint>(2048)
+    private var batchedPenPoints: List<TouchPoint>? = null
+
+    private val pendingEraserPoints = ArrayList<TouchPoint>(2048)
+    private var batchedEraserPoints: List<TouchPoint>? = null
+
+    private val callback = object : RawInputCallback() {
+        override fun onBeginRawDrawing(fromTouch: Boolean, touchPoint: TouchPoint?) {
+            pendingPenPoints.clear()
+            batchedPenPoints = null
+            touchPoint?.let { pendingPenPoints += TouchPoint(it) }
+            listener.onBooxInkStatus("BOOX pen down")
+        }
+
+        override fun onRawDrawingTouchPointMoveReceived(touchPoint: TouchPoint?) {
+            // Some BOOX firmware versions intermittently omit the final cumulative-list callback.
+            // Keep per-move samples as a fallback, but prefer the SDK list when present.
+            touchPoint?.let { pendingPenPoints += TouchPoint(it) }
+        }
+
+        override fun onRawDrawingTouchPointListReceived(touchPointList: TouchPointList?) {
+            val raw = touchPointList?.points.orEmpty()
+            if (raw.isNotEmpty()) batchedPenPoints = raw.map { TouchPoint(it) }
+        }
+
+        override fun onEndRawDrawing(fromTouch: Boolean, touchPoint: TouchPoint?) {
+            val raw = batchedPenPoints ?: buildList {
+                addAll(pendingPenPoints)
+                touchPoint?.let { add(TouchPoint(it)) }
+            }
+            pendingPenPoints.clear()
+            batchedPenPoints = null
+            if (raw.isEmpty()) return
+
+            val snapshot = raw.map { TouchPoint(it) }
+            surfaceView.post {
+                listener.onBooxPenStroke(snapshot.map(::toSample))
+            }
+        }
+
+        override fun onBeginRawErasing(fromTouch: Boolean, touchPoint: TouchPoint?) {
+            pendingEraserPoints.clear()
+            batchedEraserPoints = null
+            touchPoint?.let { pendingEraserPoints += TouchPoint(it) }
+            listener.onBooxInkStatus("BOOX eraser down")
+        }
+
+        override fun onRawErasingTouchPointMoveReceived(touchPoint: TouchPoint?) {
+            touchPoint?.let { pendingEraserPoints += TouchPoint(it) }
+        }
+
+        override fun onRawErasingTouchPointListReceived(touchPointList: TouchPointList?) {
+            val raw = touchPointList?.points.orEmpty()
+            if (raw.isNotEmpty()) batchedEraserPoints = raw.map { TouchPoint(it) }
+        }
+
+        override fun onEndRawErasing(fromTouch: Boolean, touchPoint: TouchPoint?) {
+            val raw = batchedEraserPoints ?: buildList {
+                addAll(pendingEraserPoints)
+                touchPoint?.let { add(TouchPoint(it)) }
+            }
+            pendingEraserPoints.clear()
+            batchedEraserPoints = null
+            if (raw.isEmpty()) return
+
+            val snapshot = raw.map { TouchPoint(it) }
+            surfaceView.post {
+                listener.onBooxEraserGesture(snapshot.map(::toSample))
+            }
+        }
+
+        override fun onPenActive(touchPoint: TouchPoint?) = Unit
+    }
+
+    /** Start BOOX raw drawing over the visible reader surface. Safe to call more than once. */
+    fun setup(): Boolean {
+        if (started) return true
+        val limit = Rect()
+        if (!surfaceView.getLocalVisibleRect(limit) || limit.isEmpty) {
+            listener.onBooxInkStatus("BOOX ink surface is not laid out yet")
+            return false
+        }
+
+        return try {
+            // Current Onyx SDK code reflects hidden framework APIs. Install the exemption before
+            // TouchHelper initialization, matching known-good BOOX implementations.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                runCatching { HiddenApiBypass.addHiddenApiExemptions("") }
+            }
+            runCatching { RxManager.Builder.initAppContext(surfaceView.context.applicationContext) }
+
+            val helper = TouchHelper.create(surfaceView, callback)
+            helper.setRawDrawingEnabled(false)
+            helper.closeRawDrawing()
+            helper.setStrokeWidth(STROKE_WIDTH_PX)
+            helper.setLimitRect(mutableListOf(limit))
+                .setExcludeRect(emptyList())
+                .openRawDrawing()
+            helper.enableSideBtnErase(true)
+            helper.setBrushRawDrawingEnabled(true)
+            helper.setEraserRawDrawingEnabled(true, ERASER_WIDTH)
+            helper.setStrokeStyle(TouchHelper.STROKE_STYLE_FOUNTAIN)
+            helper.setRawDrawingRenderEnabled(true)
+            runCatching { EpdController.enablePost(1) }
+            helper.setRawDrawingEnabled(true)
+
+            touchHelper = helper
+            started = true
+            listener.onBooxInkStatus("BOOX TouchHelper active: native render + portable capture")
+            true
+        } catch (t: Throwable) {
+            listener.onBooxInkStatus("BOOX TouchHelper failed: ${t.javaClass.simpleName}: ${t.message}")
+            false
+        }
+    }
+
+    /** Enable/disable BOOX firmware drawing without destroying the adapter. */
+    fun setWritable(enabled: Boolean) {
+        runCatching { touchHelper?.setRawDrawingEnabled(enabled) }
+            .onFailure { listener.onBooxInkStatus("BOOX ink toggle failed: ${it.message}") }
+    }
+
+    /** Release the firmware/native drawing path. */
+    fun teardown() {
+        if (!started) return
+        runCatching { touchHelper?.setRawDrawingEnabled(false) }
+        runCatching { touchHelper?.closeRawDrawing() }
+            .onFailure { listener.onBooxInkStatus("BOOX ink close failed: ${it.message}") }
+        touchHelper = null
+        started = false
+    }
+
+    private fun toSample(point: TouchPoint): Sample {
+        val rawPressure = point.pressure
+        val maxPressure = runCatching { EpdController.getMaxTouchPressure().toFloat() }
+            .getOrDefault(DEFAULT_MAX_PRESSURE)
+            .coerceAtLeast(1f)
+        val pressure = if (rawPressure > 1f) rawPressure / maxPressure else rawPressure
+        return Sample(
+            x = point.x,
+            y = point.y,
+            pressure = pressure.coerceIn(0f, 1f),
+        )
+    }
+
+    companion object {
+        private const val STROKE_WIDTH_PX = 3f
+        private const val ERASER_WIDTH = 5
+        private const val DEFAULT_MAX_PRESSURE = 4095f
+
+        /** BOOX firmware commonly reports Onyx/BOOX across manufacturer/brand fields. */
+        fun isBooxDevice(): Boolean {
+            val identity = "${Build.MANUFACTURER} ${Build.BRAND} ${Build.DEVICE}".lowercase()
+            return "onyx" in identity || "boox" in identity
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,15 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // BOOX/Onyx publishes its Android pen/device SDKs from these repositories.
+        maven {
+            url = uri("http://repo.boox.com/repository/proxy-public/")
+            isAllowInsecureProtocol = true
+        }
+        maven {
+            url = uri("http://repo.boox.com/repository/maven-public/")
+            isAllowInsecureProtocol = true
+        }
     }
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing to inkread! Keep PRs focused on one logical change.
  Fill in the sections below — delete any that genuinely don't apply.
-->

## What & why

<!-- What does this change do, and why? Link the issue it closes. -->

Closes #

## Requirements / design refs

<!-- Spec/ADR/requirement IDs this implements or touches, e.g. RR5-FR1, ADR-INKREAD-0010.
     External contributor without spec access? Write "n/a" and describe the behaviour instead. -->

-

## How it was tested

<!-- Commands you ran, fixtures you added, device(s) you verified on (host-only is fine). -->

- [ ] `cargo test --workspace` is green
- [ ] Added/updated a test that fails without this change (for bugs/new behaviour)
- [ ] Verified on a device (Supernote) — _or_ host-only change, N/A
      (release PRs: run [`docs/RELEASE-SMOKE-CHECKLIST.md`](../docs/RELEASE-SMOKE-CHECKLIST.md))

## Pre-merge checklist

<!-- All must be true. CI enforces them; tick to confirm you ran them locally. -->

- [ ] `cargo fmt --all` — no format diff
- [ ] `cargo clippy --all -- -D warnings` — no warnings
- [ ] `cargo test --workspace` — passes
- [ ] `cargo llvm-cov --workspace` — coverage holds the RR17 gate
- [ ] `./scripts/check-licenses.sh` — no new/unvetted dependency licenses
- [ ] The Rust core still builds **host-only** — no Android types leaked into `reader-core`,
      and `jni` is absent from its default dependency graph (RR1-AC3 / IR-7)
- [ ] The core names **no vendor** — device/EPD/pen specifics stay in `app/` + the JNI bridge (IR-7)
- [ ] Commits follow Conventional Commits (`type(scope): subject`) with **no AI/Co-Authored-By
      attribution**
- [ ] No secrets, signing keys, `.env`, or private research material (decompiled APK/`.so`/jadx)

## Notes for the reviewer

<!-- Anything to look at first, known trade-offs, follow-ups intentionally left out of scope. -->
