### PR TITLE
feat(eink): full-refresh every N page-turns + a manual "Refresh now" (#99)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -53,6 +53,9 @@ class AdjustSheetController(private val host: Host) {
         /** Engine thread only: re-read the page count after a repagination. */
         fun refreshPageCount()
 
+        /** Apply a changed periodic full-refresh interval (#99) to the live page-turn cadence. */
+        fun applyFullRefreshInterval(n: Int)
+
         /** Toggle PDF reflow; owns the zoom/pan/progress-dialog state the toggle disturbs. */
         fun setReflowMode(on: Boolean)
 
@@ -398,6 +401,12 @@ class AdjustSheetController(private val host: Host) {
         }))
         container.addView(settingRow("Menu Size", segmented(DisplayPrefs.UI_SCALE_LABELS, DisplayPrefs.nearestUiScaleIndex(prefs.uiScale)) { which ->
             applyUiScale(DisplayPrefs.UI_SCALES[which])
+        }))
+        container.addView(settingRow("Full Refresh", segmented(DisplayPrefs.REFRESH_INTERVAL_LABELS, DisplayPrefs.REFRESH_INTERVALS.indexOf(prefs.fullRefreshEvery).coerceAtLeast(0)) { which ->
+            val n = DisplayPrefs.REFRESH_INTERVALS[which]
+            prefs.fullRefreshEvery = n
+            host.applyFullRefreshInterval(n)
+            host.diag { "DIAG full-refresh every=$n pages" }
         }))
         return container
     }

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -80,6 +80,9 @@ class BottomBarController(private val host: Host) {
         fun openDicts()
 
         fun openAdjust()
+
+        /** Manual full (flashing) EPD refresh to clear ghosting now (#99); also resets the cadence. */
+        fun refreshNow()
     }
 
     private val activity: Activity get() = host.activity
@@ -241,6 +244,7 @@ class BottomBarController(private val host: Host) {
         control(R.drawable.ic_menu_dict, "Dicts") { host.openDicts() }
         // Document controls consolidated into one KOReader-style tabbed sheet (Rotate/Fit/Font/Display).
         control(R.drawable.ic_menu_adjust, "Adjust") { host.openAdjust() }
+        control(R.drawable.ic_menu_refresh, "Refresh") { host.refreshNow() } // manual full flash (#99)
         control(R.drawable.ic_menu_open, "Open") { host.openPicker() }
         container.addView(controls)
 

--- a/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
@@ -62,6 +62,13 @@ class DisplayPrefs(private val context: Context) {
         get() = display.getFloat("ui_scale", 1.0f).coerceIn(UI_SCALES.first(), UI_SCALES.last())
         set(s) = display.edit().putFloat("ui_scale", s).apply()
 
+    /** Periodic full (flashing) refresh cadence (#99): force a FULL EPD refresh every Nth page-turn
+     *  to clear accumulated e-ink ghosting. 0 = Off (partial refreshes only; the manual "Refresh
+     *  now" still works). Read coerced to a valid [REFRESH_INTERVALS] step. */
+    var fullRefreshEvery: Int
+        get() = display.getInt("full_refresh_every", 0).let { if (it in REFRESH_INTERVALS) it else 0 }
+        set(n) = display.edit().putInt("full_refresh_every", n).apply()
+
     // ---- "typography" store ----
 
     var textScale: Float
@@ -109,6 +116,10 @@ class DisplayPrefs(private val context: Context) {
          *  and coarse so the segmented control stays e-ink-tappable. */
         val UI_SCALES = floatArrayOf(0.9f, 1.0f, 1.15f, 1.3f, 1.5f)
         val UI_SCALE_LABELS = listOf("S", "M", "L", "XL", "2XL")
+
+        /** Page-turn intervals for the periodic full refresh (#99); index 0 = Off, the default. */
+        val REFRESH_INTERVALS = listOf(0, 1, 3, 5, 10)
+        val REFRESH_INTERVAL_LABELS = listOf("Off", "1", "3", "5", "10")
 
         /** Index of the entry in [values] nearest to [target]. */
         private fun nearestIndex(values: FloatArray, target: Float): Int {

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -62,6 +62,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private lateinit var surfaceView: SurfaceView
     private val adapter: EinkAdapter = SupernoteEinkAdapter()
 
+    /** Periodic full-refresh cadence (#99): fires a full EPD flash every Nth page-turn to clear
+     *  ghosting. Interval comes from [DisplayPrefs.fullRefreshEvery] (set in onCreate + on change);
+     *  the counter is touched only on the engine thread from [postJump]. */
+    private val refreshCadence = RefreshCadence(0)
+
     /** Firmware stylus-ink client (RR19): the stylus inks via the Supernote pen daemon, the finger
      *  navigates. Claimed on focus, released on pause. */
     private val ink: SupernoteInk by lazy { SupernoteInk(this) }
@@ -189,6 +194,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun engineExecute(block: () -> Unit) { engine.execute(block) }
         override fun repaintPanel() = this@ReaderActivity.repaintPanel()
         override fun refreshPageCount() { pageCount = NativeBridge.nativePageCount(docHandle) }
+        override fun applyFullRefreshInterval(n: Int) { refreshCadence.interval = n } // #99
         override fun setReflowMode(on: Boolean) = this@ReaderActivity.setReflowMode(on)
         override fun zoomIn() = zoomBy(ZOOM_STEP)
         override fun zoomOut() = zoomBy(1f / ZOOM_STEP)
@@ -218,6 +224,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun openExport() = export.showExportDialog()
         override fun openDicts() = dict.showDictionariesDialog()
         override fun openAdjust() = adjust.show()
+        override fun refreshNow() { engine.execute { refreshCadence.reset(); refreshPanel() } } // #99
     })
 
     /** Lasso selection + Define-tool text selection (ADR-INKREAD-0010) — owns the selection
@@ -387,6 +394,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // Apply the saved menu-size preference before any chrome is built (#133), so the bottom bar
         // and sheets lay out at the user's scale from the first frame.
         Ink.uiScale = displayPrefs.uiScale
+        refreshCadence.interval = displayPrefs.fullRefreshEvery // periodic full-refresh cadence (#99)
         // Re-apply the saved page rotation (RR4) before the surface is created so the first render
         // is at the right orientation. configChanges=orientation keeps us from recreating.
         requestedOrientation = displayPrefs.orientation
@@ -1459,6 +1467,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     /** Jump to an absolute page on the engine thread, then render + refresh (RR11-FR1). */
     private fun postJump(page: Int, onDone: (() -> Unit)? = null) {
+        // A real page-turn changes the page; a re-render (postJump(currentPage)) does not and must
+        // not advance the full-refresh cadence (#99).
+        val isTurn = page != currentPage
         engine.execute {
             try {
                 if (docHandle == 0L) return@execute
@@ -1474,6 +1485,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 // Flash the panel FIRST so the new page is visible with no persistence/links work
                 // in front of it; then do the off-critical-path bookkeeping (RR27 position + links).
                 adapter.executeAll(WireCodec.decodeCommands(commandBytes))
+                // Every Nth page-turn, clear accumulated ghosting with a full flash (#99).
+                if (isTurn && refreshCadence.onPageTurn()) refreshPanel()
                 savePosition() // persist position per jump so an abrupt kill still reopens here (RR27)
                 refreshCurrentLinks()
             } finally {

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -194,7 +194,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun engineExecute(block: () -> Unit) { engine.execute(block) }
         override fun repaintPanel() = this@ReaderActivity.repaintPanel()
         override fun refreshPageCount() { pageCount = NativeBridge.nativePageCount(docHandle) }
-        override fun applyFullRefreshInterval(n: Int) { refreshCadence.interval = n } // #99
+        override fun applyFullRefreshInterval(n: Int) {
+            refreshCadence.interval = n // @Volatile — safe from this UI-thread setter
+            engine.execute { refreshCadence.reset() } // restart the count on the engine thread (#99)
+        }
         override fun setReflowMode(on: Boolean) = this@ReaderActivity.setReflowMode(on)
         override fun zoomIn() = zoomBy(ZOOM_STEP)
         override fun zoomOut() = zoomBy(1f / ZOOM_STEP)
@@ -1467,10 +1470,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     /** Jump to an absolute page on the engine thread, then render + refresh (RR11-FR1). */
     private fun postJump(page: Int, onDone: (() -> Unit)? = null) {
-        // A real page-turn changes the page; a re-render (postJump(currentPage)) does not and must
-        // not advance the full-refresh cadence (#99).
-        val isTurn = page != currentPage
         engine.execute {
+            // A real page-turn changes the page; a re-render (postJump(currentPage)) does not and
+            // must not advance the full-refresh cadence (#99). Read currentPage here, on the engine
+            // thread that mutates it, so the check sees the actual pre-jump page.
+            val isTurn = page != currentPage
             try {
                 if (docHandle == 0L) return@execute
                 val commandBytes = try {

--- a/app/src/main/java/dev/jraghavan/inkread/RefreshCadence.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/RefreshCadence.kt
@@ -1,0 +1,42 @@
+package dev.jraghavan.inkread
+
+/**
+ * Page-turn cadence for the periodic full (flashing) EPD refresh (#99). e-ink panels accumulate
+ * ghosting across the partial refreshes that page-turns normally use; this decides when a page-turn
+ * should force a FULL clear instead.
+ *
+ * Pure + host-testable — no Android or device types. The reader owns the actual `EinkAdapter` call;
+ * this only counts. The counter is touched only on the engine thread that commits page-turns, but
+ * [interval] can be changed from the settings UI thread, so it is `@Volatile`.
+ */
+class RefreshCadence(interval: Int) {
+
+    /** Full-refresh interval in page-turns; 0 (or less) = Off. Updated when the setting changes. */
+    @Volatile
+    var interval: Int = interval
+
+    private var sinceFull = 0
+
+    /**
+     * Record one committed page-turn and report whether THIS turn should trigger a full refresh.
+     * When Off ([interval] <= 0) it never triggers and holds the counter at rest. Otherwise it fires
+     * on every Nth turn and restarts the count.
+     */
+    fun onPageTurn(): Boolean {
+        if (interval <= 0) {
+            sinceFull = 0
+            return false
+        }
+        sinceFull++
+        if (sinceFull >= interval) {
+            sinceFull = 0
+            return true
+        }
+        return false
+    }
+
+    /** Restart the count — e.g. after a manual "Refresh now", so the next auto-flash is a full N away. */
+    fun reset() {
+        sinceFull = 0
+    }
+}

--- a/app/src/main/res/drawable/ic_menu_refresh.xml
+++ b/app/src/main/res/drawable/ic_menu_refresh.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@android:color/black" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/app/src/test/java/dev/jraghavan/inkread/RefreshCadenceTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/RefreshCadenceTest.kt
@@ -1,0 +1,58 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Host JVM tests for [RefreshCadence] (#99) — the pure page-turn counter that decides when to force
+ * a periodic full EPD refresh. The `EinkAdapter` call it gates is device-side; the cadence logic is
+ * fully host-testable.
+ */
+class RefreshCadenceTest {
+
+    /** Count how many of [turns] page-turns fire a full refresh. */
+    private fun fires(cadence: RefreshCadence, turns: Int): Int =
+        (1..turns).count { cadence.onPageTurn() }
+
+    @Test
+    fun offNeverFires() {
+        assertEquals(0, fires(RefreshCadence(0), 100))
+        assertEquals(0, fires(RefreshCadence(-1), 100)) // any non-positive is Off
+    }
+
+    @Test
+    fun everyPageFiresWhenIntervalIsOne() {
+        assertEquals(100, fires(RefreshCadence(1), 100))
+    }
+
+    @Test
+    fun firesOnExactlyEveryNthTurn() {
+        val c = RefreshCadence(3)
+        val pattern = (1..7).map { c.onPageTurn() }
+        // turns 3 and 6 flash; 1,2,4,5,7 do not.
+        assertEquals(listOf(false, false, true, false, false, true, false), pattern)
+    }
+
+    @Test
+    fun resetRestartsTheCount() {
+        val c = RefreshCadence(3)
+        c.onPageTurn(); c.onPageTurn() // two toward the next flash
+        c.reset()
+        // After reset it takes a full 3 more turns to flash again.
+        assertFalse(c.onPageTurn())
+        assertFalse(c.onPageTurn())
+        assertEquals(true, c.onPageTurn())
+    }
+
+    @Test
+    fun changingIntervalTakesEffectAndOffResetsTheCounter() {
+        val c = RefreshCadence(5)
+        c.onPageTurn(); c.onPageTurn() // 2 toward 5
+        c.interval = 0 // Off must not fire and should clear progress
+        assertFalse(c.onPageTurn())
+        c.interval = 2 // fresh count: two turns to flash
+        assertFalse(c.onPageTurn())
+        assertEquals(true, c.onPageTurn())
+    }
+}

--- a/app/src/test/java/dev/jraghavan/inkread/RefreshCadenceTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/RefreshCadenceTest.kt
@@ -2,6 +2,7 @@ package dev.jraghavan.inkread
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -42,7 +43,7 @@ class RefreshCadenceTest {
         // After reset it takes a full 3 more turns to flash again.
         assertFalse(c.onPageTurn())
         assertFalse(c.onPageTurn())
-        assertEquals(true, c.onPageTurn())
+        assertTrue(c.onPageTurn())
     }
 
     @Test
@@ -53,6 +54,6 @@ class RefreshCadenceTest {
         assertFalse(c.onPageTurn())
         c.interval = 2 // fresh count: two turns to flash
         assertFalse(c.onPageTurn())
-        assertEquals(true, c.onPageTurn())
+        assertTrue(c.onPageTurn())
     }
 }


### PR DESCRIPTION
Resolves #99 — e-ink panels accumulate ghosting across the partial refreshes a page-turn uses. Adds an automatic full (flashing) refresh every N page-turns, plus a manual "Refresh now".

## What

- **`RefreshCadence`** (pure, host-tested) — counts committed page-turns and fires a full refresh on every Nth; `interval <= 0` = Off; `reset()` restarts the count (used by the manual refresh and on interval change).
- **`DisplayPrefs.fullRefreshEvery`** — persisted interval, default **0 = Off**, coerced to a valid step.
- **Every-Nth-turn full flash** — in `postJump`, a real page-turn (`page != currentPage`, so re-renders don't count) advances the cadence; on the Nth it calls `refreshPanel()` → `adapter.refreshFull()` (the existing `RefreshIntent.FULL` / GC16 path).
- **"Refresh now"** — a bottom-bar control (new `ic_menu_refresh`) that flashes immediately and resets the cadence.
- **"Full Refresh" setting** — an Off/1/3/5/10 segmented control in Adjust → Display, next to Contrast/Quality/Menu Size.

All in the Kotlin/eink-adapter layer — **no `reader-core` change** (IR-7), reusing the existing full-refresh chokepoint rather than adding vendor specifics.

## Design notes

- The counter is engine-thread-confined; `interval` is `@Volatile` for the settings-thread setter; the interval-change `reset()` is queued onto the engine thread.
- Coalesced page-turns (N fast taps → one render) advance the cadence once — the unit is the **render/flash cycle**, which is where ghosting actually accrues.

## Tests

`RefreshCadenceTest` (host JVM): Off/negative never fires, interval=1 every turn, exact-Nth pattern, `reset()` restart, live interval change. `./gradlew :app:testDebugUnitTest` green.

## Needs an on-device check

The cadence math is host-tested, but the actual EPD flash can't be validated on the host (screencap is blank). **Please verify on a Supernote:** set Full Refresh to (say) 3, turn pages, and confirm a clean full flash every 3rd turn; confirm "Refresh now" flashes immediately; confirm Off disables the periodic flash while "Refresh now" still works.