### PR TITLE
fix(epub): open books whose text is a legacy encoding (#159)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,10 +663,12 @@ version = "1.2.0"
 dependencies = [
  "ab_glyph",
  "ego-tree",
+ "encoding_rs",
  "hyphenation",
  "rbook",
  "scraper",
  "unicode-linebreak",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,11 @@ jpeg-decoder = { version = "0.3", default-features = false }
 png = "0.17"
 # inkread-daily (#66): RSS/Atom feed parsing. Pure-Rust pull parser, MIT/Apache, cross-compiles clean.
 quick-xml = "0.41"
+# Legacy text encodings (#159): a great many Russian EPUBs are windows-1251 or koi8-r, and rbook
+# refuses any non-UTF-8 resource outright. encoding_rs is the browser-grade decoder (the one Firefox
+# ships), so this also covers Shift-JIS/Big5/EUC-KR books rather than just the reported one.
+# "(Apache-2.0 OR MIT) AND BSD-3-Clause" — every atom is on the check-licenses.sh allowlist.
+encoding_rs = "0.8"
 # inkread-update (ADR-INKREAD-0014): semver comparison of the installed version against the GitHub
 # release tag. Pure Rust, MIT/Apache (AGPL-compatible → auto-passes check-licenses.sh).
 semver = "1"

--- a/inkread-epub/Cargo.toml
+++ b/inkread-epub/Cargo.toml
@@ -10,6 +10,11 @@ description = "EPUB container parsing + (forthcoming) pure-Rust reflow for inkre
 
 [dependencies]
 rbook = "0.7.9"
+# Legacy-encoding repair before rbook sees the book (#159): rbook refuses any non-UTF-8 resource
+# outright, which makes a windows-1251 Russian EPUB unopenable. `zip` reads and rewrites the
+# container (already a workspace dep for CBZ); `encoding_rs` does the decoding.
+zip = { workspace = true }
+encoding_rs = { workspace = true }
 # scraper (html5ever-based, ISC) parses chapter XHTML into a tree we lower to our own owned content
 # model; the parse tree is transient (never escapes parse_blocks). ego-tree (scraper's own tree, MIT)
 # is named directly so the recursive walker can take a `NodeRef`.

--- a/inkread-epub/src/lib.rs
+++ b/inkread-epub/src/lib.rs
@@ -20,6 +20,7 @@ pub mod content;
 pub mod layout;
 pub mod measure;
 pub mod render;
+mod transcode;
 pub use content::{parse_blocks, Block, Inline, TextRun};
 pub use layout::{
     paginate, paginate_with, Align, Hyphenator, LayoutLine, LayoutOpts, Metrics, NoHyphen, Page,
@@ -95,6 +96,10 @@ impl EpubPackage {
     /// the PDF path). Reads every spine document's XHTML in reading order. Returns an
     /// [`EpubError::Parse`] on any malformed-container failure — never panics.
     pub fn open(bytes: Vec<u8>) -> EpubResult<Self> {
+        // Repair legacy text encodings first (#159). rbook refuses any non-UTF-8 resource outright,
+        // so without this a windows-1251 Russian EPUB does not open at all. A conforming book comes
+        // back from this untouched.
+        let bytes = transcode::to_utf8(bytes);
         let epub = Epub::read(Cursor::new(bytes)).map_err(|e| EpubError::Parse(e.to_string()))?;
 
         let meta = epub.metadata();
@@ -162,7 +167,7 @@ mod tests {
     /// Build a minimal valid EPUB **zip** in memory: `mimetype` first, the rest stored — enough for
     /// rbook to open the fixture without an on-disk file. Two spine chapters + an EPUB-3 nav doc →
     /// exercises metadata, reading order, and TOC.
-    fn sample_epub() -> Vec<u8> {
+    pub(crate) fn sample_epub() -> Vec<u8> {
         let mut buf = Vec::new();
         write_zip(
             &mut buf,
@@ -321,5 +326,54 @@ mod tests {
     fn malformed_bytes_error_not_panic() {
         let err = EpubPackage::open(b"not a zip at all".to_vec());
         assert!(matches!(err, Err(EpubError::Parse(_))));
+    }
+
+    /// Encode Cyrillic + ASCII as **windows-1251** — the encoding a great many Russian EPUBs still
+    /// declare, especially the FB2-converted ones. А–Я and а–я are contiguous at 0xC0 and 0xE0.
+    pub(crate) fn to_cp1251(s: &str) -> Vec<u8> {
+        s.chars()
+            .map(|c| match c {
+                'А'..='Я' => 0xC0 + (c as u32 - 'А' as u32) as u8,
+                'а'..='я' => 0xE0 + (c as u32 - 'а' as u32) as u8,
+                'Ё' => 0xA8,
+                'ё' => 0xB8,
+                c if c.is_ascii() => c as u8,
+                _ => b'?',
+            })
+            .collect()
+    }
+
+    /// A book whose chapters are windows-1251, declared in the XML prolog as EPUB permits.
+    fn cp1251_epub() -> Vec<u8> {
+        let chapter = "<?xml version=\"1.0\" encoding=\"windows-1251\"?>\n\
+             <html xmlns=\"http://www.w3.org/1999/xhtml\"><body>\
+             <h1>Глава</h1><p>Первая глава книги.</p></body></html>";
+        let mut buf = Vec::new();
+        write_zip(
+            &mut buf,
+            &[
+                ("mimetype", b"application/epub+zip".to_vec()),
+                ("META-INF/container.xml", CONTAINER_XML.as_bytes().to_vec()),
+                ("OEBPS/content.opf", OPF.as_bytes().to_vec()),
+                ("OEBPS/nav.xhtml", NAV.as_bytes().to_vec()),
+                ("OEBPS/ch1.xhtml", to_cp1251(chapter)),
+                ("OEBPS/ch2.xhtml", CH2.as_bytes().to_vec()),
+            ],
+        );
+        buf
+    }
+
+    /// #159: a Russian EPUB opened but rendered nothing. Glyph coverage was ruled out (every
+    /// bundled face has Cyrillic), which leaves decoding: a non-UTF-8 chapter must still reach the
+    /// layout stage as text, not as emptiness. Blank pages are the worst failure mode here because
+    /// the book *opens* — nothing tells the reader the text was dropped rather than absent.
+    #[test]
+    fn a_windows_1251_chapter_still_yields_text() {
+        let pkg = EpubPackage::open(cp1251_epub()).expect("a cp1251 epub still opens");
+        let html = &pkg.chapters[0].html;
+        assert!(
+            html.contains("Первая глава книги."),
+            "cp1251 chapter decoded to {html:?}",
+        );
     }
 }

--- a/inkread-epub/src/transcode.rs
+++ b/inkread-epub/src/transcode.rs
@@ -1,0 +1,256 @@
+//! Repair a book's text encoding before the EPUB parser sees it (#159).
+//!
+//! EPUB requires UTF-8 (or UTF-16) for its XML, and rbook enforces that strictly: *any* resource it
+//! reads as a string must be valid UTF-8, or the whole book fails to open with `InvalidUtf8Resource`
+//! — not just the offending chapter, but the package document and table of contents too.
+//!
+//! Real libraries are less tidy than the spec. A great many Russian EPUBs — especially the ones
+//! converted from FB2 — are **windows-1251**, and a reader that refuses them is simply a reader that
+//! cannot open Russian books. The same is true of koi8-r, and of Shift-JIS/Big5/EUC-KR for books
+//! from those traditions.
+//!
+//! So this module runs first: it decodes any text resource that is not valid UTF-8, using the
+//! encoding the document itself declares, and rewrites the container with UTF-8 throughout. A
+//! well-formed book is returned **byte-identical and untouched** — the cost is one scan of the
+//! archive's text entries, and nothing else.
+//!
+//! Pure and host-testable: bytes in, bytes out, no IO.
+
+use std::io::{Cursor, Read, Write};
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+/// Return `bytes` with every non-UTF-8 text resource transcoded to UTF-8.
+///
+/// Returns the input unchanged when nothing needs repair, when the input is not a readable ZIP (the
+/// EPUB parser will report that far better than we can), or when rebuilding fails for any reason —
+/// this is a repair pass, and it must never be the thing that breaks a book that would have opened.
+#[must_use]
+pub(crate) fn to_utf8(bytes: Vec<u8>) -> Vec<u8> {
+    match read_repaired(&bytes) {
+        Some(entries) => rebuild(&entries).unwrap_or(bytes),
+        // The overwhelmingly common case: a conforming book, handed back untouched.
+        None => bytes,
+    }
+}
+
+/// Read every entry, transcoding the text resources that need it.
+///
+/// `None` means "hand back the original bytes": either nothing needed repair, or the container
+/// could not be read at all — in which case the EPUB parser's own error is the useful one.
+fn read_repaired(bytes: &[u8]) -> Option<Vec<(String, Vec<u8>, bool)>> {
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).ok()?;
+    let mut entries: Vec<(String, Vec<u8>, bool)> = Vec::with_capacity(archive.len());
+    let mut repaired_any = false;
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i).ok()?;
+        if !file.is_file() {
+            continue;
+        }
+        let name = file.name().to_string();
+        let deflate = file.compression() != CompressionMethod::Stored;
+        let mut data = Vec::with_capacity(file.size() as usize);
+        file.read_to_end(&mut data).ok()?;
+        if is_text_resource(&name) {
+            if let Some(fixed) = repair(&data) {
+                data = fixed;
+                repaired_any = true;
+            }
+        }
+        entries.push((name, data, deflate));
+    }
+    repaired_any.then_some(entries)
+}
+
+/// Resources whose bytes are read as text. Images and fonts are copied through verbatim — running a
+/// decoder over a JPEG would be both pointless and destructive.
+fn is_text_resource(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    [
+        ".xhtml", ".html", ".htm", ".xml", ".opf", ".ncx", ".css", ".svg",
+    ]
+    .iter()
+    .any(|ext| lower.ends_with(ext))
+}
+
+/// Decode `data` to UTF-8 if it is not already valid UTF-8, returning `None` when no repair is
+/// needed. The declared encoding is honoured where the document states one; otherwise windows-1252
+/// stands in, being the label the WHATWG standard maps the unlabelled legacy case onto.
+fn repair(data: &[u8]) -> Option<Vec<u8>> {
+    if std::str::from_utf8(data).is_ok() {
+        return None;
+    }
+    let label = declared_encoding(data);
+    let encoding = label
+        .as_deref()
+        .and_then(|l| encoding_rs::Encoding::for_label(l.as_bytes()))
+        .unwrap_or(encoding_rs::WINDOWS_1252);
+    // `decode` never fails: unmappable bytes become U+FFFD, which is the right trade here. A page
+    // with a few replacement characters is a page the reader can still read; refusing the book is not.
+    let (text, _, _) = encoding.decode(data);
+    Some(rewrite_declaration(&text).into_bytes())
+}
+
+/// The encoding a document declares — an XML prolog `encoding="…"`, else an HTML
+/// `<meta charset="…">` or `<meta http-equiv … content="text/html; charset=…">`.
+///
+/// Scanned over the *bytes*, since the document is by definition not decodable yet, and only over
+/// the head of the file where a declaration is permitted to appear. The label itself is always
+/// ASCII in every encoding this matters for.
+fn declared_encoding(data: &[u8]) -> Option<String> {
+    const HEAD: usize = 2048;
+    let head = &data[..data.len().min(HEAD)];
+    let text: String = head.iter().map(|&b| b as char).collect();
+    let lower = text.to_ascii_lowercase();
+
+    // `encoding="…"` (XML prolog) or `charset=…` (HTML meta), quoted or bare.
+    for key in ["encoding=", "charset="] {
+        let mut from = 0;
+        while let Some(at) = lower[from..].find(key) {
+            let start = from + at + key.len();
+            let rest = &text[start..];
+            let value: String = match rest.chars().next() {
+                Some(q @ ('"' | '\'')) => rest[1..].chars().take_while(|&c| c != q).collect(),
+                _ => rest
+                    .chars()
+                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+                    .collect(),
+            };
+            if !value.trim().is_empty() {
+                return Some(value.trim().to_string());
+            }
+            from = start;
+        }
+    }
+    None
+}
+
+/// Point any encoding declaration at UTF-8, now that the bytes are UTF-8.
+///
+/// This is not cosmetic: leaving `encoding="windows-1251"` in the prolog of a document that is now
+/// UTF-8 invites the next XML parser down the line to decode it a second time, back into mojibake.
+fn rewrite_declaration(text: &str) -> String {
+    let Some(end) = text.find("?>") else {
+        return text.to_string();
+    };
+    let (prolog, rest) = text.split_at(end);
+    let lower = prolog.to_ascii_lowercase();
+    let Some(at) = lower.find("encoding=") else {
+        return text.to_string();
+    };
+    let after = at + "encoding=".len();
+    let value_len = match prolog[after..].chars().next() {
+        Some(q @ ('"' | '\'')) => prolog[after + 1..].chars().take_while(|&c| c != q).count() + 2, // the quotes
+        _ => prolog[after..]
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+            .count(),
+    };
+    format!(
+        "{}\"UTF-8\"{}{}",
+        &prolog[..after],
+        &prolog[after + value_len..],
+        rest
+    )
+}
+
+/// Write the entries back into a fresh EPUB container.
+///
+/// `mimetype` must come first and be stored uncompressed for the file to be a valid EPUB, so it is
+/// emitted ahead of everything else regardless of where it sat in the original.
+fn rebuild(entries: &[(String, Vec<u8>, bool)]) -> Option<Vec<u8>> {
+    let mut zw = ZipWriter::new(Cursor::new(Vec::new()));
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    if let Some((name, data, _)) = entries.iter().find(|(n, _, _)| n == "mimetype") {
+        zw.start_file(name, stored).ok()?;
+        zw.write_all(data).ok()?;
+    }
+    for (name, data, deflate) in entries {
+        if name == "mimetype" {
+            continue;
+        }
+        zw.start_file(name, if *deflate { deflated } else { stored })
+            .ok()?;
+        zw.write_all(data).ok()?;
+    }
+    Some(zw.finish().ok()?.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_utf8_is_returned_byte_identical() {
+        // The common case must cost nothing and change nothing — not even a re-zip, which would
+        // churn every book's bytes on every open.
+        let original = crate::tests::sample_epub();
+        assert_eq!(to_utf8(original.clone()), original);
+    }
+
+    #[test]
+    fn a_non_zip_is_handed_back_untouched() {
+        // The EPUB parser reports "not a container" far better than a repair pass can.
+        let junk = b"not a zip at all".to_vec();
+        assert_eq!(to_utf8(junk.clone()), junk);
+    }
+
+    #[test]
+    fn declared_encoding_reads_the_xml_prolog() {
+        let xml = br#"<?xml version="1.0" encoding="windows-1251"?><html/>"#;
+        assert_eq!(declared_encoding(xml).as_deref(), Some("windows-1251"));
+    }
+
+    #[test]
+    fn declared_encoding_reads_an_html_meta_charset() {
+        let html = br#"<html><head><meta charset="koi8-r"></head></html>"#;
+        assert_eq!(declared_encoding(html).as_deref(), Some("koi8-r"));
+        let legacy =
+            br#"<html><head><meta http-equiv="Content-Type" content="text/html; charset=koi8-r"/></head></html>"#;
+        assert_eq!(declared_encoding(legacy).as_deref(), Some("koi8-r"));
+    }
+
+    #[test]
+    fn declared_encoding_is_none_when_undeclared() {
+        assert_eq!(declared_encoding(b"<html><body>hi</body></html>"), None);
+    }
+
+    #[test]
+    fn the_rewritten_declaration_says_utf8() {
+        let out = rewrite_declaration(r#"<?xml version="1.0" encoding="windows-1251"?><p/>"#);
+        assert_eq!(out, r#"<?xml version="1.0" encoding="UTF-8"?><p/>"#);
+        // Single quotes and a missing declaration must both survive the rewrite unharmed.
+        assert_eq!(
+            rewrite_declaration(r#"<?xml version='1.0' encoding='koi8-r'?><p/>"#),
+            r#"<?xml version='1.0' encoding="UTF-8"?><p/>"#,
+        );
+        assert_eq!(rewrite_declaration("<p/>"), "<p/>");
+    }
+
+    #[test]
+    fn repair_is_a_no_op_on_utf8_and_decodes_otherwise() {
+        assert_eq!(repair("Первая глава".as_bytes()), None, "already UTF-8");
+
+        let cp1251 = crate::tests::to_cp1251(
+            r#"<?xml version="1.0" encoding="windows-1251"?><p>Первая глава</p>"#,
+        );
+        let fixed = repair(&cp1251).expect("cp1251 needs repair");
+        let text = String::from_utf8(fixed).expect("repaired to valid UTF-8");
+        assert!(text.contains("Первая глава"), "decoded to {text:?}");
+        assert!(
+            text.contains(r#"encoding="UTF-8""#),
+            "declaration rewritten"
+        );
+    }
+
+    #[test]
+    fn an_undeclared_legacy_document_still_decodes_rather_than_failing() {
+        // No declaration and not UTF-8 — the WHATWG fallback keeps the book openable instead of
+        // letting one unlabelled chapter take the whole thing down.
+        let bytes = vec![0xE9, 0xE8, b'!']; // windows-1252 "éè!"
+        let fixed = repair(&bytes).expect("needs repair");
+        assert!(String::from_utf8(fixed).is_ok());
+    }
+}


### PR DESCRIPTION
Closes #159.

A Russian EPUB rendered nothing. Font coverage had already been ruled out — every bundled face carries Cyrillic — and the issue was waiting on the reporter's file. The failure reproduces without it.

## Cause

EPUB mandates UTF-8, and rbook enforces it strictly: any resource read as a string must be valid UTF-8 or the book fails to open with `InvalidUtf8Resource`. Not the offending chapter — the whole book, package document and table of contents included.

A great many Russian EPUBs, especially FB2 conversions, are windows-1251. A reader that refuses them is a reader that cannot open Russian books.

Reproduced with a constructed windows-1251 fixture:

```
Parse("[InvalidUtf8Resource - ...OEBPS/ch1.xhtml]: Resource value cannot be read as UTF-8")
```

## Fix

A transcode pass ahead of the parser (`inkread-epub/src/transcode.rs`). It decodes any text resource that is not valid UTF-8 using the encoding the document declares — an XML prolog `encoding=`, or an HTML `<meta charset>` / `http-equiv` content type — and rewrites the container as UTF-8 throughout.

The declaration is rewritten to `UTF-8` as well. Leaving `encoding="windows-1251"` on bytes that are now UTF-8 invites the next XML parser to decode them a second time, back into mojibake.

`encoding_rs` does the decoding rather than a hand-rolled windows-1251 table, so Shift-JIS, Big5 and EUC-KR books are covered by the same path. Its licence is `(Apache-2.0 OR MIT) AND BSD-3-Clause` — every atom is already on the `check-licenses.sh` allowlist.

## Properties it holds

- **A conforming book is returned byte-identical.** The repair costs one scan of the archive's text entries and nothing more, so the common case does not pay for the rare one.
- **Anything it cannot handle hands the original bytes back** — a non-zip, an unreadable entry, a failed rebuild. A repair pass must never be the thing that breaks a book that would otherwise have opened.
- **An undeclared or partly-undecodable document still yields text**, with U+FFFD where bytes were unmappable. A page with a few replacement characters is readable; a book that refuses to open is not.

Each is a test.

## How it was tested

- `cargo fmt --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --workspace` (409 tests), `check-licenses.sh` — green.
- 8 new tests: the cp1251 round-trip through `EpubPackage::open`, byte-identical passthrough, non-zip passthrough, declaration detection (prolog / meta charset / http-equiv / absent), declaration rewriting, and the undeclared-legacy fallback.

## Scope

Whether this is the reporter's exact file is unconfirmed — it is a real defect producing exactly the reported symptom. Worth asking them to retest on a build with this in rather than closing blind: if they have a UTF-8 book that still renders blank, there is a second cause and the issue should stay open.