### PR TITLE
ci(coverage): add Kover Kotlin coverage with a Codecov kotlin flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+          flags: rust # keep the Rust and Kotlin coverage numbers as separate Codecov flags
           fail_ci_if_error: false # don't fail the build on a flaky upload
         env:
           # Optional for public repos (tokenless works but is rate-limited); add a
@@ -196,3 +197,30 @@ jobs:
           cache: gradle
       - name: Run app JVM unit tests (:app:testDebugUnitTest)
         run: ./gradlew :app:testDebugUnitTest --console=plain
+
+  kotlin-coverage:
+    name: kotlin coverage (Kover → Codecov)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+      # Kover measures host-test coverage of the Kotlin shell. This is a UI-heavy Activity module,
+      # so whole-module coverage is low by nature (RR17's real gate is the Rust core); the tracked
+      # signal here is PATCH coverage via Codecov's `kotlin` flag — see codecov.yml. No emulator/NDK.
+      - name: Generate Kover XML (:app:koverXmlReport)
+        run: ./gradlew :app:koverXmlReport --console=plain
+      - name: Upload to Codecov (kotlin flag)
+        uses: codecov/codecov-action@v7
+        with:
+          files: app/build/reports/kover/report.xml
+          flags: kotlin
+          fail_ci_if_error: false # don't fail the build on a flaky upload
+        env:
+          # Same optional secret as the Rust upload: tokenless works for public repos but is
+          # rate-limited; set a CODECOV_TOKEN repo secret to make the kotlin-flag upload reliable.
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 android {
@@ -89,4 +90,21 @@ dependencies {
     // Host JVM unit tests for pure logic (e.g. PalmFilter) — run via :app:testDebugUnitTest, no
     // emulator/device needed (an emulator can't simulate the Supernote EMR pen anyway).
     testImplementation("junit:junit:4.13.2")
+}
+
+// Kotlin host-test coverage (Kover). This module is a single-Activity `Context`/UI shell that is
+// overwhelmingly not host-unit-testable, so the *whole-module* line coverage is near zero by
+// nature — a global threshold here would be theatre. The real signal is **patch coverage** (is the
+// host-testable logic in a change actually tested?), surfaced in CI via Codecov's `kotlin` flag
+// (patch status, currently informational — see codecov.yml). This block just produces the reports;
+// generated classes are excluded so the number reflects our code.
+kover {
+    reports {
+        filters {
+            excludes {
+                // Android generated classes (Kover does not exclude these by default).
+                classes("*.BuildConfig", "*.R", "*.R\$*")
+            }
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,13 @@
 // Root build file (RR1-FR2). Plugin versions are declared but not applied here.
-// AGP is pinned to 8.5.2 (with Gradle 8.9): AGP 9.x registers its own `kotlin` extension and
+// AGP is pinned to 8.5.2 (with Gradle 9.6.1): AGP 9.x registers its own `kotlin` extension and
 // conflicts with the standalone org.jetbrains.kotlin.android plugin ("Cannot add extension with
 // name 'kotlin'"), so the AGP-9 / Gradle-9 Dependabot bump broke the release build. The AGP-9
 // upgrade is a deliberate migration, not an auto-bump (Dependabot is told to ignore those majors).
 plugins {
     id("com.android.application") version "8.5.2" apply false
     id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+    // Kotlin unit-test coverage (JVM host tests). RR17's coverage gate is Rust-only
+    // (cargo-llvm-cov); this adds the equivalent measurement + Codecov patch tracking for the
+    // Kotlin shell's host-testable logic. Applied only in :app.
+    id("org.jetbrains.kotlinx.kover") version "0.9.9" apply false
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,46 @@
+# Coverage config for inkread's two languages, tracked as separate Codecov flags:
+#   - rust:   the whole Rust workspace (cargo-llvm-cov --workspace -> lcov.info) — the RR17 gate.
+#   - kotlin: the :app Android shell host tests (Kover -> report.xml).
+#
+# The Kotlin shell is a single-Activity, Context/UI-heavy module whose whole-module coverage is
+# near zero by nature, so its project status is informational (reported, never blocks). Rust keeps
+# its existing anti-regression behaviour on the `rust` flag. The Kotlin patch status shows how much
+# of the host-testable logic in a change is covered; it is informational for now (flip
+# `informational: false` to make new Kotlin logic coverage a hard gate).
+coverage:
+  status:
+    project:
+      default:
+        informational: true # combined number — reported, never blocks
+      rust:
+        flags:
+          - rust
+        target: auto # preserve the RR17 anti-regression behaviour on the Rust core
+      kotlin:
+        flags:
+          - kotlin
+        informational: true
+    patch:
+      default:
+        informational: true
+      rust:
+        flags:
+          - rust
+        target: auto
+      kotlin:
+        flags:
+          - kotlin
+        target: 80%
+        informational: true # visible patch signal; not yet a hard gate (UI churn is untestable)
+
+flag_management:
+  # No per-flag `paths`: the two uploads are disjoint by construction (rust = the whole-workspace
+  # lcov, kotlin = the :app Kover xml), and each is tagged with its flag at upload time in ci.yml.
+  # A `paths` filter here would wrongly drop coverage for files outside it — e.g. scoping `rust` to
+  # reader-core/ would shrink the RR17 gate from 10 crates to one.
+  default_rules:
+    carryforward: true
+
+comment:
+  layout: "reach, flags, files"
+  require_changes: false


### PR DESCRIPTION
Adds Kotlin host-test coverage measurement, the counterpart to RR17's Rust-only `cargo-llvm-cov` gate.

## What

- **Kover 0.9.9** applied to `:app` (declared `apply false` at root, applied in the module — same pattern as AGP/Kotlin). Produces XML + HTML reports; Android generated classes (`BuildConfig`, `R`) are excluded so the number reflects hand-written code.
- **New CI job** `kotlin coverage (Kover → Codecov)` runs `:app:koverXmlReport` and uploads under a Codecov **`kotlin`** flag. The existing `cargo llvm-cov --workspace` upload is tagged **`rust`** so the two languages track as separate flags.
- **`codecov.yml`** (new): Rust keeps a blocking anti-regression status on the `rust` flag over the **whole workspace**; the combined and Kotlin statuses are informational.

## Why patch coverage, not a global threshold

The `:app` module is a single-Activity, `Context`/UI-heavy shell — measured whole-module line coverage is **~0.6%** because the overwhelming majority is not host-unit-testable (no emulator can drive the Supernote EMR pen/EPD). A global threshold there would be theatre. The meaningful, tracked signal is **patch coverage**: does the host-testable logic in a change get a test? That's surfaced via the `kotlin` flag on each PR.

A hard Kotlin gate is intentionally **not** enabled yet: at a 0.6% baseline a project-coverage ratchet is either too loose to catch a real backslide or strict enough to block legitimate untestable-UI PRs. The patch status carries a visible `target: 80%` but is `informational` for now — flip `informational: false` in `codecov.yml` to make new-Kotlin-logic coverage a hard gate once a host-testable logic subpackage is delineated.

## Verification

- `./gradlew :app:koverXmlReport` — green; report at `app/build/reports/kover/report.xml` (0.6% line, as expected).
- Local HTML report for inspection: `./gradlew :app:koverHtmlReport` → `app/build/reports/kover/html/index.html`.
- `codecov.yml` validated against `codecov.io/validate` → **Valid!**
- No product-code or release/APK impact — Kover instruments test tasks only; `:spike` and `assembleRelease` untouched.

## Notes

- Coverage uploads use the same optional `CODECOV_TOKEN` secret as the Rust job (tokenless works for public repos but is rate-limited); `fail_ci_if_error: false` on both, so a flaky upload can't break CI.
- On the first `kotlin`-flag upload, confirm Codecov shows files for the flag (path-fixing maps the Kover XML onto `app/src/main/java/...`).