### PR TITLE
fix(open): surface CBZ and plain-text in the picker, shelf, and import (#125)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -12,7 +12,7 @@ import java.io.InputStream
 import java.io.OutputStream
 
 /**
- * A minimal on-device book library (RR17) for the shell: imported PDFs live under
+ * A minimal on-device book library (RR17) for the shell: imported documents live under
  * `filesDir/books/` (kept, not overwritten) so [HomeActivity] and the reader's Library popup can
  * list and reopen them. The Rust core owns reading state per book id; here a book's **file name**
  * is its stable id.
@@ -21,10 +21,25 @@ object Books {
     /** The books directory (created on demand). */
     fun dir(context: Context): File = File(context.filesDir, "books").apply { mkdirs() }
 
-    /** Supported document extensions (the core dispatches a backend by extension). */
-    private val SUPPORTED = setOf("pdf", "epub")
+    /** Supported document extensions — every format the core can open (PDF, EPUB, CBZ, plain text).
+     *  The core dispatches a backend by content first, then extension, so this is the shelf/import
+     *  allow-list, kept in sync with `DocFormat` in `reader-core/src/document/format.rs`. */
+    private val SUPPORTED = setOf("pdf", "epub", "cbz", "txt", "text")
 
-    /** Every imported document (PDF or EPUB), sorted by name (case-insensitive). */
+    /**
+     * The extension to store a picked document under: preserve the source extension when the core
+     * supports it (so CBZ and plain text open with the right backend — plain text has no magic
+     * bytes, so its extension is the *only* signal), else default to `pdf`. The core still
+     * content-sniffs on open, so a mislabeled or unknown file (e.g. a disguised PDF/ZIP) still
+     * resolves by its bytes; only a signature-less plain-text file whose display name carries no
+     * extension is unrecoverable — it stores as `pdf` and won't open as text. Pure + host-testable.
+     */
+    internal fun importExtension(displayName: String): String {
+        val ext = displayName.substringAfterLast('.', "").lowercase()
+        return if (ext in SUPPORTED) ext else "pdf"
+    }
+
+    /** Every imported document (PDF, EPUB, CBZ, or plain text), sorted by name (case-insensitive). */
     fun list(context: Context): List<File> =
         dir(context)
             .listFiles { f -> f.isFile && f.extension.lowercase() in SUPPORTED }
@@ -33,13 +48,13 @@ object Books {
 
     /**
      * Copy a SAF-picked document into the books dir under a sanitized name derived from its display
-     * name, **preserving the extension** (`.epub` → reflowable, else `.pdf`) so the core opens the
+     * name, **preserving a core-supported extension** (see [importExtension]) so the core opens the
      * right backend. Returns the stored file (or null on failure). A re-import of the same display
      * name overwrites — the name is the book's identity. Runs IO; call off the UI thread.
      */
     fun importFrom(context: Context, uri: Uri): File? {
         val raw = queryName(context, uri) ?: "document"
-        val ext = if (raw.substringAfterLast('.', "").equals("epub", ignoreCase = true)) "epub" else "pdf"
+        val ext = importExtension(raw)
         val dest = File(dir(context), "${sanitize(raw)}.$ext")
         return try {
             val ok = context.contentResolver.openInputStream(uri)?.use { input ->

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -619,16 +619,24 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
     }
 
-    /** Launch the system file picker for a PDF (RR22). */
+    /** Launch the system file picker for a document (RR22). */
     private fun openPicker() {
-        // PDF (fixed-layout) + EPUB (reflowable). The core dispatches by file extension; some
-        // pickers tag .epub as octet-stream, so accept that too and let the core validate.
+        // Every format the core opens: PDF (fixed-layout), EPUB (reflowable), CBZ (comics), and
+        // plain text. The core content-sniffs first, then falls back to the extension; some pickers
+        // tag these as octet-stream, so accept that too and let the core validate.
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
             type = "*/*"
             putExtra(
                 Intent.EXTRA_MIME_TYPES,
-                arrayOf("application/pdf", "application/epub+zip", "application/octet-stream"),
+                arrayOf(
+                    "application/pdf",
+                    "application/epub+zip",
+                    "application/vnd.comicbook+zip",
+                    "application/x-cbz",
+                    "text/plain",
+                    "application/octet-stream",
+                ),
             )
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }

--- a/app/src/test/java/dev/jraghavan/inkread/BooksImportTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/BooksImportTest.kt
@@ -1,0 +1,46 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Host JVM tests for [Books.importExtension] (issue #125). The core opens PDF, EPUB, CBZ, and plain
+ * text ([`reader-core` `DocFormat`]); the shell must store a picked file under a core-supported
+ * extension so it opens with the right backend — plain text has no magic bytes, so its extension is
+ * the only signal, and the pre-#125 code that forced everything to `.pdf`/`.epub` broke it.
+ */
+class BooksImportTest {
+
+    @Test
+    fun preservesEveryCoreSupportedExtension() {
+        assertEquals("pdf", Books.importExtension("paper.pdf"))
+        assertEquals("epub", Books.importExtension("novel.epub"))
+        assertEquals("cbz", Books.importExtension("comic.cbz"))
+        assertEquals("txt", Books.importExtension("notes.txt"))
+        assertEquals("text", Books.importExtension("notes.text"))
+    }
+
+    @Test
+    fun isCaseInsensitive() {
+        assertEquals("cbz", Books.importExtension("COMIC.CBZ"))
+        assertEquals("txt", Books.importExtension("Notes.Txt"))
+    }
+
+    @Test
+    fun unknownOrMissingExtensionDefaultsToPdf() {
+        // The core still content-sniffs on open, so a disguised PDF/ZIP resolves by its bytes; only a
+        // truly unknown container (e.g. a proprietary .mark) falls back to the pdf backend.
+        assertEquals("pdf", Books.importExtension("annotated.mark"))
+        assertEquals("pdf", Books.importExtension("noextension"))
+        assertEquals("pdf", Books.importExtension("archive.zip"))
+        assertEquals("pdf", Books.importExtension("")) // empty display name
+        assertEquals("pdf", Books.importExtension("file.")) // trailing dot → empty suffix
+    }
+
+    @Test
+    fun usesTheLastDotSegment() {
+        assertEquals("epub", Books.importExtension("My.Book.v2.epub"))
+        // A dotfile whose whole name is a supported suffix still resolves by that suffix.
+        assertEquals("txt", Books.importExtension(".txt"))
+    }
+}


### PR DESCRIPTION
Fixes the reader-half of #125.

## Problem

The Rust core opens **PDF, EPUB, CBZ, and plain text** (`DocFormat` in `reader-core/src/document/format.rs`, dispatched to real backends in `reader-core/src/jni.rs:147-151`), but the Android shell only surfaced PDF/EPUB:

- The Home shelf filter `Books.SUPPORTED = {pdf, epub}` hid CBZ and `.txt` files.
- The file picker advertised only `application/pdf`, `application/epub+zip`, `application/octet-stream`.
- `Books.importFrom` forced every non-EPUB import to a `.pdf` name. For plain text — which has no magic bytes, so its extension is the *only* signal the core can use — this stored it as `.pdf` and made it open with the PDF backend and fail.

## Change

- `Books.SUPPORTED`: add `cbz`, `txt`, `text`, kept in sync with `DocFormat::from_extension`.
- New pure `Books.importExtension(displayName)`: preserve a core-supported source extension, else default to `pdf`. The core still content-sniffs first, so a mislabeled/disguised PDF or ZIP still resolves by its bytes.
- Picker `EXTRA_MIME_TYPES`: add `application/vnd.comicbook+zip`, `application/x-cbz`, `text/plain` (octet-stream fallback retained).
- Add host-JVM `BooksImportTest` covering the extension contract (every supported extension, case-insensitivity, unknown/empty/trailing-dot/dotfile edges, disguised-container fallback).

README already documents PDF/EPUB/CBZ/plain-text with content detection (README:60-61, 165); this brings the shell up to that claim, so no README change is needed.

## Tests

`./gradlew :app:testDebugUnitTest` — green. `reader-core` is untouched (no Rust change; the core's format detection/dispatch already had test coverage).

## Scope / follow-ups

- **This does not fully close #125.** The `.mark` verdict is still open pending a real sample from the reporter: a content-sniffable `.mark` (disguised PDF/ZIP) already opens via the octet-stream picker entry + byte-sniff, but a proprietary annotation container would need dedicated support. Keep #125 open (or split a `.mark` follow-up).
- **Adjacent, pre-existing:** annotation export (`ExportController`) is PDF-only. CBZ/TXT now join EPUB (already importable pre-#125) in that bucket; if export doesn't gracefully no-op on non-PDF, that's a separate gap to track.