### PR TITLE
fix(ink): stop firmware ink leaking into other apps after backgrounding (#157)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/eink/SupernoteInk.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/eink/SupernoteInk.kt
@@ -114,6 +114,12 @@ class SupernoteInk(private val context: Context) {
     fun teardown() {
         if (!active) return
         clearAll()
+        // Disable the EMR writable area via the service_myservice binder — the lever that actually
+        // works for a sideloaded app (#157). Without this the firmware keeps painting our ink after
+        // we background, so the stylus leaves invisible inkread marks in whatever app is now
+        // foreground (e.g. KOReader). enableFullUiAuto(false) below is SELinux-blocked for us and
+        // was releasing nothing. Must run while still `active` (setWritable early-returns otherwise).
+        setWritable(false)
         enableFullUiAuto(false)
         active = false
         Log.i(TAG, "firmware ink released")


### PR DESCRIPTION
Fixes #157 — after inkread is backgrounded, the stylus keeps painting invisible inkread ink into the foreground app (e.g. KOReader); the marks can reappear later, and only force-stopping inkread clears it.

## Root cause

`ReaderActivity.onPause()` calls `ink.teardown()`, but `teardown()` released the firmware ink claim only via `enableFullUiAuto(false)` — SELinux-blocked for a sideloaded app, so it released nothing. The EMR writable area is held through the `service_myservice` binder (`setWritable`), whose disable sentinel `teardown()` never sent, so the claim persisted across background.

## Fix

`SupernoteInk.teardown()` sends `setWritable(false)` (the `service_myservice` disable-everywhere sentinel) before the existing `enableFullUiAuto(false)`/`active = false`, while `active` is still true (that call early-returns otherwise). The disable is scoped to inkread's own firmware registration, so it suppresses only inkread's ink, not the foreground app's pen. `clearAll()` (already in `teardown()`) wipes buffered ink.

Return-to-foreground is unaffected: `onResume` → `applyToolInkState` → `setup()` (zero disabled-area rects, clearing the sentinel) + `setWritable(pen/eraser)` re-claims ink. `onPause` is the correct hook — in-app dialogs don't trigger it, so they keep ink.

Firmware-binder path; not exercised by host tests.