### PR TITLE
feat(ui): user Menu Size setting to scale reader chrome on large panels (#133)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -128,7 +128,7 @@ class AdjustSheetController(private val host: Host) {
                     LinearLayout.LayoutParams(dp(24), dp(24)),
                 )
                 addView(TextView(activity).apply {
-                    text = label; textSize = 10f; setTextColor(Ink.inkSoft); typeface = Ink.mono
+                    text = label; textSize = Ink.sp(10f); setTextColor(Ink.inkSoft); typeface = Ink.mono
                     gravity = Gravity.CENTER; setPadding(0, dp(3), 0, 0)
                 })
             }
@@ -193,7 +193,7 @@ class AdjustSheetController(private val host: Host) {
             val p = dp(3); setPadding(p, p, p, p)
             options.forEachIndexed { i, opt ->
                 val tv = TextView(activity).apply {
-                    text = opt; textSize = 15f; gravity = Gravity.CENTER
+                    text = opt; textSize = Ink.sp(15f); gravity = Gravity.CENTER
                     setPadding(dp(6), dp(10), dp(6), dp(10)); isClickable = true
                     setOnClickListener { sel = i; segs.forEachIndexed { j, t -> style(t, j == sel) }; onSelect(i) }
                 }
@@ -240,7 +240,7 @@ class AdjustSheetController(private val host: Host) {
             orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
             setPadding(dp(16), dp(14), dp(16), dp(14))
             addView(TextView(activity).apply {
-                text = label; textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.END
+                text = label; textSize = Ink.sp(16f); setTextColor(Color.BLACK); gravity = Gravity.END
             }, LinearLayout.LayoutParams(dp(96), ViewGroup.LayoutParams.WRAP_CONTENT))
             addView(control, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
                 marginStart = dp(14)
@@ -345,7 +345,7 @@ class AdjustSheetController(private val host: Host) {
         val d = activity.resources.displayMetrics.density
         fun dp(v: Int) = (v * d).toInt()
         return TextView(activity).apply {
-            text = t; textSize = 16f; gravity = Gravity.CENTER; setTextColor(Color.BLACK)
+            text = t; textSize = Ink.sp(16f); gravity = Gravity.CENTER; setTextColor(Color.BLACK)
             setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
             background = GradientDrawable().apply {
                 setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
@@ -359,7 +359,7 @@ class AdjustSheetController(private val host: Host) {
         val d = activity.resources.displayMetrics.density
         fun dp(v: Int) = (v * d).toInt()
         val zlabel = TextView(activity).apply {
-            textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
+            textSize = Ink.sp(16f); setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
         }
         fun refresh() { zlabel.text = "${host.zoomPercent}%" }
         refresh()
@@ -452,7 +452,7 @@ class AdjustSheetController(private val host: Host) {
         fun dp(v: Int) = (v * d).toInt()
         var idx = DisplayPrefs.nearestScaleIndex(prefs.textScale)
         val value = TextView(activity).apply {
-            textSize = 16f; setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
+            textSize = Ink.sp(16f); setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
         }
         fun refresh() { value.text = "${(DisplayPrefs.TEXT_SCALES[idx] * 100).toInt()}%" }
         refresh()

--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -396,7 +396,20 @@ class AdjustSheetController(private val host: Host) {
                 host.repaintPanel()
             }
         }))
+        container.addView(settingRow("Menu Size", segmented(DisplayPrefs.UI_SCALE_LABELS, DisplayPrefs.nearestUiScaleIndex(prefs.uiScale)) { which ->
+            applyUiScale(DisplayPrefs.UI_SCALES[which])
+        }))
         return container
+    }
+
+    /** Persist + apply the menu/chrome scale (#133) for large panels (e.g. the Manta). The reader's
+     *  menus read [Ink.uiScale] as they build, so the new size lands as each menu/sheet is next
+     *  opened; this open sheet keeps its current size, so a toast confirms the change. */
+    private fun applyUiScale(scale: Float) {
+        prefs.uiScale = scale
+        Ink.uiScale = scale
+        val label = DisplayPrefs.UI_SCALE_LABELS[DisplayPrefs.nearestUiScaleIndex(scale)]
+        Toast.makeText(activity, "Menu size $label — reopen a menu to see it", Toast.LENGTH_SHORT).show()
     }
 
     /** A reading style preset (1.10): a bundle of (text scale, line-spacing index, contrast step,

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -211,12 +211,14 @@ class BottomBarController(private val host: Host) {
                 ImageView(activity).apply {
                     setImageResource(iconRes); setColorFilter(Ink.ink)
                 },
-                LinearLayout.LayoutParams(dp(39), dp(39)),
+                // Scale the icon box with the label (#133) so a raised menu size grows the whole
+                // control coherently, not just its text. The cell is WRAP_CONTENT, so this can't clip.
+                LinearLayout.LayoutParams(Ink.sdp(39), Ink.sdp(39)),
             )
             cell.addView(TextView(activity).apply {
                 text = label; setTextColor(Ink.inkSoft); textSize = Ink.sp(11f)
                 typeface = Ink.mono; letterSpacing = 0.02f
-                gravity = Gravity.CENTER; setPadding(0, dp(5), 0, 0)
+                gravity = Gravity.CENTER; setPadding(0, Ink.sdp(5), 0, 0)
             })
             controls.addView(cell, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
         }

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -116,7 +116,7 @@ class BottomBarController(private val host: Host) {
         val pageLabel = TextView(activity).apply {
             text = "${cur + 1} / $total"
             setTextColor(Ink.ink)
-            textSize = 12f
+            textSize = Ink.sp(12f)
             typeface = Ink.mono
             letterSpacing = 0.04f
             gravity = Gravity.CENTER
@@ -155,7 +155,7 @@ class BottomBarController(private val host: Host) {
         // Double-chevron chapter jumps flank the scrubber (distinct from single-page edge taps),
         // shown only when the document has a table of contents (1.7).
         fun chapterBtn(glyph: String, dir: Int) = TextView(activity).apply {
-            text = glyph; setTextColor(Ink.ink); textSize = 20f; typeface = Ink.serifBold
+            text = glyph; setTextColor(Ink.ink); textSize = Ink.sp(20f); typeface = Ink.serifBold
             gravity = Gravity.CENTER; setPadding(dp(8), dp(2), dp(8), dp(2)); isClickable = true
             setOnClickListener { dialog.dismiss(); chapterJump(dir) }
         }
@@ -181,12 +181,12 @@ class BottomBarController(private val host: Host) {
                 isClickable = true
                 setOnClickListener { dialog.dismiss(); showContentsLazy() }
                 addView(TextView(activity).apply {
-                    text = lbl; setTextColor(Ink.inkSoft); textSize = 12f; typeface = Ink.serif
+                    text = lbl; setTextColor(Ink.inkSoft); textSize = Ink.sp(12f); typeface = Ink.serif
                     maxLines = 1; ellipsize = android.text.TextUtils.TruncateAt.END
                 }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
                 inChapterPosition()?.let { pos ->
                     addView(TextView(activity).apply {
-                        text = pos; setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
+                        text = pos; setTextColor(Ink.muted); textSize = Ink.sp(12f); typeface = Ink.mono
                         setPadding(dp(10), 0, 0, 0)
                     })
                 }
@@ -214,7 +214,7 @@ class BottomBarController(private val host: Host) {
                 LinearLayout.LayoutParams(dp(39), dp(39)),
             )
             cell.addView(TextView(activity).apply {
-                text = label; setTextColor(Ink.inkSoft); textSize = 11f
+                text = label; setTextColor(Ink.inkSoft); textSize = Ink.sp(11f)
                 typeface = Ink.mono; letterSpacing = 0.02f
                 gravity = Gravity.CENTER; setPadding(0, dp(5), 0, 0)
             })
@@ -416,11 +416,11 @@ class BottomBarController(private val host: Host) {
                 setOnClickListener { dialog.dismiss(); host.postJump(page) }
                 addView(TextView(activity).apply {
                     text = "Page ${page + 1}"
-                    setTextColor(Ink.ink); textSize = 17f; typeface = Ink.serifBold
+                    setTextColor(Ink.ink); textSize = Ink.sp(17f); typeface = Ink.serifBold
                 }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
                 addView(TextView(activity).apply {
                     text = if (count == 1) "1 note" else "$count notes"
-                    setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
+                    setTextColor(Ink.muted); textSize = Ink.sp(12f); typeface = Ink.mono
                 })
             })
         }
@@ -462,13 +462,13 @@ class BottomBarController(private val host: Host) {
                 addView(TextView(activity).apply {
                     text = item.title
                     setTextColor(if (item.targetPage != null) Ink.ink else Ink.muted)
-                    textSize = if (item.depth == 0) 17f else 15f
+                    textSize = Ink.sp(if (item.depth == 0) 17f else 15f)
                     typeface = if (item.depth == 0) Ink.serifBold else Ink.serif
                     maxLines = 2
                 }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
                 item.targetPage?.let { p ->
                     addView(TextView(activity).apply {
-                        text = "${p + 1}"; setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono
+                        text = "${p + 1}"; setTextColor(Ink.muted); textSize = Ink.sp(12f); typeface = Ink.mono
                         setPadding(dp(12), 0, 0, 0)
                     })
                 }

--- a/app/src/main/java/dev/jraghavan/inkread/ColorPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ColorPalette.kt
@@ -123,7 +123,7 @@ class ColorPalette(
         }
         val label = TextView(activity).apply {
             text = name
-            textSize = 11f
+            textSize = Ink.sp(11f)
             typeface = Ink.mono
             letterSpacing = 0.04f
             gravity = Gravity.CENTER

--- a/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
@@ -61,6 +61,9 @@ class DailyActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Keep shared Ink chrome (e.g. the compile progress dialog) in step with the menu-size
+        // preference (#133); Daily's own body text uses its independent width scaler.
+        Ink.uiScale = DisplayPrefs(this).uiScale
         daily.ensureSeeded() // curated feeds ready on first run — no manual set-up
         setContentView(buildView())
     }

--- a/app/src/main/java/dev/jraghavan/inkread/DictController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DictController.kt
@@ -246,19 +246,19 @@ class DictController(private val host: Host) {
         // ── header: headword + looked-up chip · WordNet source ───────────────────
         val header = LinearLayout(activity).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL }
         header.addView(TextView(activity).apply {
-            text = headword; setTextColor(Ink.ink); textSize = 27f; typeface = serifBold
+            text = headword; setTextColor(Ink.ink); textSize = Ink.sp(27f); typeface = serifBold
             includeFontPadding = false
         })
         if (!word.equals(headword, ignoreCase = true) && word.isNotEmpty()) {
             header.addView(TextView(activity).apply {
-                text = "⟨ $word ⟩"; setTextColor(grey); textSize = 14f; typeface = serif
+                text = "⟨ $word ⟩"; setTextColor(grey); textSize = Ink.sp(14f); typeface = serif
                 setPadding(dp(10), dp(8), 0, 0)
             })
         }
         header.addView(View(activity), LinearLayout.LayoutParams(0, 0, 1f)) // spacer
         header.addView(TextView(activity).apply {
             text = if (def.lang.isNotEmpty() && def.lang != "en") "WORDNET · ${def.lang.uppercase()}" else "WORDNET"
-            setTextColor(faint); textSize = 11f; letterSpacing = 0.12f; typeface = Ink.mono
+            setTextColor(faint); textSize = Ink.sp(11f); letterSpacing = 0.12f; typeface = Ink.mono
         })
         root.addView(header)
 
@@ -289,7 +289,7 @@ class DictController(private val host: Host) {
                 body.addView(senseRow(sense.index, sense.definition, dp(2)))
                 for (ex in sense.examples) {
                     body.addView(TextView(activity).apply {
-                        text = "“$ex”"; setTextColor(grey); textSize = 15f
+                        text = "“$ex”"; setTextColor(grey); textSize = Ink.sp(15f)
                         typeface = Ink.serifItalic
                         setPadding(dp(22), dp(4), 0, 0)
                     })
@@ -297,7 +297,7 @@ class DictController(private val host: Host) {
                 if (sense.synonyms.isNotEmpty()) {
                     body.addView(TextView(activity).apply {
                         text = "≈ ${sense.synonyms.joinToString(", ")}"
-                        setTextColor(faint); textSize = 13f; setPadding(dp(22), dp(3), 0, 0)
+                        setTextColor(faint); textSize = Ink.sp(13f); setPadding(dp(22), dp(3), 0, 0)
                     })
                 }
             }
@@ -307,25 +307,25 @@ class DictController(private val host: Host) {
             if (thesaurus.isEmpty()) {
                 body.addView(TextView(activity).apply {
                     text = "No thesaurus entries for this word."
-                    setTextColor(grey); textSize = 15f; setPadding(0, dp(4), 0, 0)
+                    setTextColor(grey); textSize = Ink.sp(15f); setPadding(0, dp(4), 0, 0)
                 })
                 return
             }
             body.addView(posBadge("synonyms"))
             body.addView(TextView(activity).apply {
                 text = thesaurus.joinToString(" · ")
-                setTextColor(Ink.ink); textSize = 16f; typeface = Ink.serif; setLineSpacing(dp(4).toFloat(), 1f)
+                setTextColor(Ink.ink); textSize = Ink.sp(16f); typeface = Ink.serif; setLineSpacing(dp(4).toFloat(), 1f)
                 setPadding(0, dp(6), 0, 0)
             })
         }
         val tabs = LinearLayout(activity).apply { orientation = LinearLayout.HORIZONTAL; setPadding(0, dp(10), 0, 0) }
         tabDef = TextView(activity).apply {
-            text = "DEFINITION"; textSize = 12f; letterSpacing = 0.1f
+            text = "DEFINITION"; textSize = Ink.sp(12f); letterSpacing = 0.1f
             setPadding(0, dp(4), dp(24), dp(4)); isClickable = true
             setOnClickListener { styleTab(tabDef, true); styleTab(tabThe, false); renderDefinition() }
         }
         tabThe = TextView(activity).apply {
-            text = "THESAURUS"; textSize = 12f; letterSpacing = 0.1f
+            text = "THESAURUS"; textSize = Ink.sp(12f); letterSpacing = 0.1f
             setPadding(0, dp(4), 0, dp(4)); isClickable = true
             setOnClickListener { styleTab(tabThe, true); styleTab(tabDef, false); renderThesaurus() }
         }
@@ -361,7 +361,7 @@ class DictController(private val host: Host) {
         val d = activity.resources.displayMetrics.density
         fun dp(v: Int) = (v * d).toInt()
         return TextView(activity).apply {
-            text = label.uppercase(); setTextColor(Ink.inkSoft); textSize = 10f; typeface = Ink.mono
+            text = label.uppercase(); setTextColor(Ink.inkSoft); textSize = Ink.sp(10f); typeface = Ink.mono
             letterSpacing = 0.12f
             setPadding(dp(10), dp(4), dp(10), dp(5))
             background = GradientDrawable().apply {
@@ -383,12 +383,12 @@ class DictController(private val host: Host) {
             orientation = LinearLayout.HORIZONTAL
             setPadding(0, maxOf(topPad, dp(7)), 0, 0)
             addView(TextView(activity).apply {
-                this.text = "$index"; setTextColor(Ink.muted); textSize = 13f
+                this.text = "$index"; setTextColor(Ink.muted); textSize = Ink.sp(13f)
                 typeface = Ink.mono
                 layoutParams = LinearLayout.LayoutParams(dp(22), ViewGroup.LayoutParams.WRAP_CONTENT)
             })
             addView(TextView(activity).apply {
-                this.text = text; setTextColor(Ink.ink); textSize = 16f; typeface = Ink.serif
+                this.text = text; setTextColor(Ink.ink); textSize = Ink.sp(16f); typeface = Ink.serif
                 setLineSpacing(dp(3).toFloat(), 1f)
                 layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
             })
@@ -434,7 +434,7 @@ class DictController(private val host: Host) {
             if (bundles.isEmpty()) {
                 list.addView(TextView(activity).apply {
                     text = "No dictionaries found.\n\nCopy a StarDict folder (its .ifo, .idx and .dict/.dict.dz files) into:\n${home.absolutePath}\n\nthen reopen this screen."
-                    setTextColor(Color.parseColor("#555555")); textSize = 14f; setLineSpacing(dp(3).toFloat(), 1f)
+                    setTextColor(Color.parseColor("#555555")); textSize = Ink.sp(14f); setLineSpacing(dp(3).toFloat(), 1f)
                 })
                 return
             }
@@ -447,16 +447,16 @@ class DictController(private val host: Host) {
                     orientation = LinearLayout.VERTICAL
                     layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
                     addView(TextView(activity).apply {
-                        text = b.name; setTextColor(Color.BLACK); textSize = 16f
+                        text = b.name; setTextColor(Color.BLACK); textSize = Ink.sp(16f)
                     })
                     addView(TextView(activity).apply {
                         text = if (b.installed) "Installed" else "Not installed"
-                        setTextColor(Color.parseColor("#9E9E9E")); textSize = 12f
+                        setTextColor(Color.parseColor("#9E9E9E")); textSize = Ink.sp(12f)
                     })
                 })
                 row.addView(TextView(activity).apply {
                     text = if (b.installed) "Remove" else "Install"
-                    setTextColor(Color.BLACK); textSize = 14f; typeface = Typeface.DEFAULT_BOLD
+                    setTextColor(Color.BLACK); textSize = Ink.sp(14f); typeface = Typeface.DEFAULT_BOLD
                     setPadding(dp(14), dp(6), dp(14), dp(6))
                     background = GradientDrawable().apply {
                         setColor(Color.WHITE); setStroke(maxOf(1, dp(1)), Color.BLACK); cornerRadius = dp(16).toFloat()

--- a/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
@@ -55,6 +55,13 @@ class DisplayPrefs(private val context: Context) {
         get() = display.getInt("render_quality", 1).coerceIn(0, 2)
         set(q) = display.edit().putInt("render_quality", q).apply()
 
+    /** UI-chrome scale for menus/sheets (#133). Larger panels (e.g. the Manta) want bigger menus;
+     *  this scales the reader's chrome text/controls independently of [textScale] (the reading body
+     *  text). 1.0 = the current sizing. Read clamped to the [UI_SCALES] range. */
+    var uiScale: Float
+        get() = display.getFloat("ui_scale", 1.0f).coerceIn(UI_SCALES.first(), UI_SCALES.last())
+        set(s) = display.edit().putFloat("ui_scale", s).apply()
+
     // ---- "typography" store ----
 
     var textScale: Float
@@ -98,15 +105,26 @@ class DisplayPrefs(private val context: Context) {
         /** Reflow font-size steps (multiples of the core's base body size); 1.0 = default. */
         val TEXT_SCALES = floatArrayOf(0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.15f, 1.3f, 1.5f, 1.75f, 2.0f, 2.5f, 3.0f)
 
-        /** Index of the [TEXT_SCALES] entry nearest to [scale]. */
-        fun nearestScaleIndex(scale: Float): Int {
+        /** Menu/chrome scale steps (#133); 1.0 = current sizing, the default (index 1). Kept small
+         *  and coarse so the segmented control stays e-ink-tappable. */
+        val UI_SCALES = floatArrayOf(0.9f, 1.0f, 1.15f, 1.3f, 1.5f)
+        val UI_SCALE_LABELS = listOf("S", "M", "L", "XL", "2XL")
+
+        /** Index of the entry in [values] nearest to [target]. */
+        private fun nearestIndex(values: FloatArray, target: Float): Int {
             var best = 0
             var bestDist = Float.MAX_VALUE
-            TEXT_SCALES.forEachIndexed { i, v ->
-                val dist = kotlin.math.abs(v - scale)
+            values.forEachIndexed { i, v ->
+                val dist = kotlin.math.abs(v - target)
                 if (dist < bestDist) { bestDist = dist; best = i }
             }
             return best
         }
+
+        /** Index of the [TEXT_SCALES] entry nearest to [scale]. */
+        fun nearestScaleIndex(scale: Float): Int = nearestIndex(TEXT_SCALES, scale)
+
+        /** Index of the [UI_SCALES] entry nearest to [scale]. */
+        fun nearestUiScaleIndex(scale: Float): Int = nearestIndex(UI_SCALES, scale)
     }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -73,6 +73,9 @@ class HomeActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Keep the shared chrome scale (#133) in sync with the user's menu-size preference so any
+        // Ink-built popup on the home screen matches the reader.
+        Ink.uiScale = DisplayPrefs(this).uiScale
         setContentView(buildView())
         shelfSig = shelfSignature()
         DailyAutoCompileWorker.schedule(this) // a fresh Daily issue compiles each morning (#66)

--- a/app/src/main/java/dev/jraghavan/inkread/Ink.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Ink.kt
@@ -83,7 +83,7 @@ object Ink {
         TextView(ctx).apply {
             this.text = text.uppercase()
             setTextColor(muted)
-            textSize = 11f
+            textSize = sp(11f)
             typeface = mono
             letterSpacing = 0.14f
         }
@@ -93,7 +93,7 @@ object Ink {
         TextView(ctx).apply {
             this.text = text
             setTextColor(ink)
-            textSize = size
+            textSize = sp(size)
             typeface = serif
             includeFontPadding = false
         }
@@ -122,7 +122,7 @@ object Ink {
             setContentView(
                 TextView(ctx).apply {
                     text = message
-                    textSize = 16f
+                    textSize = sp(16f)
                     setTextColor(ink)
                     setPadding(dp(28), dp(22), dp(28), dp(22))
                 },
@@ -135,7 +135,7 @@ object Ink {
     fun pillButton(ctx: Context, label: String, primary: Boolean, onTap: () -> Unit): TextView =
         TextView(ctx).apply {
             text = label
-            textSize = 13f
+            textSize = sp(13f)
             typeface = mono
             letterSpacing = 0.08f
             gravity = Gravity.CENTER

--- a/app/src/main/java/dev/jraghavan/inkread/Ink.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Ink.kt
@@ -42,6 +42,17 @@ object Ink {
     // ── Metrics (system density → no Context needed) ──
     private val density = android.content.res.Resources.getSystem().displayMetrics.density
 
+    /**
+     * UI-chrome scale (#133) — the user's menu-size preference ([DisplayPrefs.uiScale]), set once at
+     * Activity start. Chrome text sizes are declared at their design value and passed through [sp],
+     * so a larger panel (e.g. the Manta) gets proportionally bigger menus. 1.0 = the design sizing.
+     */
+    @JvmField
+    var uiScale: Float = 1f
+
+    /** A chrome text size, in sp, scaled by the user's [uiScale]. */
+    fun sp(designSp: Float): Float = designSp * uiScale
+
     fun dp(v: Int): Int = (v * density).toInt()
 
     fun dpf(v: Int): Float = v * density

--- a/app/src/main/java/dev/jraghavan/inkread/Ink.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Ink.kt
@@ -53,6 +53,11 @@ object Ink {
     /** A chrome text size, in sp, scaled by the user's [uiScale]. */
     fun sp(designSp: Float): Float = designSp * uiScale
 
+    /** A chrome dimension, in px, scaled by the user's [uiScale] — for the fixed-size boxes (icon
+     *  cells, etc.) around [sp] text, so a raised menu size grows the whole control, not just the
+     *  glyph. `uiScale == 1f` returns exactly [dp] (no change at the default). */
+    fun sdp(v: Int): Int = (dp(v) * uiScale).toInt()
+
     fun dp(v: Int): Int = (v * density).toInt()
 
     fun dpf(v: Int): Float = v * density

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -384,6 +384,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Apply the saved menu-size preference before any chrome is built (#133), so the bottom bar
+        // and sheets lay out at the user's scale from the first frame.
+        Ink.uiScale = displayPrefs.uiScale
         // Re-apply the saved page rotation (RR4) before the surface is created so the first render
         // is at the right orientation. configChanges=orientation keeps us from recreating.
         requestedOrientation = displayPrefs.orientation

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -516,7 +516,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // once a selection exists or another tool is chosen.
         lassoHint = TextView(this).apply {
             text = "Lasso — draw a loop around your writing to select"
-            textSize = 14f
+            textSize = Ink.sp(14f)
             setTextColor(Color.WHITE)
             setBackgroundColor(Color.BLACK)
             setPadding(dpInt(16), dpInt(8), dpInt(16), dpInt(8))

--- a/app/src/main/java/dev/jraghavan/inkread/SearchController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SearchController.kt
@@ -193,11 +193,11 @@ class SearchController(private val host: Host) {
                 isClickable = true
                 setOnClickListener { dialog.dismiss(); gotoHit(i) }
                 addView(TextView(activity).apply {
-                    text = "P. ${hit.page + 1}"; setTextColor(Ink.muted); textSize = 10f
+                    text = "P. ${hit.page + 1}"; setTextColor(Ink.muted); textSize = Ink.sp(10f)
                     typeface = Ink.mono; letterSpacing = 0.08f
                 })
                 addView(TextView(activity).apply {
-                    text = hit.match.snippet; setTextColor(Ink.ink); textSize = 15f
+                    text = hit.match.snippet; setTextColor(Ink.ink); textSize = Ink.sp(15f)
                     typeface = Ink.serif; setPadding(0, dp(3), 0, 0)
                 })
             })
@@ -206,7 +206,7 @@ class SearchController(private val host: Host) {
         }
         // Header: a count label flanked by Prev/Next steppers (step renders behind the sheet).
         fun stepper(label: String, delta: Int) = TextView(activity).apply {
-            text = label; setTextColor(Ink.ink); textSize = 18f; gravity = Gravity.CENTER
+            text = label; setTextColor(Ink.ink); textSize = Ink.sp(18f); gravity = Gravity.CENTER
             setPadding(dp(16), dp(8), dp(16), dp(8)); isClickable = true
             setOnClickListener { step(delta) }
         }
@@ -216,7 +216,7 @@ class SearchController(private val host: Host) {
             addView(stepper("◀", -1))
             addView(TextView(activity).apply {
                 text = "${h.size} results · “$query”"
-                setTextColor(Ink.muted); textSize = 12f; typeface = Ink.mono; gravity = Gravity.CENTER
+                setTextColor(Ink.muted); textSize = Ink.sp(12f); typeface = Ink.mono; gravity = Gravity.CENTER
                 setPadding(dp(8), dp(14), dp(8), dp(10))
             }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
             addView(stepper("▶", +1))

--- a/app/src/test/java/dev/jraghavan/inkread/UiScaleTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/UiScaleTest.kt
@@ -1,0 +1,43 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for the menu/chrome scale math (#133) — the pure `DisplayPrefs` companion logic
+ * that maps a saved [DisplayPrefs.uiScale] to a segmented-control index. `Ink.sp` is a trivial
+ * multiply and can't run here (Ink's object init touches `Resources.getSystem()`), so the testable
+ * contract lives in `DisplayPrefs`.
+ */
+class UiScaleTest {
+
+    @Test
+    fun defaultScaleIsThePresentSizing() {
+        // 1.0 must be an exact step and the default, so a fresh install renders at today's sizes.
+        assertTrue("1.0 must be a UI_SCALES step", DisplayPrefs.UI_SCALES.any { it == 1.0f })
+        assertEquals(1.0, DisplayPrefs.UI_SCALES[DisplayPrefs.nearestUiScaleIndex(1.0f)].toDouble(), 0.0)
+    }
+
+    @Test
+    fun labelsAndScalesAlign() {
+        assertEquals(DisplayPrefs.UI_SCALES.size, DisplayPrefs.UI_SCALE_LABELS.size)
+    }
+
+    @Test
+    fun nearestUiScaleIndexSnapsToTheClosestStep() {
+        assertEquals(0, DisplayPrefs.nearestUiScaleIndex(0.9f)) // exact min
+        assertEquals(DisplayPrefs.UI_SCALES.size - 1, DisplayPrefs.nearestUiScaleIndex(1.5f)) // exact max
+        // Off-grid inputs snap to the nearest step, and out-of-range clamps to an end.
+        assertEquals(1, DisplayPrefs.nearestUiScaleIndex(1.02f)) // nearest 1.0
+        assertEquals(0, DisplayPrefs.nearestUiScaleIndex(0.1f)) // below range -> min
+        assertEquals(DisplayPrefs.UI_SCALES.size - 1, DisplayPrefs.nearestUiScaleIndex(9f)) // above range -> max
+    }
+
+    @Test
+    fun textAndUiScaleIndicesAreIndependent() {
+        // The DRY nearestIndex refactor must not conflate the two scales' arrays.
+        assertEquals(1.0, DisplayPrefs.TEXT_SCALES[DisplayPrefs.nearestScaleIndex(1.0f)].toDouble(), 0.0)
+        assertEquals(3.0, DisplayPrefs.TEXT_SCALES[DisplayPrefs.nearestScaleIndex(9f)].toDouble(), 0.0) // TEXT max 3.0
+    }
+}


### PR DESCRIPTION
Resolves #133 — the reader's menus and menu text are too small on large Supernote panels (Manta). Adds a user-adjustable **Menu Size** that scales the reader's chrome.

## What

- **`DisplayPrefs.uiScale`** — a persisted UI-chrome scale (display store), distinct from the reading text scale. Steps `UI_SCALES = [0.9, 1.0, 1.15, 1.3, 1.5]` (labels S/M/L/XL/2XL), default **M = 1.0** (a fresh install renders exactly as before). `nearestUiScaleIndex` shares a `nearestIndex` helper with the existing `nearestScaleIndex` (DRY).
- **`Ink.uiScale` + `Ink.sp()` / `Ink.sdp()`** — chrome declares design sizes and reads them through `sp()` (text) and `sdp()` (the fixed-size boxes around that text), so a raised size grows whole controls. `uiScale = 1.0` is an exact no-op. Initialised from the saved pref in `ReaderActivity`, `HomeActivity`, and `DailyActivity` `onCreate`, before any chrome builds.
- **Applied across all reader chrome text**: bottom bar + main menu, TOC, bookmarks, annotations, the Adjust/Search/Define sheets, the colour palette, the lasso hint, and the shared `Ink` builders. The bottom-bar control's icon box + padding also scale so it grows coherently.
- **"Menu Size" control** — a segmented S/M/L/XL/2XL control in the Adjust sheet's Display panel. Selecting a step persists the pref and updates `Ink.uiScale`; menus render at the new size the next time each is opened (a toast confirms).

## Tests

- New `UiScaleTest` (host JVM) covers the pure scale math: default-is-1.0, label/scale alignment, nearest-step snapping, out-of-range clamping, and that the text/UI scale arrays stay independent after the DRY refactor.
- `./gradlew :app:testDebugUnitTest` green. `Ink.sp`/`sdp` themselves aren't unit-tested (Ink's init touches `Resources.getSystem()`), so the testable contract lives in `DisplayPrefs`.

## Not host-verifiable — needs an on-device check

The visual result can't be validated on the host (EPD screencap is blank). **Please verify on a Manta (and a 7\" Nomad for regression):** the bottom bar, main menu, and the Adjust/Search/Define sheets at each Menu Size step, confirming default (M) is unchanged and larger steps read well without awkward layout.

## Scope / follow-ups

- **Text and the bottom-bar control** scale; finer padding balance inside the modal sheets and the tool-palette/selection-toolbar **icon** chrome are not scaled here — track as a follow-up if the Manta still shows small icons/tight padding at high steps.
- The setting lives in the reader's Adjust sheet; it is not mirrored in the standalone `SettingsActivity` (reachable only with a document open). Mirror it there in a follow-up if desired.
- Changing the size doesn't restyle the currently-open Adjust sheet or the persistent lasso hint until reopened/recreated (disclosed via the toast).