### PR TITLE
fix(ink): stop the eraser corrupting the page (#158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Pick a tool from the floating palette. Tap a tool again to reveal its options (e
 |---|---|
 | **Pen** | Write directly on the page with low-latency e-ink ink. Strokes bake into the page and persist. |
 | **Highlighter** | Lay down a wide translucent band; multiple colours. |
-| **Eraser** | Drag across strokes to remove them. |
+| **Eraser** | Drag across strokes to remove them. If your pen has an eraser end, flipping it over erases from any tool. |
 | **Lasso** | Draw a loop around your writing to select it. A floating toolbar then offers **move, cut, copy, paste, delete, select-all**, and **Add to Digest**. (Loop over printed text instead and it selects the text.) |
 | **Define** | Tap a word to look it up, or drag to select text for **Copy / Define / Highlight / Add to Digest**. |
 

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -426,7 +426,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 if (a == MotionEvent.ACTION_DOWN || a == MotionEvent.ACTION_UP) {
                     diag { "DIAG stylus action=$a tool=$tool type=$toolType hist=${event.historySize}" }
                 }
-                when (tool) {
+                // An inverted pen erases regardless of the palette (#158) — see [Tool.forStylus].
+                when (Tool.forStylus(tool, toolType)) {
                     Tool.DEFINE -> lasso.captureSelection(event)
                     Tool.ERASER -> stylus.captureErase(event)
                     Tool.LASSO -> lasso.captureLasso(event)
@@ -1550,7 +1551,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         val hint = when (chosen) {
             Tool.PEN -> "Pen — write with the stylus"
             Tool.HIGHLIGHTER -> "Highlighter — drag over text; tap again to change shade"
-            Tool.ERASER -> "Eraser — drag the stylus over ink to remove it"
+            Tool.ERASER -> "Eraser — drag over ink to remove it, or flip the pen from any tool"
             Tool.DEFINE -> "Define — tap a word to look it up; drag over text to select it"
             Tool.LASSO -> "Lasso — circle strokes to select; tap Lasso again for Freehand"
             else -> chosen.label
@@ -1735,13 +1736,16 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     private fun applyToolInkState(reason: String) {
         val ok = ink.setup()
-        // Only the Pen (and Eraser) want the firmware EMR pen painting the live stroke. Lasso,
-        // Define and Highlighter draw their OWN overlay (dashed loop / dashed select line / wide
-        // band), so suppress the firmware ink for them — else it paints a solid black stroke on top.
+        // Only the Pen wants the firmware EMR pen painting the live stroke. Lasso, Define,
+        // Highlighter and Eraser draw their OWN overlay (dashed loop / dashed select line / wide
+        // band / swept band), so suppress the firmware ink for them — else it paints a solid black
+        // stroke on top. The Eraser used to be grouped with the Pen here, which had the firmware
+        // ink a real eraser sweep onto the panel; wiping it afterwards was a race the eraser
+        // sometimes lost, leaving a scribble over the page (#158).
         // setup() re-enables the writable area each call (incl. on focus regain), so re-assert here
         // for every reason. setWritable rides the service_myservice binder (works for a sideloaded
         // app); enableFullUiAuto is SELinux-blocked.
-        val inkWritable = tool == Tool.PEN || tool == Tool.ERASER
+        val inkWritable = tool == Tool.PEN
         ink.setWritable(inkWritable)
         Log.i(TAG, "ink claimed ($reason) for $tool: available=$ok writable=$inkWritable")
     }

--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -250,7 +250,7 @@ class SettingsActivity : Activity() {
         /** Concise, accurate cheatsheet of the non-obvious features (title → one line). */
         val HELP = listOf(
             "Pen & Highlighter" to "Write and highlight on the page with the stylus; the floating tool palette switches between them.",
-            "Eraser" to "Switch to the eraser in the tool palette to wipe strokes.",
+            "Eraser" to "Switch to the eraser in the tool palette to wipe strokes — or, if your pen has an eraser end, just flip it over.",
             "Lasso select" to "Circle ink or text to move, copy, delete, or look it up.",
             "Define" to "Select a word and tap Define to look it up in the on-device dictionaries.",
             "Search" to "Find text anywhere in the document and jump between matches.",

--- a/app/src/main/java/dev/jraghavan/inkread/StylusInkController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/StylusInkController.kt
@@ -128,9 +128,12 @@ class StylusInkController(private val host: Host) {
 
     /** Live eraser band — the swept region, at the real hit width (2× the radius), so you can see
      *  what is about to go. The firmware EMR ink is suppressed for the Eraser (#158), so this is the
-     *  only feedback during the drag; the page is repainted from the core when the gesture ends. */
+     *  only feedback during the drag; the page is repainted from the core when the gesture ends.
+     *  Translucent (like the highlighter's band) so the ink under the nib stays visible — an opaque
+     *  band would hide the very strokes you are aiming at. */
     private val eraseLivePaint = Paint().apply {
         color = Ink.ringSoft
+        alpha = ERASE_BAND_ALPHA
         style = Paint.Style.STROKE; strokeCap = Paint.Cap.ROUND; strokeJoin = Paint.Join.ROUND; isAntiAlias = true
         strokeWidth = ERASE_RADIUS_PX * 2f
     }
@@ -345,6 +348,7 @@ class StylusInkController(private val host: Host) {
         const val INK_STROKE_WIDTH = 6f // baked-ink line width (px) tuned to match the firmware pen.
         const val HIGHLIGHT_WIDTH_PX = 30f // wide marker band (vs INK_STROKE_WIDTH for the pen).
         const val ERASE_RADIUS_PX = 22f // eraser hit radius (px): a stroke within this of the path goes.
+        const val ERASE_BAND_ALPHA = 96 // live eraser band opacity: reads on the panel, hides nothing.
         const val INK_FLUSH_MS = 1500L // trailing-edge delay before the deferred ink autosave fsyncs.
         const val LONG_PRESS_MS = 500L // hold the pen this long (≈still) on a word → look it up.
         const val LONG_PRESS_SLOP_PX = 16f // movement beyond this cancels the long-press (it's a stroke).

--- a/app/src/main/java/dev/jraghavan/inkread/StylusInkController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/StylusInkController.kt
@@ -126,6 +126,15 @@ class StylusInkController(private val host: Host) {
         style = Paint.Style.STROKE; strokeCap = Paint.Cap.ROUND; strokeJoin = Paint.Join.ROUND; isAntiAlias = true
     }
 
+    /** Live eraser band — the swept region, at the real hit width (2× the radius), so you can see
+     *  what is about to go. The firmware EMR ink is suppressed for the Eraser (#158), so this is the
+     *  only feedback during the drag; the page is repainted from the core when the gesture ends. */
+    private val eraseLivePaint = Paint().apply {
+        color = Ink.ringSoft
+        style = Paint.Style.STROKE; strokeCap = Paint.Cap.ROUND; strokeJoin = Paint.Join.ROUND; isAntiAlias = true
+        strokeWidth = ERASE_RADIUS_PX * 2f
+    }
+
     /** Current pen / highlighter colour (index into the palettes); re-tapping a tool cycles it. */
     var penColorIndex = 0
     var hlColorIndex = 0
@@ -281,6 +290,9 @@ class StylusInkController(private val host: Host) {
                 }
                 eraseBuf.add(e.x); eraseBuf.add(e.y)
                 armEraseTimeout()
+                // The Eraser's firmware EMR ink is suppressed (it would deposit a real stroke, #158),
+                // so draw the swept band ourselves — the same live-overlay path the Highlighter uses.
+                host.drawLivePath(eraseBuf, eraseLivePaint)
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 eraseBuf.add(e.x); eraseBuf.add(e.y)
@@ -306,17 +318,22 @@ class StylusInkController(private val host: Host) {
     /** Feed the eraser path to the core (Eraser stroke removes crossed strokes); re-render (engine). */
     private fun commitErase(viewPts: FloatArray) {
         val w = host.viewW; val h = host.viewH
-        if (host.docHandle == 0L || w == 0 || h == 0) return
-        val radiusNorm = host.lenToNorm(ERASE_RADIUS_PX)
-        try {
-            NativeBridge.nativeInkBeginStroke(host.docHandle, ReaderActivity.CORE_TOOL_ERASER, ReaderActivity.INK_COLOR_BLACK, radiusNorm, System.currentTimeMillis())
-            NativeBridge.nativeInkAddPoints(host.docHandle, toNormPoints(viewPts))
-            NativeBridge.nativeInkEndStroke(host.docHandle)
-            scheduleInkFlush() // deferred autosave: persist on a trailing debounce, not this fsync
-        } catch (e: RuntimeException) {
-            Log.e(TAG, "erase failed: ${e.message}"); return
+        if (host.docHandle != 0L && w != 0 && h != 0) {
+            val radiusNorm = host.lenToNorm(ERASE_RADIUS_PX)
+            try {
+                NativeBridge.nativeInkBeginStroke(host.docHandle, ReaderActivity.CORE_TOOL_ERASER, ReaderActivity.INK_COLOR_BLACK, radiusNorm, System.currentTimeMillis())
+                NativeBridge.nativeInkAddPoints(host.docHandle, toNormPoints(viewPts))
+                NativeBridge.nativeInkEndStroke(host.docHandle)
+                scheduleInkFlush() // deferred autosave: persist on a trailing debounce, not this fsync
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "erase failed: ${e.message}")
+            }
         }
-        host.clearFirmwareInk() // wipe the firmware ink left by the eraser drag
+        // Always restore the page from the core, on every path (#158). The live band we drew is
+        // transient, and an inverted pen sweeps while the palette is PEN — where the firmware ink is
+        // still claimed — so a bailed-out or failed erase must never leave marks the model doesn't
+        // have. The core is the only source of truth for what is on the page.
+        host.clearFirmwareInk()
         host.repaintPanel()
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -23,6 +23,24 @@ enum class Tool(val label: String, val iconRes: Int, val phase2: Boolean) {
     ERASER("Eraser", R.drawable.ic_tool_eraser, false),
     LASSO("Lasso", R.drawable.ic_tool_lasso, false),
     DEFINE("Define", R.drawable.ic_menu_dict, false),
+    ;
+
+    companion object {
+        /**
+         * Which tool a stylus event actually drives (#158). The palette decides — except for an
+         * **inverted pen**, which Android reports as [MotionEvent.TOOL_TYPE_ERASER] and which must
+         * erase whatever the palette says. The hardware end of the pen is a deliberate, unambiguous
+         * statement of intent; no user flips the pen over meaning to write.
+         *
+         * Getting this wrong corrupted the page rather than merely doing the wrong thing: an
+         * inverted pen used to fall through to the ink path, so the firmware's own eraser wiped the
+         * live ink off the panel (the stroke *looked* erased) while the app committed the eraser
+         * sweep to the core as a **Pen** stroke. Nothing was deleted from the model, so the next
+         * full render brought the original stroke back with the sweep inked on top of it.
+         */
+        fun forStylus(palette: Tool, motionToolType: Int): Tool =
+            if (motionToolType == MotionEvent.TOOL_TYPE_ERASER) ERASER else palette
+    }
 }
 
 /**

--- a/app/src/test/java/dev/jraghavan/inkread/ToolRoutingTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolRoutingTest.kt
@@ -1,0 +1,51 @@
+package dev.jraghavan.inkread
+
+import android.view.MotionEvent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Host JVM tests for [Tool.forStylus] — which tool a stylus event drives (#158).
+ *
+ * The bug this guards: an inverted pen (`TOOL_TYPE_ERASER`) used to fall through to the ink path,
+ * so the firmware eraser cleared the panel while the app committed the sweep as a Pen stroke —
+ * a refresh then showed the original stroke *and* an eraser-shaped scribble. No emulator reproduces
+ * the EMR pen, so this pure routing decision is the deterministic guard against a regression.
+ *
+ * The `TOOL_TYPE_*` values are compile-time constants, so they inline here without an Android
+ * runtime.
+ */
+class ToolRoutingTest {
+
+    @Test
+    fun invertedPenErasesWhateverThePaletteSays() {
+        for (palette in Tool.entries) {
+            assertEquals(
+                "palette=$palette with an inverted pen must erase",
+                Tool.ERASER,
+                Tool.forStylus(palette, MotionEvent.TOOL_TYPE_ERASER),
+            )
+        }
+    }
+
+    @Test
+    fun penTipFollowsThePalette() {
+        for (palette in Tool.entries) {
+            assertEquals(palette, Tool.forStylus(palette, MotionEvent.TOOL_TYPE_STYLUS))
+        }
+    }
+
+    /** The eraser palette still erases with the pen tip — the ordinary way to erase. */
+    @Test
+    fun eraserPaletteErasesWithThePenTip() {
+        assertEquals(Tool.ERASER, Tool.forStylus(Tool.ERASER, MotionEvent.TOOL_TYPE_STYLUS))
+    }
+
+    /** Only the eraser end overrides; an unknown/finger tool type is left to the palette (the
+     *  caller already gates on the tool type, so this must not silently reroute). */
+    @Test
+    fun otherToolTypesLeaveThePaletteAlone() {
+        assertEquals(Tool.PEN, Tool.forStylus(Tool.PEN, MotionEvent.TOOL_TYPE_FINGER))
+        assertEquals(Tool.LASSO, Tool.forStylus(Tool.LASSO, MotionEvent.TOOL_TYPE_UNKNOWN))
+    }
+}

--- a/docs/RELEASE-SMOKE-CHECKLIST.md
+++ b/docs/RELEASE-SMOKE-CHECKLIST.md
@@ -38,9 +38,11 @@ Tick a step only when the expected result is observed. Any failure blocks the ta
 | 3.1 | With Pen tool active, write a few words | Ink appears under the nib at firmware latency (no visible lag) | both |
 | 3.2 | Turn the page and come back | Strokes persisted and re-render baked on the page | primary |
 | 3.3 | Undo, then redo from the selection toolbar / palette | Last stroke disappears, then returns | primary |
-| 3.4 | Eraser tool: scrub across a stroke | Stroke vanishes; surrounding strokes untouched | primary |
-| 3.5 | Rest a palm while writing | No stray finger input fires (palm rejection); writing unaffected | both |
-| 3.6 | Kill the app right after a stroke; relaunch | The stroke survived (autosave + crash-safe sidecar, RR20) | primary |
+| 3.4 | Eraser tool: scrub across a stroke | Grey swept band follows the nib (no black firmware ink); stroke vanishes; surrounding strokes untouched | primary |
+| 3.5 | After 3.4, turn the page and come back | Stroke still gone; **no** eraser-shaped scribble anywhere on the page (#158) | primary |
+| 3.6 | With the **Pen** tool active, flip the pen to its eraser end and scrub a stroke | Erases — does not ink. Turn the page and back: stroke stays gone, nothing new drawn (#158) | primary |
+| 3.7 | Rest a palm while writing | No stray finger input fires (palm rejection); writing unaffected | both |
+| 3.8 | Kill the app right after a stroke; relaunch | The stroke survived (autosave + crash-safe sidecar, RR20) | primary |
 
 ## 4. Lasso & selection
 


### PR DESCRIPTION
Closes #158.

Erasing could leave the page worse than before: after a refresh the original stroke reappeared with an eraser-shaped scribble drawn over it. Two independent paths let an erase gesture deposit ink.

## 1. An inverted pen was inking

Stylus gestures were routed on the palette tool alone, so a pen flipped to its eraser end — which Android reports as `TOOL_TYPE_ERASER` — fell through to the ink path whenever the palette was on Pen.

The firmware's own eraser wiped the live ink off the panel, so the stroke *looked* erased, while the app committed the eraser sweep to the core as a **Pen** stroke and deleted nothing. The next full render brought the original back with the sweep inked on top.

`Tool.forStylus(palette, motionToolType)` now decides: the palette rules, except that an inverted pen always erases. The override is scoped to the hardware tool type only — no gesture or contact-geometry heuristic is admitted, so ADR-INKREAD-0010's modal model still governs everything else.

## 2. The Eraser was claiming firmware EMR ink

`applyToolInkState` had `inkWritable = tool == Tool.PEN || tool == Tool.ERASER`, so the firmware painted a real black stroke along every eraser sweep; the post-commit `clearFirmwareInk()` was a race.

This was **drift from an accepted decision**, not a new one: ADR-INKREAD-0010 Decision 2 already places the Eraser with Highlighter/Lasso/Define, where the app captures the stylus and the firmware does not ink. The fix restores the ADR as written.

With the firmware no longer painting the sweep, the Eraser draws its own translucent swept band at the real hit width (2× `ERASE_RADIUS_PX`) through the existing `drawLivePath` primitive. Translucent so it doesn't hide the strokes you're aiming at. The end of a gesture now repaints from the core on *every* path, including the bailed-out and native-exception paths, so a failed erase can never leave marks the model doesn't have.

## Scope

The richer eraser-mask affordance stays with #126. ADR-INKREAD-0010 carries an amendment recording both the drift and the hardware override.

## How it was tested

- `cargo fmt --check`, `cargo clippy --all -- -D warnings`, `cargo test --workspace` — green.
- `:app:testDebugUnitTest`, `:app:assembleDebug` — green.
- New `ToolRoutingTest` (4 cases) pins the routing decision. No emulator reproduces the EMR pen, so the pure decision is the regression guard — the same approach `PalmFilter` uses.

**Not device-tested.** Could you run smoke rows 3.5 and 3.6 on the Nomad before this lands: erase then revisit the page (no scribble, stroke stays gone), and flip the pen while the Pen tool is active (erases, does not ink). Those two steps are new to the checklist in this PR because their absence is why this shipped.