### PR TITLE
Inkbridge supernote native bridge poc

### DIFF
--- a/.github/workflows/inkbridge-boox-build.yml
+++ b/.github/workflows/inkbridge-boox-build.yml
@@ -1,0 +1,85 @@
+name: InkBridge BOOX build
+
+on:
+  push:
+    branches: [inkbridge-boox-integration]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  apk:
+    name: build debug APK with BOOX SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+
+      - name: Configure Android NDK
+        run: |
+          set -euo pipefail
+          ndk="${ANDROID_NDK_LATEST_HOME:-${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}}"
+          test -n "$ndk" || { echo "::error::No Android NDK found on the runner"; exit 1; }
+          echo "ANDROID_NDK_HOME=$ndk" >> "$GITHUB_ENV"
+          echo "Using NDK: $ndk"
+
+      - name: Build debug APK
+        shell: bash
+        run: |
+          chmod +x ./buildApk.sh
+          set +e
+          ./buildApk.sh --debug > inkbridge-build.log 2>&1
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "===== COMPACT BUILD FAILURE ====="
+            grep -E '(^FAILURE:|^\* What went wrong:|^e: |^error:|Could not resolve|Could not find|Unresolved reference|Execution failed for task|Manifest merger failed|Compilation error|BUILD FAILED|Duplicate relative path|duplicate files|A failure occurred while executing)' inkbridge-build.log | tail -n 80 || true
+            echo "===== FINAL 40 LINES ====="
+            tail -n 40 inkbridge-build.log
+            exit $rc
+          fi
+          echo "Build succeeded"
+
+      - name: Upload build diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inkbridge-boox-build-log
+          path: inkbridge-build.log
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Verify APK and native libraries
+        if: success()
+        run: |
+          set -euo pipefail
+          apk="$(find app/build/outputs/apk/debug -type f -name '*.apk' -print -quit)"
+          test -n "$apk" || { echo "::error::No APK produced"; exit 1; }
+          listing="$(unzip -l "$apk")"
+          for lib in lib/arm64-v8a/libreader.so lib/arm64-v8a/libpdfium.so; do
+            [[ "$listing" == *"$lib"* ]] || { echo "::error::$lib missing from $apk"; exit 1; }
+          done
+          echo "APK OK: $apk"
+
+      - name: Upload debug APK
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inkbridge-boox-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+          retention-days: 7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         versionCode = (project.findProperty("inkreadVersionCode") as String?)?.toInt() ?: 1
         versionName = (project.findProperty("inkreadVersionName") as String?) ?: "1.0.0-dev"
         ndk {
-            // RK3566 is arm64; M0 ships arm64 only (RR29-FR1).
+            // RK3566 and current BOOX targets are arm64; M0 ships arm64 only (RR29-FR1).
             abiFilters += "arm64-v8a"
         }
     }
@@ -70,9 +70,11 @@ android {
         jvmTarget = "17"
     }
 
-    // Don't let Gradle strip/recompress the prebuilt .so (it is already stripped).
+    // Don't let Gradle strip/recompress the prebuilt .so (it is already stripped). Onyx's native
+    // pen stack and MMKV both bundle libc++_shared.so; package one ABI-equivalent copy per ABI.
     packaging {
         jniLibs.useLegacyPackaging = false
+        jniLibs.pickFirsts += setOf("**/libc++_shared.so")
     }
 }
 
@@ -85,6 +87,22 @@ dependencies {
     // Background scheduler for the daily auto-compile (#66). 2.9.x is the last line that builds
     // against compileSdk 34 (2.10+ needs SDK 35) — bump with compileSdk + AGP, not piecemeal.
     implementation("androidx.work:work-runtime-ktx:2.9.1")
+
+    // BOOX native pen path. Keep vendor dependencies at the Android shell boundary; the Rust core
+    // remains vendor-neutral. Exclude legacy support artifacts that collide with AndroidX.
+    implementation("com.onyx.android.sdk:onyxsdk-pen:1.5.4") {
+        exclude(group = "com.android.support", module = "support-compat")
+        exclude(group = "com.android.support", module = "appcompat-v7")
+        exclude(group = "com.onyx.android.sdk", module = "onyxsdk-geometry")
+    }
+    implementation("com.onyx.android.sdk:onyxsdk-device:1.3.5") {
+        exclude(group = "com.android.support", module = "support-compat")
+    }
+    implementation("com.onyx.android.sdk:onyxsdk-base:1.8.5") {
+        exclude(group = "com.android.support", module = "support-compat")
+        exclude(group = "com.android.support", module = "appcompat-v7")
+    }
+    implementation("org.lsposed.hiddenapibypass:hiddenapibypass:6.1")
 
     // Host JVM unit tests for pure logic (e.g. PalmFilter) — run via :app:testDebugUnitTest, no
     // emulator/device needed (an emulator can't simulate the Supernote EMR pen anyway).

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- inkread M0 Android shell (RR1-FR2). Storage permission per RR22 (M1a) is intentionally
      not requested yet for the M0 bring-up; M0 opens a path the user places on-device. -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Opt-in online dictionary fallback (Wiktionary) for non-bundled languages (RR12 / D4). -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -31,7 +32,8 @@
         android:label="InkRead"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        tools:replace="android:allowBackup,android:label">
 
         <!-- Home screen + launcher: brand and entry points (Open / Library / Continue). -->
         <activity

--- a/app/src/main/java/dev/jraghavan/inkread/eink/BooxInk.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/eink/BooxInk.kt
@@ -1,0 +1,249 @@
+package dev.jraghavan.inkread.eink
+
+import android.graphics.Rect
+import android.os.Build
+import android.view.SurfaceView
+import com.onyx.android.sdk.api.device.epd.EpdController
+import com.onyx.android.sdk.data.note.TouchPoint
+import com.onyx.android.sdk.pen.RawInputCallback
+import com.onyx.android.sdk.pen.TouchHelper
+import com.onyx.android.sdk.pen.data.TouchPointList
+import com.onyx.android.sdk.rx.RxManager
+import org.lsposed.hiddenapibypass.HiddenApiBypass
+
+/**
+ * BOOX firmware/native wet-ink client.
+ *
+ * [TouchHelper] owns the live stroke so handwriting follows the nib without waiting for the
+ * application's render loop. The same raw samples are copied out through [Listener] after pen-up;
+ * the reader can then map them into its vendor-neutral Rust ink model.
+ *
+ * Vendor code deliberately stays in the Android shell, matching [SupernoteInk].
+ */
+class BooxInk(
+    private val surfaceView: SurfaceView,
+    private val listener: Listener,
+) {
+    data class Sample(
+        val x: Float,
+        val y: Float,
+        val pressure: Float,
+    )
+
+    interface Listener {
+        fun onBooxPenStroke(samples: List<Sample>)
+        fun onBooxEraserGesture(samples: List<Sample>)
+        fun onBooxInkStatus(message: String) {}
+    }
+
+    private var touchHelper: TouchHelper? = null
+    private var started = false
+
+    private val pendingPenPoints = ArrayList<TouchPoint>(2048)
+    private var batchedPenPoints: List<TouchPoint>? = null
+    private var penFromTouch = false
+
+    private val pendingEraserPoints = ArrayList<TouchPoint>(2048)
+    private var batchedEraserPoints: List<TouchPoint>? = null
+    private var eraserFromTouch = false
+
+    private val callback = object : RawInputCallback() {
+        override fun onBeginRawDrawing(fromTouch: Boolean, touchPoint: TouchPoint?) {
+            pendingPenPoints.clear()
+            batchedPenPoints = null
+            penFromTouch = fromTouch
+            if (fromTouch) return
+            touchPoint?.let { pendingPenPoints += TouchPoint(it) }
+            listener.onBooxInkStatus("BOOX pen down")
+        }
+
+        override fun onRawDrawingTouchPointMoveReceived(touchPoint: TouchPoint?) {
+            if (penFromTouch) return
+            // Some BOOX firmware versions intermittently omit the final cumulative-list callback.
+            // Keep per-move samples as a fallback, but prefer the SDK list when present.
+            touchPoint?.let { pendingPenPoints += TouchPoint(it) }
+        }
+
+        override fun onRawDrawingTouchPointListReceived(touchPointList: TouchPointList?) {
+            if (penFromTouch) return
+            val raw = touchPointList?.points.orEmpty()
+            if (raw.isNotEmpty()) batchedPenPoints = raw.map { TouchPoint(it) }
+        }
+
+        override fun onEndRawDrawing(fromTouch: Boolean, touchPoint: TouchPoint?) {
+            val ignore = penFromTouch || fromTouch
+            penFromTouch = false
+            if (ignore) {
+                pendingPenPoints.clear()
+                batchedPenPoints = null
+                return
+            }
+
+            val snapshot = mergedSequence(pendingPenPoints, batchedPenPoints, touchPoint)
+            pendingPenPoints.clear()
+            batchedPenPoints = null
+            if (snapshot.isEmpty()) return
+
+            surfaceView.post {
+                listener.onBooxPenStroke(snapshot.map(::toSample))
+            }
+        }
+
+        override fun onBeginRawErasing(fromTouch: Boolean, touchPoint: TouchPoint?) {
+            pendingEraserPoints.clear()
+            batchedEraserPoints = null
+            eraserFromTouch = fromTouch
+            if (fromTouch) return
+            touchPoint?.let { pendingEraserPoints += TouchPoint(it) }
+            listener.onBooxInkStatus("BOOX eraser down")
+        }
+
+        override fun onRawErasingTouchPointMoveReceived(touchPoint: TouchPoint?) {
+            if (eraserFromTouch) return
+            touchPoint?.let { pendingEraserPoints += TouchPoint(it) }
+        }
+
+        override fun onRawErasingTouchPointListReceived(touchPointList: TouchPointList?) {
+            if (eraserFromTouch) return
+            val raw = touchPointList?.points.orEmpty()
+            if (raw.isNotEmpty()) batchedEraserPoints = raw.map { TouchPoint(it) }
+        }
+
+        override fun onEndRawErasing(fromTouch: Boolean, touchPoint: TouchPoint?) {
+            val ignore = eraserFromTouch || fromTouch
+            eraserFromTouch = false
+            if (ignore) {
+                pendingEraserPoints.clear()
+                batchedEraserPoints = null
+                return
+            }
+
+            val snapshot = mergedSequence(pendingEraserPoints, batchedEraserPoints, touchPoint)
+            pendingEraserPoints.clear()
+            batchedEraserPoints = null
+            if (snapshot.isEmpty()) return
+
+            surfaceView.post {
+                listener.onBooxEraserGesture(snapshot.map(::toSample))
+            }
+        }
+
+        override fun onPenActive(touchPoint: TouchPoint?) = Unit
+    }
+
+    /**
+     * Build one portable sequence without losing SDK begin/end samples.
+     *
+     * BOOX can deliver a cumulative list for the middle of the stroke, while begin/end arrive in
+     * separate callbacks. When the list is present we use it as the authoritative middle, but still
+     * prepend the begin sample and append the pen-up sample when they are not already present.
+     */
+    private fun mergedSequence(
+        pending: List<TouchPoint>,
+        batch: List<TouchPoint>?,
+        end: TouchPoint?,
+    ): List<TouchPoint> {
+        val middle = batch.orEmpty()
+        val out = ArrayList<TouchPoint>((if (middle.isNotEmpty()) middle.size else pending.size) + 2)
+
+        if (middle.isNotEmpty()) {
+            pending.firstOrNull()?.let { appendDistinct(out, it) }
+            middle.forEach { appendDistinct(out, it) }
+        } else {
+            pending.forEach { appendDistinct(out, it) }
+        }
+        end?.let { appendDistinct(out, it) }
+        return out
+    }
+
+    private fun appendDistinct(out: MutableList<TouchPoint>, point: TouchPoint) {
+        val copy = TouchPoint(point)
+        val last = out.lastOrNull()
+        if (last == null || last.x != copy.x || last.y != copy.y || last.pressure != copy.pressure) {
+            out += copy
+        }
+    }
+
+    /** Start BOOX raw drawing over the visible reader surface. Safe to call more than once. */
+    fun setup(): Boolean {
+        if (started) return true
+        val limit = Rect()
+        if (!surfaceView.getLocalVisibleRect(limit) || limit.isEmpty) {
+            listener.onBooxInkStatus("BOOX ink surface is not laid out yet")
+            return false
+        }
+
+        return try {
+            // Current Onyx SDK code reflects hidden framework APIs. Install the exemption before
+            // TouchHelper initialization, matching known-good BOOX implementations.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                runCatching { HiddenApiBypass.addHiddenApiExemptions("") }
+            }
+            runCatching { RxManager.Builder.initAppContext(surfaceView.context.applicationContext) }
+
+            val helper = TouchHelper.create(surfaceView, callback)
+            helper.setRawDrawingEnabled(false)
+            helper.closeRawDrawing()
+            helper.setStrokeWidth(STROKE_WIDTH_PX)
+            helper.setLimitRect(mutableListOf(limit))
+                .setExcludeRect(emptyList())
+                .openRawDrawing()
+            helper.enableSideBtnErase(true)
+            helper.setBrushRawDrawingEnabled(true)
+            helper.setEraserRawDrawingEnabled(true, ERASER_WIDTH)
+            helper.setStrokeStyle(TouchHelper.STROKE_STYLE_FOUNTAIN)
+            helper.setRawDrawingRenderEnabled(true)
+            runCatching { EpdController.enablePost(1) }
+            helper.setRawDrawingEnabled(true)
+
+            touchHelper = helper
+            started = true
+            listener.onBooxInkStatus("BOOX TouchHelper active: native render + portable capture")
+            true
+        } catch (t: Throwable) {
+            listener.onBooxInkStatus("BOOX TouchHelper failed: ${t.javaClass.simpleName}: ${t.message}")
+            false
+        }
+    }
+
+    /** Enable/disable BOOX firmware drawing without destroying the adapter. */
+    fun setWritable(enabled: Boolean) {
+        runCatching { touchHelper?.setRawDrawingEnabled(enabled) }
+            .onFailure { listener.onBooxInkStatus("BOOX ink toggle failed: ${it.message}") }
+    }
+
+    /** Release the firmware/native drawing path. */
+    fun teardown() {
+        if (!started) return
+        runCatching { touchHelper?.setRawDrawingEnabled(false) }
+        runCatching { touchHelper?.closeRawDrawing() }
+            .onFailure { listener.onBooxInkStatus("BOOX ink close failed: ${it.message}") }
+        touchHelper = null
+        started = false
+    }
+
+    private fun toSample(point: TouchPoint): Sample {
+        val rawPressure = point.pressure
+        val maxPressure = runCatching { EpdController.getMaxTouchPressure().toFloat() }
+            .getOrDefault(DEFAULT_MAX_PRESSURE)
+            .coerceAtLeast(1f)
+        val pressure = if (rawPressure > 1f) rawPressure / maxPressure else rawPressure
+        return Sample(
+            x = point.x,
+            y = point.y,
+            pressure = pressure.coerceIn(0f, 1f),
+        )
+    }
+
+    companion object {
+        private const val STROKE_WIDTH_PX = 3f
+        private const val ERASER_WIDTH = 5
+        private const val DEFAULT_MAX_PRESSURE = 4095f
+
+        /** BOOX firmware commonly reports Onyx/BOOX across manufacturer/brand fields. */
+        fun isBooxDevice(): Boolean {
+            val identity = "${Build.MANUFACTURER} ${Build.BRAND} ${Build.DEVICE}".lowercase()
+            return "onyx" in identity || "boox" in identity
+        }
+    }
+}

--- a/docs/INKBRIDGE-BOOX.md
+++ b/docs/INKBRIDGE-BOOX.md
@@ -1,0 +1,5 @@
+# InkBridge BOOX integration
+
+This fork extends Inkread with a BOOX/Onyx low-latency pen path while preserving the existing vendor-neutral Rust ink core.
+
+The current integration branch first validates Onyx SDK compilation and APK packaging inside Inkread's canonical build pipeline. Reader input routing remains on the existing Supernote path until that build gate is green.

--- a/docs/NATIVE-BRIDGE-POC.md
+++ b/docs/NATIVE-BRIDGE-POC.md
@@ -1,0 +1,67 @@
+# InkBridge native bridge proof
+
+## Goal
+
+Keep each vendor's native reading/annotation environment and make the two systems exchange editable ink rather than replacing NeoReader or Supernote DOC with a common reader.
+
+## BOOX proof result (Note Air 4C, 2026-07-24)
+
+A test PDF containing four externally-created standard PDF `/Ink` annotations was opened in NeoReader, edited, and saved with **Embed Data to PDF**.
+
+Inspection of the returned PDF shows:
+
+- Externally-created standard `/Ink` annotations are editable in NeoReader.
+- NeoReader preserves their `/NM` annotation IDs and adds `/onyxtag` metadata with a BOOX UUID and `type: PencilStroke`.
+- NeoReader can transform those imported `/Ink` annotations (for example scaling/translating them) while leaving them as standard `/Ink` objects.
+- Deleting an imported stroke removes it from the page's active annotation list.
+- Native NeoReader handwriting embedded into the PDF is stored as `/Subtype /Stamp`, `/Name /#ONYX-STROKE`, with `/onyxtag` `type: BrushStroke` and a stable UUID.
+- Native BOOX strokes also carry an `/onyxpoints` stream. The observed stream is structured binary rather than a raster-only appearance: an 8-byte header followed by fixed five-float records. X/Y and elapsed-time fields are directly visible; pressure-like sample values are also present. The remaining per-sample field must be mapped before relying on it.
+
+This is sufficient evidence that BOOX-to-bridge extraction can be implemented without replacing NeoReader.
+
+## Supernote official API capability
+
+Ratta's official plugin API exposes native NOTE/DOC elements, including handwritten strokes with:
+
+- UUID
+- page/layer
+- thickness
+- pen type/color
+- EMR points
+- pressure samples
+
+The API supports reading, inserting, modifying, replacing, and deleting elements, plus reloading the currently-open file.
+
+Relevant official documentation:
+
+- https://github.com/Supernote-Ratta/docs-plugin
+- `PluginFileAPI.getElements`
+- `PluginFileAPI.insertElements`
+- `PluginFileAPI.modifyElements`
+- `PluginCommAPI.reloadFile`
+
+## Next proof
+
+Build the smallest possible official Supernote plugin that runs inside NOTE/DOC and proves that plugin-created stroke data becomes an ordinary native editable Supernote stroke.
+
+Acceptance test:
+
+1. Open a PDF/DOC containing at least one handwritten native Supernote stroke.
+2. Tap an `InkBridge Test` toolbar button.
+3. Plugin reads current file path/page and enumerates page elements.
+4. Plugin takes one existing stroke, duplicates its geometry with a small X/Y offset, assigns a new element identity as required by the API, and inserts it via `PluginFileAPI.insertElements`.
+5. Plugin calls `PluginCommAPI.reloadFile`.
+6. The duplicated stroke must be selectable with native lasso, movable, erasable, and otherwise behave like ordinary Supernote ink.
+
+If this passes, both device-native environments have a viable editable-ink bridge.
+
+## Architecture after both proofs
+
+InkBridge should become a lightweight translation/synchronization layer:
+
+- BOOX side: NeoReader remains the reader. A companion bridge watches/merges PDF annotations and understands standard `/Ink` plus BOOX `/onyxtag` + `/onyxpoints` strokes.
+- Supernote side: official plugin remains inside native NOTE/DOC and translates native `Element/Stroke` data.
+- Portable identity/journal: small InkBridge sidecar for stable cross-device IDs, tombstones, origin metadata, and conflict resolution.
+- PDF remains the document carrier/interoperability surface, but not the sole multiwriter conflict database.
+
+The existing Inkread-based BOOX reader work remains a useful fallback and SDK reference, but PR #2 should stay draft while the native-bridge proof is evaluated.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,15 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // BOOX/Onyx publishes its Android pen/device SDKs from these repositories.
+        maven {
+            url = uri("http://repo.boox.com/repository/proxy-public/")
+            isAllowInsecureProtocol = true
+        }
+        maven {
+            url = uri("http://repo.boox.com/repository/maven-public/")
+            isAllowInsecureProtocol = true
+        }
     }
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing to inkread! Keep PRs focused on one logical change.
  Fill in the sections below — delete any that genuinely don't apply.
-->

## What & why

<!-- What does this change do, and why? Link the issue it closes. -->

Closes #

## Requirements / design refs

<!-- Spec/ADR/requirement IDs this implements or touches, e.g. RR5-FR1, ADR-INKREAD-0010.
     External contributor without spec access? Write "n/a" and describe the behaviour instead. -->

-

## How it was tested

<!-- Commands you ran, fixtures you added, device(s) you verified on (host-only is fine). -->

- [ ] `cargo test --workspace` is green
- [ ] Added/updated a test that fails without this change (for bugs/new behaviour)
- [ ] Verified on a device (Supernote) — _or_ host-only change, N/A
      (release PRs: run [`docs/RELEASE-SMOKE-CHECKLIST.md`](../docs/RELEASE-SMOKE-CHECKLIST.md))

## Pre-merge checklist

<!-- All must be true. CI enforces them; tick to confirm you ran them locally. -->

- [ ] `cargo fmt --all` — no format diff
- [ ] `cargo clippy --all -- -D warnings` — no warnings
- [ ] `cargo test --workspace` — passes
- [ ] `cargo llvm-cov --workspace` — coverage holds the RR17 gate
- [ ] `./scripts/check-licenses.sh` — no new/unvetted dependency licenses
- [ ] The Rust core still builds **host-only** — no Android types leaked into `reader-core`,
      and `jni` is absent from its default dependency graph (RR1-AC3 / IR-7)
- [ ] The core names **no vendor** — device/EPD/pen specifics stay in `app/` + the JNI bridge (IR-7)
- [ ] Commits follow Conventional Commits (`type(scope): subject`) with **no AI/Co-Authored-By
      attribution**
- [ ] No secrets, signing keys, `.env`, or private research material (decompiled APK/`.so`/jadx)

## Notes for the reviewer

<!-- Anything to look at first, known trade-offs, follow-ups intentionally left out of scope. -->
