### PR TITLE
feat(opds): browse a calibre / Calibre-Web library and download onto the shelf (#175)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "inkread-dict",
  "inkread-epub",
  "inkread-ink",
+ "inkread-opds",
  "inkread-pdftext",
  "inkread-update",
  "jni",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkread-opds"
+version = "1.2.0"
+dependencies = [
+ "feed-rs",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "inkread-pdftext"
 version = "1.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # RR1-AC3: bare `cargo test -p reader-core` builds with `jni` absent from the resolved graph.
 [workspace]
 resolver = "2"
-members = ["build-dict", "device-eink", "inkread-daily", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "inkread-pdftext", "inkread-update", "reader-core"]
+members = ["build-dict", "device-eink", "inkread-daily", "inkread-dict", "inkread-epub", "inkread-ink", "inkread-lua", "inkread-opds", "inkread-pdftext", "inkread-update", "reader-core"]
 
 [workspace.package]
 version = "1.2.0"
@@ -24,6 +24,7 @@ inkread-dict = { path = "inkread-dict" }
 inkread-epub = { path = "inkread-epub" }
 inkread-ink = { path = "inkread-ink" }
 inkread-lua = { path = "inkread-lua" }
+inkread-opds = { path = "inkread-opds" }
 inkread-pdftext = { path = "inkread-pdftext" }
 inkread-update = { path = "inkread-update" }
 reader-core = { path = "reader-core" }
@@ -55,6 +56,9 @@ jpeg-decoder = { version = "0.3", default-features = false }
 png = "0.17"
 # inkread-daily (#66): RSS/Atom feed parsing. Pure-Rust pull parser, MIT/Apache, cross-compiles clean.
 quick-xml = "0.41"
+# RSS/Atom/JSON-feed model shared by inkread-daily (#66) and inkread-opds (ADR-INKREAD-0016) — OPDS
+# is Atom plus link relations, and feed-rs already carries each link's rel, media type and length.
+feed-rs = "2.3.1"
 # Legacy text encodings (#159): a great many Russian EPUBs are windows-1251 or koi8-r, and rbook
 # refuses any non-UTF-8 resource outright. encoding_rs is the browser-grade decoder (the one Firefox
 # ships), so this also covers Shift-JIS/Big5/EUC-KR books rather than just the reported one.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ an open [AGPL-3.0](./LICENSE) Rust core you can audit and extend.
   - Add your own custom dictionaries (drop a starter dictionary into `MYSTYLES/SnDict/<name>` and install it in-app)
   - Send a multi-line selection to the **Supernote Digest**
 
+  **Your calibre library**
+  - Browse a **calibre content server** or **Calibre-Web** over its catalog and pull books straight
+    onto your shelf — no cable, no vendor cloud
+  - Search the library, walk it by author or tag, and page through large collections
+  - Picks the format that reads best on e-ink (EPUB before PDF), and says so when it can't open one
+  - Books calibre builds from **news recipes** land in the library, so they arrive the same way
+
   **Export & data**
   - Export annotations as a PDF into a synced folder
   - Overwrite the original PDF in place, or save a separate `-annotated` copy
@@ -117,6 +124,7 @@ an open [AGPL-3.0](./LICENSE) Rust core you can audit and extend.
 | Annotation portability | **Written into the PDF** + portable sidecar | Sidecar metadata | Proprietary, locked-in |
 | Document reading (PDF reflow, dictionary) | Yes | **Mature** | Limited |
 | Daily reading companion (RSS → on-device issue) | **Built-in** (InkRead Daily) | Plugin (NewsDownloader) | No |
+| calibre library over the air | **Built-in** (OPDS: calibre + Calibre-Web) | Plugin (OPDS) | No |
 | E-ink refresh control | Vendor-neutral policy in core ([platform-capped](./docs/EINK-LIMITS.md)) | **Excellent** (on devices that allow it) | Native / vendor-optimal |
 | Extensibility | Native Lua API + selected KOReader-shim | **Huge Lua ecosystem** | None (closed) |
 | Architecture | Rust core, host-testable | C + Lua | Closed-source |

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,13 @@
             android:exported="false"
             android:configChanges="orientation|screenSize|keyboardHidden" />
 
+        <!-- OPDS library browser (ADR-INKREAD-0016, #175) — calibre / Calibre-Web, launched from the
+             Home library card once a server is configured (not exported). -->
+        <activity
+            android:name=".OpdsActivity"
+            android:exported="false"
+            android:configChanges="orientation|screenSize|keyboardHidden" />
+
         <!-- Self-update install callback (ADR-INKREAD-0014): receives the PackageInstaller session
              result and launches the OS install-confirmation intent. Internal only. -->
         <receiver

--- a/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
@@ -15,6 +15,9 @@ object AppSettings {
     private const val KEY_AUTO_INSTALL_UPDATES = "auto_install_updates"
     private const val KEY_UPDATE_SKIP_VERSION = "update_skip_version"
     private const val KEY_UPDATE_LAST_CHECK_MS = "update_last_check_ms"
+    private const val KEY_OPDS_URL = "opds_url"
+    private const val KEY_OPDS_USER = "opds_user"
+    private const val KEY_OPDS_PASSWORD = "opds_password"
 
     private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -79,4 +82,38 @@ object AppSettings {
 
     fun setUpdateLastCheckMs(c: Context, ms: Long) =
         prefs(c).edit().putLong(KEY_UPDATE_LAST_CHECK_MS, ms).apply()
+
+    // ---- OPDS library: calibre content server / Calibre-Web (ADR-INKREAD-0016, #175) ----
+
+    /**
+     * The catalog server's address, as the reader typed it ("" = no library configured, which is
+     * what hides the Home entry). [OpdsController.catalogRoot] normalizes it before use, so a bare
+     * host is fine here.
+     */
+    fun opdsUrl(c: Context): String = prefs(c).getString(KEY_OPDS_URL, "").orEmpty()
+
+    fun setOpdsUrl(c: Context, value: String) =
+        prefs(c).edit().putString(KEY_OPDS_URL, value.trim()).apply()
+
+    /** Basic-auth username; "" when the server allows anonymous access (calibre's default). */
+    fun opdsUser(c: Context): String = prefs(c).getString(KEY_OPDS_USER, "").orEmpty()
+
+    fun setOpdsUser(c: Context, value: String) =
+        prefs(c).edit().putString(KEY_OPDS_USER, value.trim()).apply()
+
+    /**
+     * Basic-auth password, stored **in plain text** like every other preference here.
+     *
+     * That is a deliberate, disclosed choice rather than an oversight (ADR-INKREAD-0016 Decision 4):
+     * on a sideloaded app that already holds MANAGE_EXTERNAL_STORAGE on a single-user device, a
+     * keystore wrapper would raise the effort of an attack who is already inside by approximately
+     * nothing. The Settings screen says so plainly instead of implying a protection that is not there.
+     */
+    fun opdsPassword(c: Context): String = prefs(c).getString(KEY_OPDS_PASSWORD, "").orEmpty()
+
+    fun setOpdsPassword(c: Context, value: String) =
+        prefs(c).edit().putString(KEY_OPDS_PASSWORD, value).apply()
+
+    /** Whether a library is configured at all — gates the Home entry point. */
+    fun opdsConfigured(c: Context): Boolean = opdsUrl(c).isNotBlank()
 }

--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -85,6 +85,16 @@ object Books {
         }
     }
 
+    /**
+     * Where a book downloaded from a catalog is stored (ADR-INKREAD-0016). Unlike [importFrom],
+     * [title] is a *document* title rather than a file name, so it keeps everything before its last
+     * dot — "Vol. 2" must not become "Vol". [ext] falls back to `pdf` on anything the core cannot
+     * open, matching [importExtension]. As with a SAF import, re-downloading the same title
+     * overwrites: the name is the book's identity.
+     */
+    fun destinationFor(context: Context, title: String, ext: String): File =
+        File(dir(context), "${sanitizeStem(title)}.${if (ext in SUPPORTED) ext else "pdf"}")
+
     /** A human title for a stored book file (drop the extension). */
     fun title(file: File): String = file.nameWithoutExtension
 
@@ -215,8 +225,10 @@ object Books {
             .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
             ?.use { c -> if (c.moveToFirst()) c.getString(0) else null }
 
-    private fun sanitize(name: String): String {
-        val stem = name.substringBeforeLast('.').ifBlank { "document" }
-        return stem.replace(Regex("[^A-Za-z0-9 ._-]"), "_").trim().take(80).ifBlank { "document" }
-    }
+    private fun sanitize(name: String): String =
+        sanitizeStem(name.substringBeforeLast('.').ifBlank { "document" })
+
+    /** Make [stem] safe as a file name (no extension handling — see [sanitize]). */
+    private fun sanitizeStem(stem: String): String =
+        stem.replace(Regex("[^A-Za-z0-9 ._-]"), "_").trim().take(80).ifBlank { "document" }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -127,6 +127,13 @@ class HomeActivity : Activity() {
         // The InkRead Daily — the day's issue as a strip card (the design's in-flow Daily entry).
         column.addView(spacer(dim(24)))
         column.addView(dailyCard(contentW))
+        // Your calibre / Calibre-Web library, once one is configured (ADR-INKREAD-0016). Hidden
+        // until then: an entry point to a server you have not set up is a dead end, and Settings is
+        // where you would go looking for it anyway.
+        if (AppSettings.opdsConfigured(this)) {
+            column.addView(spacer(dim(14)))
+            column.addView(libraryCard(contentW))
+        }
         if (recents.size >= 2) {
             column.addView(spacer(dim(28)))
             column.addView(eyebrowItalic("Recently on your shelf"))
@@ -287,6 +294,45 @@ class HomeActivity : Activity() {
             }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
 
             // Right action (WRAP height, centred — not full-height, which made it a black bar).
+            addView(TextView(this@HomeActivity).apply {
+                text = "Open →"; setTextColor(Color.WHITE); textSize = fs(14f)
+                typeface = Typeface.create(serif, Typeface.BOLD); gravity = Gravity.CENTER
+                setPadding(dim(18), dim(10), dim(18), dim(10))
+                background = GradientDrawable().apply { setColor(ink); cornerRadius = dim(6).toFloat() }
+            }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                marginEnd = dim(12)
+            })
+        }
+    }
+
+    // ── Your library — the configured OPDS server as a quiet strip (taps → OpdsActivity) ─────────
+
+    private fun libraryCard(contentW: Int): View {
+        val pad = dim(15)
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            background = outlined(dim(12))
+            isClickable = true
+            setOnClickListener { startActivity(Intent(this@HomeActivity, OpdsActivity::class.java)) }
+            layoutParams = LinearLayout.LayoutParams(contentW, ViewGroup.LayoutParams.WRAP_CONTENT)
+
+            addView(LinearLayout(this@HomeActivity).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(dim(16), pad, dim(12), pad)
+                addView(eyebrow("Your library"))
+                addView(TextView(this@HomeActivity).apply {
+                    text = "Browse and download"
+                    setTextColor(ink); textSize = fs(19f); typeface = serif
+                    setPadding(0, dim(4), 0, 0); maxLines = 1
+                })
+                addView(TextView(this@HomeActivity).apply {
+                    text = AppSettings.opdsUrl(this@HomeActivity)
+                    setTextColor(inkSoft); textSize = fs(13f); typeface = mono
+                    setPadding(0, dim(3), 0, 0); maxLines = 1
+                })
+            }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+
             addView(TextView(this@HomeActivity).apply {
                 text = "Open →"; setTextColor(Color.WHITE); textSize = fs(14f)
                 typeface = Typeface.create(serif, Typeface.BOLD); gravity = Gravity.CENTER

--- a/app/src/main/java/dev/jraghavan/inkread/HttpFetch.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HttpFetch.kt
@@ -1,5 +1,6 @@
 package dev.jraghavan.inkread
 
+import android.util.Base64
 import android.util.Log
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -8,18 +9,39 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 /**
- * The shell's one bounded HTTP GET, shared by the network features (the daily fetch #66 and the
- * self-updater, ADR-INKREAD-0014). The Rust core stays IO-free (IR-7) — every HTTP byte enters here.
+ * The shell's one bounded HTTP GET, shared by the network features (the daily fetch #66, the
+ * self-updater ADR-INKREAD-0014, and the OPDS library ADR-INKREAD-0016 — the only one that
+ * authenticates). The Rust core stays IO-free (IR-7) — every HTTP byte enters here.
  * Both entry points cap the response so a runaway/hostile body can never exhaust memory or disk, and
  * both swallow failures into a `null`/`false` so callers degrade silently (offline ⇒ no-op).
  */
 object HttpFetch {
 
+    /**
+     * Build an HTTP **Basic** `Authorization` value, or `null` when there is no username to send.
+     *
+     * Basic only: Calibre-Web authenticates OPDS this way, and calibre's content server does when
+     * started with `--auth-mode=basic` (its `auto` default resolves to Digest without SSL, which
+     * Android's OkHttp-backed `HttpURLConnection` cannot answer) — see ADR-INKREAD-0016 Decision 4.
+     */
+    fun basicAuth(user: String, password: String): String? {
+        if (user.isBlank()) return null
+        val raw = "$user:$password".toByteArray(Charsets.UTF_8)
+        return "Basic " + Base64.encodeToString(raw, Base64.NO_WRAP)
+    }
+
     /** GET [url] as UTF-8 text, capped at [capBytes]; `null` on blank URL / non-2xx / IO error. */
-    fun getText(url: String, userAgent: String, accept: String?, timeoutMs: Int, capBytes: Int): String? {
+    fun getText(
+        url: String,
+        userAgent: String,
+        accept: String?,
+        timeoutMs: Int,
+        capBytes: Int,
+        authorization: String? = null,
+    ): String? {
         if (url.isBlank()) return null
         return try {
-            val conn = open(url, userAgent, accept, timeoutMs)
+            val conn = open(url, userAgent, accept, timeoutMs, authorization)
             if (conn.responseCode !in 200..299) {
                 Log.w(TAG, "GET $url -> HTTP ${conn.responseCode}")
                 null
@@ -33,10 +55,17 @@ object HttpFetch {
     }
 
     /** Stream [url] to [dest], aborting past [capBytes]; `false` on non-2xx / IO error / oversize. */
-    fun download(url: String, dest: File, userAgent: String, timeoutMs: Int, capBytes: Long): Boolean {
+    fun download(
+        url: String,
+        dest: File,
+        userAgent: String,
+        timeoutMs: Int,
+        capBytes: Long,
+        authorization: String? = null,
+    ): Boolean {
         if (url.isBlank()) return false
         return try {
-            val conn = open(url, userAgent, null, timeoutMs)
+            val conn = open(url, userAgent, null, timeoutMs, authorization)
             if (conn.responseCode !in 200..299) {
                 Log.w(TAG, "download $url -> HTTP ${conn.responseCode}")
                 return false
@@ -64,13 +93,24 @@ object HttpFetch {
         }
     }
 
-    private fun open(url: String, userAgent: String, accept: String?, timeoutMs: Int): HttpURLConnection =
+    private fun open(
+        url: String,
+        userAgent: String,
+        accept: String?,
+        timeoutMs: Int,
+        authorization: String?,
+    ): HttpURLConnection =
         (URL(url).openConnection() as HttpURLConnection).apply {
             connectTimeout = timeoutMs
             readTimeout = timeoutMs
             instanceFollowRedirects = true // GitHub asset URLs 302 to an HTTPS CDN (same-protocol → followed)
             setRequestProperty("User-Agent", userAgent)
             if (accept != null) setRequestProperty("Accept", accept)
+            // Sent pre-emptively rather than waiting for a 401 challenge: it saves a round trip on
+            // every catalog page, and Basic gains nothing from the challenge anyway. The underlying
+            // client drops this header when a redirect changes host, so a redirecting catalog cannot
+            // hand the credential to a third party.
+            if (authorization != null) setRequestProperty("Authorization", authorization)
         }
 
     /** Read up to [cap] bytes (the last chunk may cross it by &lt;64 KiB), then stop. */

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -103,6 +103,15 @@ object NativeBridge {
      *  sha256Url}` (ADR-INKREAD-0014). Junk in -> `{"updateAvailable":false}`. */
     external fun nativeUpdateDecide(installedVersion: String, releaseJson: String): String
 
+    /** Classify a fetched OPDS catalog document into the browse model (ADR-INKREAD-0016, #175).
+     *  Standalone — the shell fetches the catalog and resolves the relative hrefs against the server
+     *  URL; the core only says what is in it. Returns
+     *  `{title,entries:[{kind,title,author,summary,published,href,cover,formats:[{mime,href,bytes,
+     *  ext}]}],next,prev,start,searchTemplate}`, where `kind` is `navigation` or `acquisition`,
+     *  `formats` is ordered best-openable-first, and an empty `ext` means inkread cannot open that
+     *  format. Absent fields are omitted. Junk in -> `{"title":"","entries":[]}`. */
+    external fun nativeOpdsParseCatalog(xml: String): String
+
     /**
      * Render the current page into [directBuffer] — a DIRECT [ByteBuffer] of exactly
      * `width*height*4` bytes (RGBA). The core borrows it for the call only (Amendment 5).

--- a/app/src/main/java/dev/jraghavan/inkread/OpdsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/OpdsActivity.kt
@@ -51,7 +51,14 @@ class OpdsActivity : Activity() {
     private val trail = ArrayDeque<String>()
 
     private var current: OpdsController.Catalog? = null
+
+    /** The feed currently shown — the thing pushed onto [trail] when we walk one level deeper. */
+    private var currentUrl: String? = null
     private var busy: Dialog? = null
+
+    /** Network results arrive after the screen may already have closed; nothing may touch the UI
+     *  then (a dialog on a dead window throws). Every posted handler checks this first. */
+    private val gone: Boolean get() = isFinishing || isDestroyed
 
     private lateinit var column: LinearLayout
 
@@ -75,6 +82,9 @@ class OpdsActivity : Activity() {
     override fun onDestroy() {
         super.onDestroy()
         io.shutdownNow()
+        // A fetch in flight when the screen closes would otherwise leave its busy dialog attached to
+        // a dead window (and the posted result would try to show another on top of it).
+        dismissBusy()
     }
 
     /**
@@ -98,6 +108,7 @@ class OpdsActivity : Activity() {
         io.execute {
             val catalog = opds.fetchCatalog(url)
             main.post {
+                if (gone) return@post
                 dismissBusy()
                 if (catalog == null) {
                     render(
@@ -114,8 +125,6 @@ class OpdsActivity : Activity() {
             }
         }
     }
-
-    private var currentUrl: String? = null
 
     // ── rendering ────────────────────────────────────────────────────────────────────────────────
 
@@ -207,6 +216,7 @@ class OpdsActivity : Activity() {
         io.execute {
             val file = opds.download(entry, format)
             main.post {
+                if (gone) return@post
                 dismissBusy()
                 if (file == null) {
                     Toast.makeText(this, "Download failed", Toast.LENGTH_SHORT).show()
@@ -267,6 +277,7 @@ class OpdsActivity : Activity() {
 
     private fun showBusy(message: String) {
         dismissBusy()
+        if (isFinishing || isDestroyed) return
         busy = Ink.progressDialog(this, message)
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/OpdsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/OpdsActivity.kt
@@ -1,0 +1,277 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Intent
+import android.graphics.Typeface
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import android.widget.Toast
+import java.util.concurrent.Executors
+
+/**
+ * **Your library** — browsing a calibre content server or Calibre-Web over OPDS
+ * (ADR-INKREAD-0016, #175). One screen, one job: walk the catalog, then bring a book onto the shelf.
+ *
+ * The shape follows the catalog rather than inventing one. A feed is a list of rows that are either
+ * *navigation* (another feed: by author, by tag, recent) or *acquisition* (a book), so the screen is
+ * a list of rows, a back stack of the feeds walked into, and a Next control when the server pages.
+ * Deliberately typographic and flat like [DailyActivity] and [HomeActivity] — no covers are fetched,
+ * because a grid of images on a panel that repaints in whole frames costs a great deal of flashing
+ * for very little; the title and author are what you choose a book by anyway.
+ *
+ * Network work runs on a single background thread and posts results back; the screen shows what it
+ * is doing, and a failure says so in place rather than leaving an empty list looking like an empty
+ * library.
+ */
+class OpdsActivity : Activity() {
+
+    private val density get() = resources.displayMetrics.density
+    private fun dp(v: Int) = (v * density).toInt()
+
+    private val serif = Ink.serif
+    private val serifItalic = Ink.serifItalic
+    private val mono = Ink.mono
+    private val ink = Ink.ink
+
+    private val opds by lazy { OpdsController(this) }
+    private val io = Executors.newSingleThreadExecutor()
+    private val main = Handler(Looper.getMainLooper())
+
+    /** The feeds walked into, so Back steps out one level instead of leaving the library. */
+    private val trail = ArrayDeque<String>()
+
+    private var current: OpdsController.Catalog? = null
+    private var busy: Dialog? = null
+
+    private lateinit var column: LinearLayout
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Ink.uiScale = DisplayPrefs(this).uiScale
+        column = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(22), dp(20), dp(22), dp(28))
+        }
+        setContentView(ScrollView(this).apply { isFillViewport = true; addView(column) })
+
+        val root = OpdsController.catalogRoot(AppSettings.opdsUrl(this))
+        if (root.isEmpty()) {
+            render(message = "No library is set up yet.\n\nAdd your calibre or Calibre-Web address in Settings → Library.")
+            return
+        }
+        load(root, pushTrail = false)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        io.shutdownNow()
+    }
+
+    /**
+     * Back steps out of the feed we walked into; at the top it leaves the library as usual.
+     *
+     * Deprecated upstream in favour of `OnBackInvokedCallback`, which is API 33 — the Supernote runs
+     * Android 11 (API 30), and the app does not depend on androidx.activity for its dispatcher
+     * back-port. This override is the mechanism that actually exists on the target device.
+     */
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    override fun onBackPressed() {
+        val previous = trail.removeLastOrNull()
+        if (previous == null) super.onBackPressed() else load(previous, pushTrail = false)
+    }
+
+    // ── loading ──────────────────────────────────────────────────────────────────────────────────
+
+    private fun load(url: String, pushTrail: Boolean) {
+        val from = currentUrl
+        showBusy("Opening the library…")
+        io.execute {
+            val catalog = opds.fetchCatalog(url)
+            main.post {
+                dismissBusy()
+                if (catalog == null) {
+                    render(
+                        message = "Could not reach the library.\n\nCheck that the server is running " +
+                            "and reachable from this device. If it asks for a login, calibre must be " +
+                            "started with --auth-mode=basic.",
+                    )
+                    return@post
+                }
+                if (pushTrail && from != null) trail.addLast(from)
+                currentUrl = url
+                current = catalog
+                render()
+            }
+        }
+    }
+
+    private var currentUrl: String? = null
+
+    // ── rendering ────────────────────────────────────────────────────────────────────────────────
+
+    private fun render(message: String? = null) {
+        column.removeAllViews()
+        column.addView(header(current?.title?.ifBlank { null } ?: "Your library"))
+
+        if (message != null) {
+            column.addView(note(message))
+            return
+        }
+        val catalog = current ?: return
+
+        if (catalog.searchTemplate.isNotEmpty()) column.addView(searchRow(catalog.searchTemplate))
+
+        if (catalog.entries.isEmpty()) {
+            column.addView(note("Nothing here."))
+        } else {
+            for (entry in catalog.entries) column.addView(row(entry))
+        }
+        if (catalog.next.isNotEmpty()) {
+            column.addView(spacer(dp(18)))
+            column.addView(Ink.pillButton(this, "More →", primary = false) { load(catalog.next, pushTrail = true) })
+        }
+    }
+
+    private fun header(title: String): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        addView(Ink.eyebrow(this@OpdsActivity, "Library"))
+        addView(TextView(this@OpdsActivity).apply {
+            text = title
+            setTextColor(ink); textSize = Ink.sp(28f); typeface = serif
+            setPadding(0, dp(4), 0, dp(2))
+        })
+        addView(Ink.rule(this@OpdsActivity))
+        addView(spacer(dp(14)))
+    }
+
+    /** A catalog row. Navigation walks in; a book offers its best openable format. */
+    private fun row(entry: OpdsController.Entry): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        setPadding(0, dp(12), 0, dp(12))
+        isClickable = true
+        setOnClickListener { onRowTapped(entry) }
+
+        addView(TextView(this@OpdsActivity).apply {
+            text = entry.title.ifBlank { "Untitled" }
+            setTextColor(ink); textSize = Ink.sp(18f); typeface = serif
+            maxLines = 3; setLineSpacing(0f, 1.1f)
+        })
+        if (entry.author.isNotEmpty()) {
+            addView(TextView(this@OpdsActivity).apply {
+                text = entry.author
+                setTextColor(Ink.inkSoft); textSize = Ink.sp(14f); typeface = serifItalic
+                setPadding(0, dp(3), 0, 0); maxLines = 2
+            })
+        }
+        addView(TextView(this@OpdsActivity).apply {
+            text = subtitleFor(entry)
+            setTextColor(Ink.muted); textSize = Ink.sp(11f); typeface = mono; letterSpacing = 0.08f
+            setPadding(0, dp(5), 0, 0)
+        })
+        addView(Ink.rule(this@OpdsActivity))
+    }
+
+    /**
+     * The one-line status under a row: where it leads, or what would be downloaded. A book whose
+     * formats inkread cannot open says so here rather than failing on the tap.
+     */
+    private fun subtitleFor(entry: OpdsController.Entry): String {
+        if (entry.navigation) return "BROWSE →"
+        val best = entry.best
+            ?: return "UNSUPPORTED FORMAT" + entry.formats.firstOrNull()?.let { " · ${it.mime}" }.orEmpty()
+        val size = if (best.bytes > 0) " · ${best.bytes / 1024 / 1024} MB" else ""
+        return "DOWNLOAD ${best.ext.uppercase()}$size"
+    }
+
+    private fun onRowTapped(entry: OpdsController.Entry) {
+        if (entry.navigation) {
+            if (entry.href.isEmpty()) return
+            load(entry.href, pushTrail = true)
+            return
+        }
+        val format = entry.best ?: run {
+            Toast.makeText(this, "inkread can't open any format of this book", Toast.LENGTH_SHORT).show()
+            return
+        }
+        showBusy("Downloading ${entry.title}…")
+        io.execute {
+            val file = opds.download(entry, format)
+            main.post {
+                dismissBusy()
+                if (file == null) {
+                    Toast.makeText(this, "Download failed", Toast.LENGTH_SHORT).show()
+                } else {
+                    offerToRead(entry.title, file.absolutePath, file.name)
+                }
+            }
+        }
+    }
+
+    /** A downloaded book is on the shelf either way; this just saves a trip back to Home to open it. */
+    private fun offerToRead(title: String, path: String, id: String) {
+        AlertDialog.Builder(this)
+            .setTitle("Added to your shelf")
+            .setMessage("$title is now on your shelf.")
+            .setPositiveButton("Read now") { _, _ ->
+                startActivity(
+                    Intent(this, ReaderActivity::class.java)
+                        .putExtra(ReaderActivity.EXTRA_BOOK_PATH, path)
+                        .putExtra(ReaderActivity.EXTRA_BOOK_ID, id),
+                )
+            }
+            .setNegativeButton("Keep browsing", null)
+            .show()
+    }
+
+    // ── search ───────────────────────────────────────────────────────────────────────────────────
+
+    private fun searchRow(template: String): View = LinearLayout(this).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(0, 0, 0, dp(10))
+        val field = EditText(this@OpdsActivity).apply {
+            hint = "Search the library"
+            setTextColor(ink); textSize = Ink.sp(15f); typeface = serif
+            setSingleLine()
+        }
+        addView(field, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+        addView(Ink.pillButton(this@OpdsActivity, "Find", primary = true) {
+            val url = OpdsController.searchUrl(template, field.text.toString())
+            if (url.isNotEmpty()) load(url, pushTrail = true)
+        })
+    }
+
+    // ── chrome ───────────────────────────────────────────────────────────────────────────────────
+
+    private fun note(text: String): View = TextView(this).apply {
+        this.text = text
+        setTextColor(Ink.inkSoft); textSize = Ink.sp(15f)
+        typeface = Typeface.create(serif, Typeface.NORMAL)
+        setLineSpacing(0f, 1.25f)
+        setPadding(0, dp(18), 0, 0)
+    }
+
+    private fun spacer(h: Int): View = View(this).apply {
+        layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, h)
+    }
+
+    private fun showBusy(message: String) {
+        dismissBusy()
+        busy = Ink.progressDialog(this, message)
+    }
+
+    private fun dismissBusy() {
+        runCatching { busy?.dismiss() }
+        busy = null
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/OpdsController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/OpdsController.kt
@@ -1,0 +1,207 @@
+package dev.jraghavan.inkread
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.net.URL
+import java.net.URLEncoder
+
+/**
+ * The OPDS library client's shell half (ADR-INKREAD-0016, #175): fetch a catalog document, hand it
+ * to the core to classify, resolve the relative hrefs it returns, and download a chosen book into
+ * the shelf.
+ *
+ * The split follows the daily companion (#66) and the self-updater (ADR-INKREAD-0014): the core is
+ * pure and knows nothing about the server, while everything here is I/O and URLs. Reaching a
+ * catalog server means [fetchCatalog] and [download] block — call them off the UI thread.
+ *
+ * The URL work lives in [Companion] as pure functions because that is where this class can actually
+ * go wrong: a mis-resolved relative href walks off the server, and a mis-encoded search term
+ * silently returns nothing. Those are host-tested; the catalog semantics are tested in Rust.
+ */
+class OpdsController(private val context: Context) {
+
+    /** A book format offered by the catalog. [ext] is empty when inkread cannot open it. */
+    data class Format(val mime: String, val href: String, val bytes: Long, val ext: String) {
+        val openable: Boolean get() = ext.isNotEmpty()
+    }
+
+    /** One catalog row: either a link to another feed, or a book to download. */
+    data class Entry(
+        val navigation: Boolean,
+        val title: String,
+        val author: String,
+        val summary: String,
+        val published: String,
+        /** Absolute URL — of the next feed for a navigation entry, empty for a book. */
+        val href: String,
+        val cover: String,
+        val formats: List<Format>,
+    ) {
+        /** The format to download by default: the first the reader can open, or null if none can. */
+        val best: Format? get() = formats.firstOrNull { it.openable }
+    }
+
+    /** One fetched feed, with its hrefs already resolved to absolute URLs. */
+    data class Catalog(
+        val title: String,
+        val entries: List<Entry>,
+        val next: String,
+        val prev: String,
+        val start: String,
+        val searchTemplate: String,
+    )
+
+    /**
+     * Fetch [url] and classify it. Returns null when the server is unreachable, refuses us, or
+     * answers with something that is not a catalog — the caller shows the failure; a null here is
+     * never a crash.
+     */
+    fun fetchCatalog(url: String): Catalog? {
+        if (!isHttpUrl(url)) return null
+        val xml = HttpFetch.getText(url, USER_AGENT, ACCEPT, TIMEOUT_MS, MAX_CATALOG_BYTES, auth())
+            ?: return null
+        val json = runCatching { NativeBridge.nativeOpdsParseCatalog(xml) }.getOrElse {
+            Log.e(TAG, "catalog parse failed: ${it.message}")
+            return null
+        }
+        return runCatching { parseCatalog(json, url) }.getOrElse {
+            Log.e(TAG, "catalog decode failed: ${it.message}")
+            null
+        }
+    }
+
+    /**
+     * Download [format] of [entry] into the shelf, returning the stored file (or null on failure).
+     * The catalog's own title names the file, because an acquisition URL generally carries no
+     * usable name of its own; the format's extension is what the core dispatches a backend on.
+     */
+    fun download(entry: Entry, format: Format): File? {
+        if (!format.openable || !isHttpUrl(format.href)) return null
+        val dest = Books.destinationFor(context, entry.title.ifBlank { "document" }, format.ext)
+        val ok = HttpFetch.download(format.href, dest, USER_AGENT, TIMEOUT_MS, MAX_BOOK_BYTES, auth())
+        if (!ok) {
+            dest.delete() // never leave a partial book on the shelf pretending to be readable
+            return null
+        }
+        return dest
+    }
+
+    /** The configured server's Basic credential, or null when the server needs no login. */
+    private fun auth(): String? =
+        HttpFetch.basicAuth(AppSettings.opdsUser(context), AppSettings.opdsPassword(context))
+
+    /** Turn the core's catalog JSON into the model, resolving every href against [base]. */
+    private fun parseCatalog(json: String, base: String): Catalog {
+        val root = JSONObject(json)
+        val entriesJson = root.optJSONArray("entries")
+        val entries = buildList {
+            for (i in 0 until (entriesJson?.length() ?: 0)) {
+                val e = entriesJson!!.getJSONObject(i)
+                val formatsJson = e.optJSONArray("formats")
+                val formats = buildList {
+                    for (j in 0 until (formatsJson?.length() ?: 0)) {
+                        val f = formatsJson!!.getJSONObject(j)
+                        val href = resolve(base, f.optString("href"))
+                        if (href.isNotEmpty()) {
+                            add(
+                                Format(
+                                    mime = f.optString("mime"),
+                                    href = href,
+                                    bytes = f.optLong("bytes", 0L),
+                                    ext = f.optString("ext"),
+                                ),
+                            )
+                        }
+                    }
+                }
+                add(
+                    Entry(
+                        navigation = e.optString("kind") == "navigation",
+                        title = e.optString("title"),
+                        author = e.optString("author"),
+                        summary = e.optString("summary"),
+                        published = e.optString("published"),
+                        href = resolve(base, e.optString("href")),
+                        cover = resolve(base, e.optString("cover")),
+                        formats = formats,
+                    ),
+                )
+            }
+        }
+        return Catalog(
+            title = root.optString("title"),
+            entries = entries,
+            next = resolve(base, root.optString("next")),
+            prev = resolve(base, root.optString("prev")),
+            start = resolve(base, root.optString("start")),
+            // Left as a template (its {searchTerms} placeholder intact) — resolved, not substituted.
+            searchTemplate = resolve(base, root.optString("searchTemplate")),
+        )
+    }
+
+    companion object {
+        private const val TAG = "Opds"
+
+        /** Named so a server's logs show who called; catalogs sometimes vary by client. */
+        const val USER_AGENT = "inkread"
+
+        /** OPDS catalogs are Atom; ask for it explicitly so a server does not hand us its HTML UI. */
+        private const val ACCEPT = "application/atom+xml, application/xml;q=0.9, */*;q=0.1"
+
+        private const val TIMEOUT_MS = 15_000
+
+        /** A catalog page is text; a server sending far more than this is not sending a page. */
+        private const val MAX_CATALOG_BYTES = 4 * 1024 * 1024
+
+        /** Matches the shelf's own import cap (the core refuses larger documents at open anyway). */
+        private const val MAX_BOOK_BYTES = 2L shl 30
+
+        /**
+         * Resolve [href] against [base] into an absolute URL, or "" when it is absent or does not
+         * survive the check.
+         *
+         * The scheme test is the point: a catalog is a remote party naming the next thing we fetch,
+         * and `file:`, `jar:` or `content:` in that position would turn a browse into a local read.
+         * Resolution itself is delegated to [URL], which already implements RFC 3986 — hand-rolling
+         * that would be new, subtle, security-relevant code for nothing.
+         */
+        fun resolve(base: String, href: String): String {
+            if (href.isBlank()) return ""
+            return runCatching {
+                val resolved = URL(URL(base), href).toString()
+                if (isHttpUrl(resolved)) resolved else ""
+            }.getOrDefault("")
+        }
+
+        /** Only `http`/`https` are ever fetched — see [resolve]. */
+        fun isHttpUrl(url: String): Boolean {
+            val lower = url.trim().lowercase()
+            return lower.startsWith("http://") || lower.startsWith("https://")
+        }
+
+        /**
+         * Substitute [terms] into an OpenSearch [template]'s `{searchTerms}` placeholder.
+         *
+         * `+` is *not* a space outside a query string, and calibre's template puts the terms in a
+         * path segment (`/opds/search/{searchTerms}`), so the `+` that [URLEncoder] emits would be
+         * searched for literally. Percent-encoding instead is correct in both positions.
+         */
+        fun searchUrl(template: String, terms: String): String {
+            if (template.isBlank() || terms.isBlank()) return ""
+            val encoded = URLEncoder.encode(terms, "UTF-8").replace("+", "%20")
+            return template.replace("{searchTerms}", encoded)
+        }
+
+        /** The user's server address, normalized to the catalog root the browse screen starts at. */
+        fun catalogRoot(serverUrl: String): String {
+            val trimmed = serverUrl.trim().trimEnd('/')
+            if (trimmed.isEmpty()) return ""
+            val withScheme = if (isHttpUrl(trimmed)) trimmed else "http://$trimmed"
+            // A bare host is the common way people write it down; both calibre and Calibre-Web
+            // serve the catalog at /opds, so complete it rather than making the user know that.
+            return if (URL(withScheme).path.trimEnd('/').isEmpty()) "$withScheme/opds" else withScheme
+        }
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/OpdsController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/OpdsController.kt
@@ -76,13 +76,19 @@ class OpdsController(private val context: Context) {
      * Download [format] of [entry] into the shelf, returning the stored file (or null on failure).
      * The catalog's own title names the file, because an acquisition URL generally carries no
      * usable name of its own; the format's extension is what the core dispatches a backend on.
+     *
+     * Downloads land in a temp file and are renamed into place only once complete. Writing straight
+     * to the destination would truncate it on open, so a re-download that then failed — a dropped
+     * Wi-Fi mid-transfer is the ordinary case here — would destroy the perfectly good copy already
+     * on the shelf, with annotations attached to it. A failed download must cost nothing.
      */
     fun download(entry: Entry, format: Format): File? {
         if (!format.openable || !isHttpUrl(format.href)) return null
         val dest = Books.destinationFor(context, entry.title.ifBlank { "document" }, format.ext)
-        val ok = HttpFetch.download(format.href, dest, USER_AGENT, TIMEOUT_MS, MAX_BOOK_BYTES, auth())
-        if (!ok) {
-            dest.delete() // never leave a partial book on the shelf pretending to be readable
+        val partial = File(dest.parentFile, "${dest.name}.part")
+        val ok = HttpFetch.download(format.href, partial, USER_AGENT, TIMEOUT_MS, MAX_BOOK_BYTES, auth())
+        if (!ok || !partial.renameTo(dest)) {
+            partial.delete() // never leave a partial book on the shelf pretending to be readable
             return null
         }
         return dest

--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -319,6 +319,7 @@ class SettingsActivity : Activity() {
         val HELP = listOf(
             "Pen & Highlighter" to "Write and highlight on the page with the stylus; the floating tool palette switches between them.",
             "Eraser" to "Switch to the eraser in the tool palette to wipe strokes — or, if your pen has an eraser end, just flip it over.",
+            "Your library" to "Connect a calibre content server or Calibre-Web under Library, then browse it from Home and download books onto your shelf.",
             "Lasso select" to "Circle ink or text to move, copy, delete, or look it up.",
             "Define" to "Select a word and tap Define to look it up in the on-device dictionaries.",
             "Search" to "Find text anywhere in the document and jump between matches.",

--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -117,6 +117,22 @@ class SettingsActivity : Activity() {
         column.addView(spacer(dp(18)))
         column.addView(actionRow("Check for updates now") { UpdateGate.checkNow(this) })
 
+        // ── Library (ADR-INKREAD-0016) ─────────────────────────────────────────────
+        column.addView(spacer(dp(34)))
+        column.addView(eyebrow("Library"))
+        column.addView(spacer(dp(12)))
+        column.addView(
+            actionRow(
+                if (AppSettings.opdsConfigured(this)) AppSettings.opdsUrl(this) else "Connect a calibre library",
+            ) { onLibraryTapped() },
+        )
+        column.addView(TextView(this).apply {
+            text = "Browse a calibre content server or Calibre-Web over its catalog and pull books " +
+                "straight onto your shelf. Books calibre builds from news recipes arrive the same way."
+            setTextColor(inkSoft); textSize = 14f; typeface = serif
+            setPadding(0, dp(6), 0, 0); setLineSpacing(0f, 1.2f)
+        })
+
         // ── How it works ───────────────────────────────────────────────────────────
         column.addView(spacer(dp(34)))
         column.addView(eyebrow("How it works"))
@@ -180,6 +196,58 @@ class SettingsActivity : Activity() {
     // ── Pieces ──────────────────────────────────────────────────────────────────────
 
     /** A tappable action with a title on the left and an outlined affordance pill on the right. */
+    /**
+     * Server address + optional login for the OPDS library (ADR-INKREAD-0016). Three plain fields:
+     * a bare host is fine, since [OpdsController.catalogRoot] completes the scheme and the `/opds`
+     * path. The password note is not boilerplate — it is stored in plain text and the reader is
+     * entitled to know that before typing one in (Decision 4).
+     */
+    private fun onLibraryTapped() {
+        val pad = dp(20)
+        val url = android.widget.EditText(this).apply {
+            hint = "192.168.1.20:8080"
+            setText(AppSettings.opdsUrl(this@SettingsActivity)); setSingleLine()
+        }
+        val user = android.widget.EditText(this).apply {
+            hint = "Username (leave blank if none)"
+            setText(AppSettings.opdsUser(this@SettingsActivity)); setSingleLine()
+        }
+        val password = android.widget.EditText(this).apply {
+            hint = "Password"
+            setText(AppSettings.opdsPassword(this@SettingsActivity)); setSingleLine()
+            inputType = android.text.InputType.TYPE_CLASS_TEXT or
+                android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD
+        }
+        val body = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(pad, dp(8), pad, 0)
+            addView(url); addView(user); addView(password)
+            addView(TextView(this@SettingsActivity).apply {
+                text = "The password is stored on this device in plain text. calibre only accepts a " +
+                    "login like this when started with --auth-mode=basic; Calibre-Web works as is."
+                setTextColor(textMuted); textSize = 12f; typeface = mono
+                setPadding(0, dp(12), 0, 0); setLineSpacing(0f, 1.25f)
+            })
+        }
+        AlertDialog.Builder(this)
+            .setTitle("Your library")
+            .setView(body)
+            .setPositiveButton("Save") { _, _ ->
+                AppSettings.setOpdsUrl(this, url.text.toString())
+                AppSettings.setOpdsUser(this, user.text.toString())
+                AppSettings.setOpdsPassword(this, password.text.toString())
+                refresh()
+            }
+            .setNeutralButton("Forget") { _, _ ->
+                AppSettings.setOpdsUrl(this, "")
+                AppSettings.setOpdsUser(this, "")
+                AppSettings.setOpdsPassword(this, "")
+                refresh()
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
     private fun actionRow(title: String, onTap: () -> Unit): View =
         LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL

--- a/app/src/test/java/dev/jraghavan/inkread/OpdsUrlTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/OpdsUrlTest.kt
@@ -1,0 +1,139 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for [OpdsController]'s URL handling (ADR-INKREAD-0016, #175).
+ *
+ * This is the half of the client that can go wrong quietly: a catalog hands us relative hrefs and we
+ * turn them into the next thing the app fetches, so a bad resolution walks off the server and a bad
+ * encoding searches for the wrong string. The catalog *semantics* are tested in Rust
+ * (`inkread-opds`); what is left here is URLs, which is plain `java.net` and needs no device.
+ */
+class OpdsUrlTest {
+
+    private val base = "http://192.168.1.20:8080/opds"
+
+    // ---- resolve ----
+
+    @Test
+    fun absolutePathsResolveAgainstTheServerRoot() {
+        assertEquals(
+            "http://192.168.1.20:8080/get/EPUB/42/lib",
+            OpdsController.resolve(base, "/get/EPUB/42/lib"),
+        )
+    }
+
+    @Test
+    fun relativePathsResolveAgainstTheFeed() {
+        assertEquals(
+            "http://192.168.1.20:8080/navcatalog/616263",
+            OpdsController.resolve(base, "navcatalog/616263"),
+        )
+    }
+
+    @Test
+    fun anAbsoluteUrlIsKeptAsIs() {
+        val other = "https://books.example.org/opds/page/2"
+        assertEquals(other, OpdsController.resolve(base, other))
+    }
+
+    @Test
+    fun queryStringsAndPortsSurvive() {
+        assertEquals(
+            "http://192.168.1.20:8080/opds/navcatalog/4e?offset=25",
+            OpdsController.resolve(base, "/opds/navcatalog/4e?offset=25"),
+        )
+    }
+
+    @Test
+    fun anAbsentHrefResolvesToEmpty() {
+        assertEquals("", OpdsController.resolve(base, ""))
+        assertEquals("", OpdsController.resolve(base, "   "))
+    }
+
+    @Test
+    fun nonHttpSchemesAreRefused() {
+        // The catalog is a remote party naming what we fetch next. These would turn a browse into a
+        // local read, so resolution must drop them rather than hand them to the fetcher.
+        for (hostile in listOf(
+            "file:///data/data/dev.jraghavan.inkread/shared_prefs/settings.xml",
+            "jar:file:///tmp/x.jar!/y",
+            "content://com.android.providers/downloads",
+            "javascript:alert(1)",
+        )) {
+            assertEquals("refused: $hostile", "", OpdsController.resolve(base, hostile))
+        }
+    }
+
+    @Test
+    fun aGarbageBaseDoesNotThrow() {
+        assertEquals("", OpdsController.resolve("not a url", "/opds"))
+    }
+
+    // ---- isHttpUrl ----
+
+    @Test
+    fun onlyHttpAndHttpsAreFetchable() {
+        assertTrue(OpdsController.isHttpUrl("http://a/b"))
+        assertTrue(OpdsController.isHttpUrl("HTTPS://A/B"))
+        assertFalse(OpdsController.isHttpUrl("ftp://a/b"))
+        assertFalse(OpdsController.isHttpUrl(""))
+        assertFalse(OpdsController.isHttpUrl("//a/b"))
+    }
+
+    // ---- searchUrl ----
+
+    @Test
+    fun searchTermsArePercentEncodedNotPlusEncoded() {
+        // calibre's template puts the terms in a PATH segment, where "+" is a literal plus. Getting
+        // this wrong returns no results rather than failing loudly, so it is worth pinning.
+        assertEquals(
+            "/opds/search/le%20guin",
+            OpdsController.searchUrl("/opds/search/{searchTerms}", "le guin"),
+        )
+    }
+
+    @Test
+    fun searchTermsWithReservedCharactersAreEscaped() {
+        val url = OpdsController.searchUrl("/opds/search/{searchTerms}", "sci-fi & fantasy/short")
+        assertFalse("no bare ampersand", url.contains("&"))
+        assertFalse("no bare slash in the term", url.removePrefix("/opds/search/").contains("/"))
+    }
+
+    @Test
+    fun searchWithoutATemplateOrTermsYieldsNothing() {
+        assertEquals("", OpdsController.searchUrl("", "x"))
+        assertEquals("", OpdsController.searchUrl("/opds/search/{searchTerms}", ""))
+    }
+
+    // ---- catalogRoot ----
+
+    @Test
+    fun aBareHostGetsTheSchemeAndTheCatalogPath() {
+        // What people actually write down is "192.168.1.20:8080"; both servers publish the catalog
+        // at /opds, so completing it is knowledge the app should hold, not the reader.
+        assertEquals("http://192.168.1.20:8080/opds", OpdsController.catalogRoot("192.168.1.20:8080"))
+        assertEquals("http://calibre.local/opds", OpdsController.catalogRoot("http://calibre.local"))
+        assertEquals("https://books.example.org/opds", OpdsController.catalogRoot("https://books.example.org/"))
+    }
+
+    @Test
+    fun anExplicitPathIsRespected() {
+        // Calibre-Web behind a reverse proxy is commonly mounted on a sub-path; never clobber it.
+        assertEquals(
+            "https://example.org/calibre/opds",
+            OpdsController.catalogRoot("https://example.org/calibre/opds"),
+        )
+        assertEquals("http://host/custom", OpdsController.catalogRoot("http://host/custom/"))
+    }
+
+    @Test
+    fun anEmptyAddressYieldsNothing() {
+        assertEquals("", OpdsController.catalogRoot(""))
+        assertEquals("", OpdsController.catalogRoot("   "))
+    }
+}

--- a/docs/RELEASE-SMOKE-CHECKLIST.md
+++ b/docs/RELEASE-SMOKE-CHECKLIST.md
@@ -83,6 +83,19 @@ Tick a step only when the expected result is observed. Any failure blocks the ta
 | 7.2 | Open a Daily article → bottom bar → "Daily" | Returns to the issue's front page | primary |
 | 7.3 | Settings → check for updates (on a production-signed install) | Finds/declines the latest release correctly; a debug-signed build reports the updater inert (signer gate fails closed) | primary |
 
+## 7b. Calibre library (OPDS, needs a calibre content server or Calibre-Web on the LAN)
+
+| # | Action | Expect | Devices |
+|---|--------|--------|---------|
+| 7b.1 | Settings → Library; enter a bare host (e.g. `192.168.1.20:8080`); save | Home grows a "Your library" card showing that address | primary |
+| 7b.2 | Tap the card | The library's top-level feed lists rows; navigation rows read BROWSE →, books read DOWNLOAD EPUB | primary |
+| 7b.3 | Walk into a category, then press Back | Returns to the previous feed, not out of the library | primary |
+| 7b.4 | Search for a title with a space in it | Matches come back (percent-encoded path, not `+`) | primary |
+| 7b.5 | Download a book, then "Read now" | Opens in the reader; it is also on the Home shelf afterwards | primary |
+| 7b.6 | Re-download the same book, then kill Wi-Fi mid-transfer | The already-shelved copy still opens — a failed download costs nothing (#175) | primary |
+| 7b.7 | Point at a server that is off / wrong | Says it could not reach the library and names `--auth-mode=basic`; no crash, no empty-looking library | primary |
+| 7b.8 | On a Calibre-Web instance with a login, set username + password | Catalog loads (Basic auth); wrong credentials fail with the same clear notice | primary |
+
 ## 8. Lifecycle & stability
 
 | # | Action | Expect | Devices |

--- a/inkread-daily/Cargo.toml
+++ b/inkread-daily/Cargo.toml
@@ -21,7 +21,7 @@ ego-tree = "0.11"
 # JSON at the JNI boundary: the shell hands the core a fetched issue (sources + article HTML) as JSON.
 serde = { workspace = true }
 serde_json = { workspace = true }
-feed-rs = "2.3.1"
+feed-rs = { workspace = true }
 
 [dev-dependencies]
 # Round-trip the assembled issue through the real EPUB parser the reader uses, so a malformed

--- a/inkread-opds/Cargo.toml
+++ b/inkread-opds/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "inkread-opds"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "inkread-opds (ADR-INKREAD-0016): turn an OPDS catalog document into the browse/download model the reader shell renders. Pure, host-testable, IO- and vendor-free (IR-7) — the Android shell does the fetch, the URL resolution, and the download."
+
+[dependencies]
+# OPDS 1.2 *is* Atom with extra link relations, and feed-rs already models a link's rel, media type
+# and length — every field the classification needs. Reused from inkread-daily rather than adding a
+# second XML parser (REUSE-FIRST); malformed input yields an empty catalog, never an error.
+feed-rs = { workspace = true }
+# The catalog crosses the JNI boundary as JSON, the same string contract inkread-daily and
+# inkread-update use.
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/inkread-opds/src/lib.rs
+++ b/inkread-opds/src/lib.rs
@@ -1,0 +1,286 @@
+//! `inkread-opds` (ADR-INKREAD-0016): the **classification** half of the OPDS library client.
+//!
+//! Readers keep their books in a catalog server and want them on the device without a cable. The
+//! Android shell fetches an OPDS document and hands the XML to this crate, which turns it into the
+//! browse model the shelf renders: which entries lead to another feed, which entries are books,
+//! which of a book's formats the reader can actually open, and where the paging/search links go.
+//!
+//! Everything here is **pure**: no network, no clock, no host string, no product name (IR-7). The
+//! shell owns the server address, resolves relative hrefs against it, and does every byte of I/O.
+//!
+//! OPDS 1.2 is Atom with extra link relations, so [`feed_rs`] does the parsing (the same dependency
+//! `inkread-daily` uses) and this crate supplies the OPDS meaning on top. The public surface is the
+//! string-in/string-out [`parse_catalog_json`], matching the `parse_feed_json` / `decide` contract
+//! the other crates expose over the same JNI bridge.
+
+use feed_rs::model::{Entry, Link};
+use serde::Serialize;
+
+/// Parse an OPDS document into the catalog JSON the shell renders (the JNI-friendly form of
+/// [`parse_catalog`]).
+///
+/// Any unusable input — malformed XML, a non-feed document, an empty body — yields a catalog with
+/// no entries rather than an error (RR21-FR3: junk in → benign out).
+#[must_use]
+pub fn parse_catalog_json(xml: &str) -> String {
+    serde_json::to_string(&parse_catalog(xml)).unwrap_or_else(|_| Catalog::EMPTY_JSON.to_string())
+}
+
+/// Parse an OPDS document into a [`Catalog`]. Tolerant of malformed input (see
+/// [`parse_catalog_json`]).
+#[must_use]
+pub fn parse_catalog(xml: &str) -> Catalog {
+    let feed = match feed_rs::parser::parse(xml.as_bytes()) {
+        Ok(f) => f,
+        Err(_) => return Catalog::default(),
+    };
+    Catalog {
+        title: feed
+            .title
+            .map(|t| t.content.trim().to_string())
+            .unwrap_or_default(),
+        next: feed_href(&feed.links, &["next"]),
+        prev: feed_href(&feed.links, &["previous", "prev"]),
+        start: feed_href(&feed.links, &["start"]),
+        search_template: feed_href(&feed.links, &["search"]),
+        entries: feed.entries.into_iter().map(catalog_entry).collect(),
+    }
+}
+
+/// One OPDS feed, flattened into what a browse screen needs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct Catalog {
+    /// Feed title, for the screen's heading.
+    pub title: String,
+    pub entries: Vec<CatalogEntry>,
+    /// Paging + navigation links, verbatim as the server wrote them (usually relative — the shell
+    /// resolves them against the feed URL). Empty when the feed omits the relation.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub next: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub prev: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub start: String,
+    /// The OpenSearch template, with its `{searchTerms}` placeholder left in place for the shell to
+    /// substitute (it owns the escaping, since it owns the URL).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub search_template: String,
+}
+
+impl Catalog {
+    /// The serialization of an empty catalog — the defensive fallback in [`parse_catalog_json`].
+    const EMPTY_JSON: &'static str = r#"{"title":"","entries":[]}"#;
+}
+
+/// What tapping an entry does: load another feed, or download a book.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EntryKind {
+    /// Leads to another OPDS feed (a shelf, an author, a category).
+    Navigation,
+    /// A book, with one or more downloadable formats.
+    Acquisition,
+}
+
+/// One entry in a catalog.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CatalogEntry {
+    pub kind: EntryKind,
+    pub title: String,
+    /// Authors joined with ", "; empty when the entry names none.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub author: String,
+    /// Summary (or, failing that, content) as the server supplied it.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub summary: String,
+    /// Published (or, failing that, updated) date as "DD Mon YYYY" — the format the daily companion
+    /// already renders, so dates read the same everywhere in the app.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub published: String,
+    /// Where a `Navigation` entry leads. Empty for an acquisition entry.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub href: String,
+    /// Cover art, preferring the thumbnail (an e-ink list wants the small one).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub cover: String,
+    /// Downloadable formats, **best first**: the ones this reader can open, in preference order,
+    /// then anything else. Empty for a navigation entry.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub formats: Vec<Format>,
+}
+
+/// One downloadable rendition of a book.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Format {
+    /// The media type the server advertised.
+    pub mime: String,
+    /// The acquisition href, verbatim (the shell resolves and fetches it).
+    pub href: String,
+    /// Size in bytes when the server declared one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<u64>,
+    /// The file extension this reader would save it as (`epub`/`pdf`/`cbz`/`txt`), or empty when
+    /// inkread cannot open the format. An acquisition href generally carries no extension of its
+    /// own, so this is what the shell names the downloaded file — and how the UI knows what to
+    /// offer versus grey out.
+    pub ext: String,
+}
+
+/// Formats the reader opens, in the order it prefers them. EPUB first: it reflows, so it is the
+/// format that actually reads well on a small panel. Kept in step with the shell's supported set.
+const PREFERRED: [(&str, &str); 5] = [
+    ("application/epub+zip", "epub"),
+    ("application/pdf", "pdf"),
+    ("application/x-cbz", "cbz"),
+    ("application/vnd.comicbook+zip", "cbz"),
+    ("text/plain", "txt"),
+];
+
+/// The OPDS relation prefix marking a link as a download. OPDS defines sub-relations
+/// (`/open-access`, `/borrow`, `/buy`, `/sample`), so this matches on the prefix rather than an
+/// exact string — a lending catalog's `…/acquisition/borrow` is still a way to get the book.
+const REL_ACQUISITION: &str = "http://opds-spec.org/acquisition";
+
+/// Cover-art relations, most wanted first: a thumbnail is the right size for a list on a panel that
+/// repaints slowly, so prefer it over the full cover.
+const REL_IMAGES: [&str; 4] = [
+    "http://opds-spec.org/image/thumbnail",
+    "http://opds-spec.org/thumbnail",
+    "http://opds-spec.org/image",
+    "http://opds-spec.org/cover",
+];
+
+/// The media-type marker OPDS uses for "this link is another catalog feed" — the navigation/
+/// acquisition discriminator when an entry carries no acquisition link.
+const CATALOG_PROFILE: &str = "profile=opds-catalog";
+
+/// Classify one Atom entry as navigation or acquisition and flatten it.
+fn catalog_entry(entry: Entry) -> CatalogEntry {
+    let formats = acquisition_formats(&entry.links);
+    let kind = if formats.is_empty() {
+        EntryKind::Navigation
+    } else {
+        EntryKind::Acquisition
+    };
+    CatalogEntry {
+        kind,
+        title: entry
+            .title
+            .map(|t| t.content.trim().to_string())
+            .unwrap_or_default(),
+        author: entry
+            .authors
+            .iter()
+            .map(|p| p.name.trim())
+            .filter(|n| !n.is_empty())
+            .collect::<Vec<_>>()
+            .join(", "),
+        summary: entry
+            .summary
+            .map(|t| t.content)
+            .or_else(|| entry.content.and_then(|c| c.body))
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default(),
+        published: entry
+            .published
+            .or(entry.updated)
+            .map(|d| d.format("%d %b %Y").to_string())
+            .unwrap_or_default(),
+        // A navigation entry's destination: the catalog link if it is marked as one, else the
+        // entry's first link — some servers omit the profile marker on a plain alternate link.
+        href: match kind {
+            EntryKind::Navigation => navigation_href(&entry.links),
+            EntryKind::Acquisition => String::new(),
+        },
+        cover: image_href(&entry.links),
+        formats,
+    }
+}
+
+/// The download links on an entry, best-supported first. Unsupported formats are kept (so the UI can
+/// show that a MOBI exists and cannot be opened) but sorted last.
+fn acquisition_formats(links: &[Link]) -> Vec<Format> {
+    let mut formats: Vec<Format> = links
+        .iter()
+        .filter(|l| {
+            l.rel
+                .as_deref()
+                .is_some_and(|r| r.starts_with(REL_ACQUISITION))
+                && !l.href.trim().is_empty()
+        })
+        .map(|l| {
+            let mime = l.media_type.clone().unwrap_or_default();
+            Format {
+                ext: extension_for(&mime).unwrap_or_default().to_string(),
+                mime,
+                href: l.href.trim().to_string(),
+                bytes: l.length,
+            }
+        })
+        .collect();
+    // Stable sort by preference rank, so equally-ranked formats keep the server's order.
+    formats.sort_by_key(|f| rank(&f.mime));
+    formats
+}
+
+/// Preference rank of a media type: its index in [`PREFERRED`], or past the end when unsupported.
+fn rank(mime: &str) -> usize {
+    PREFERRED
+        .iter()
+        .position(|(m, _)| mime.eq_ignore_ascii_case(m))
+        .unwrap_or(PREFERRED.len())
+}
+
+/// The file extension this reader would save `mime` as, or `None` when it cannot open it.
+fn extension_for(mime: &str) -> Option<&'static str> {
+    PREFERRED
+        .iter()
+        .find(|(m, _)| mime.eq_ignore_ascii_case(m))
+        .map(|(_, ext)| *ext)
+}
+
+/// Where a navigation entry leads: a link explicitly marked as a catalog feed, else the first link
+/// with an href (a server may omit the profile marker).
+fn navigation_href(links: &[Link]) -> String {
+    links
+        .iter()
+        .find(|l| {
+            l.media_type
+                .as_deref()
+                .is_some_and(|t| t.contains(CATALOG_PROFILE))
+        })
+        .or_else(|| links.iter().find(|l| !l.href.trim().is_empty()))
+        .map(|l| l.href.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// The entry's cover art, preferring the smallest useful rendition (see [`REL_IMAGES`]).
+fn image_href(links: &[Link]) -> String {
+    REL_IMAGES
+        .iter()
+        .find_map(|want| {
+            links
+                .iter()
+                .find(|l| l.rel.as_deref() == Some(*want) && !l.href.trim().is_empty())
+        })
+        .map(|l| l.href.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// The feed-level href for the first of `rels` the feed carries (paging / start / search).
+fn feed_href(links: &[Link], rels: &[&str]) -> String {
+    rels.iter()
+        .find_map(|want| {
+            links.iter().find(|l| {
+                l.rel
+                    .as_deref()
+                    .is_some_and(|r| r.eq_ignore_ascii_case(want))
+                    && !l.href.trim().is_empty()
+            })
+        })
+        .map(|l| l.href.trim().to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests;

--- a/inkread-opds/src/tests.rs
+++ b/inkread-opds/src/tests.rs
@@ -1,0 +1,214 @@
+//! Host tests for the OPDS classification (ADR-INKREAD-0016).
+//!
+//! The fixtures mirror what the two servers #175 names actually emit — the shapes were taken from
+//! `src/calibre/srv/opds.py` (navigation entries carry a `profile=opds-catalog;kind=navigation`
+//! link; books carry `rel="http://opds-spec.org/acquisition"` links plus cover/thumbnail relations)
+//! and Calibre-Web's `cps/opds.py`. Parsing a realistic document is the point: a synthetic feed
+//! would not exercise the rel/media-type discrimination that does all the work here.
+
+use super::*;
+
+/// A calibre-shaped acquisition feed: one book in three formats, with cover art and paging.
+const ACQUISITION_FEED: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>calibre library</title>
+  <id>urn:uuid:1c5c1a4e</id>
+  <updated>2026-08-14T10:00:00+00:00</updated>
+  <link rel="start" type="application/atom+xml;type=feed;profile=opds-catalog" href="/opds"/>
+  <link rel="next" type="application/atom+xml;type=feed;profile=opds-catalog" href="/opds/navcatalog/4e6577?offset=25"/>
+  <link rel="search" type="application/atom+xml" href="/opds/search/{searchTerms}"/>
+  <entry>
+    <title>The Left Hand of Darkness</title>
+    <id>urn:uuid:ac2f9b1e</id>
+    <author><name>Ursula K. Le Guin</name></author>
+    <updated>2026-08-01T09:00:00+00:00</updated>
+    <published>1969-03-01T00:00:00+00:00</published>
+    <summary>Winter is a planet of perpetual ice.</summary>
+    <link type="application/pdf" href="/get/PDF/42/lib" rel="http://opds-spec.org/acquisition" length="9100000"/>
+    <link type="application/epub+zip" href="/get/EPUB/42/lib" rel="http://opds-spec.org/acquisition" length="410000"/>
+    <link type="application/x-mobipocket-ebook" href="/get/MOBI/42/lib" rel="http://opds-spec.org/acquisition"/>
+    <link type="image/jpeg" href="/get/cover/42/lib" rel="http://opds-spec.org/cover"/>
+    <link type="image/jpeg" href="/get/thumb/42/lib" rel="http://opds-spec.org/thumbnail"/>
+  </entry>
+</feed>"#;
+
+/// A calibre-shaped navigation feed: entries that lead to further feeds, no downloads.
+const NAVIGATION_FEED: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>calibre library</title>
+  <id>urn:uuid:9f0b</id>
+  <updated>2026-08-14T10:00:00+00:00</updated>
+  <entry>
+    <title>By Author</title>
+    <id>calibre-navcatalog:8b1f</id>
+    <updated>2026-08-14T10:00:00+00:00</updated>
+    <content type="text">Books sorted by author</content>
+    <link type="application/atom+xml;type=feed;profile=opds-catalog;kind=navigation" href="/opds/navcatalog/617574686f7273"/>
+  </entry>
+</feed>"#;
+
+#[test]
+fn acquisition_entry_is_classified_and_ranked() {
+    let catalog = parse_catalog(ACQUISITION_FEED);
+    assert_eq!(catalog.title, "calibre library");
+    assert_eq!(catalog.entries.len(), 1);
+
+    let book = &catalog.entries[0];
+    assert_eq!(book.kind, EntryKind::Acquisition);
+    assert_eq!(book.title, "The Left Hand of Darkness");
+    assert_eq!(book.author, "Ursula K. Le Guin");
+    assert_eq!(book.summary, "Winter is a planet of perpetual ice.");
+    assert!(
+        book.href.is_empty(),
+        "an acquisition entry has no navigation destination"
+    );
+
+    // EPUB is listed after PDF in the feed but must come first: it reflows, so it is what the
+    // reader should download by default.
+    let exts: Vec<&str> = book.formats.iter().map(|f| f.ext.as_str()).collect();
+    assert_eq!(
+        exts,
+        ["epub", "pdf", ""],
+        "supported formats first, in preference order"
+    );
+    assert_eq!(book.formats[0].href, "/get/EPUB/42/lib");
+    assert_eq!(book.formats[0].bytes, Some(410_000));
+    assert_eq!(book.formats[2].mime, "application/x-mobipocket-ebook");
+}
+
+#[test]
+fn thumbnail_is_preferred_over_the_full_cover() {
+    let book = &parse_catalog(ACQUISITION_FEED).entries[0];
+    assert_eq!(
+        book.cover, "/get/thumb/42/lib",
+        "an e-ink list wants the small rendition"
+    );
+}
+
+#[test]
+fn feed_level_paging_and_search_links_are_surfaced() {
+    let catalog = parse_catalog(ACQUISITION_FEED);
+    assert_eq!(catalog.start, "/opds");
+    assert_eq!(catalog.next, "/opds/navcatalog/4e6577?offset=25");
+    assert!(
+        catalog.prev.is_empty(),
+        "this feed declares no previous page"
+    );
+    // The placeholder survives: the shell owns substitution because it owns the URL escaping.
+    assert_eq!(catalog.search_template, "/opds/search/{searchTerms}");
+}
+
+#[test]
+fn navigation_entry_carries_its_destination_and_no_formats() {
+    let catalog = parse_catalog(NAVIGATION_FEED);
+    assert_eq!(catalog.entries.len(), 1);
+
+    let nav = &catalog.entries[0];
+    assert_eq!(nav.kind, EntryKind::Navigation);
+    assert_eq!(nav.title, "By Author");
+    assert_eq!(nav.href, "/opds/navcatalog/617574686f7273");
+    assert_eq!(
+        nav.summary, "Books sorted by author",
+        "content stands in for a missing summary"
+    );
+    assert!(nav.formats.is_empty());
+}
+
+#[test]
+fn acquisition_sub_relations_still_count_as_downloads() {
+    // OPDS defines /open-access, /borrow, /buy, /sample under the acquisition relation. A lending
+    // catalog's entry is still a way to get the book, so the prefix must match, not the exact rel.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title><id>i</id><updated>2026-08-14T10:00:00+00:00</updated>
+  <entry>
+    <title>Borrowable</title><id>e</id><updated>2026-08-14T10:00:00+00:00</updated>
+    <link type="application/epub+zip" href="/borrow/7" rel="http://opds-spec.org/acquisition/borrow"/>
+  </entry>
+</feed>"#;
+    let entry = &parse_catalog(xml).entries[0];
+    assert_eq!(entry.kind, EntryKind::Acquisition);
+    assert_eq!(entry.formats.len(), 1);
+    assert_eq!(entry.formats[0].ext, "epub");
+}
+
+#[test]
+fn an_entry_whose_formats_are_all_unopenable_is_still_a_book() {
+    // Classification is about what the entry *is*, not what we can read. The UI needs to show the
+    // book and explain that nothing on it is openable — silently hiding it would look like data loss.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title><id>i</id><updated>2026-08-14T10:00:00+00:00</updated>
+  <entry>
+    <title>Only MOBI</title><id>e</id><updated>2026-08-14T10:00:00+00:00</updated>
+    <link type="application/x-mobipocket-ebook" href="/get/MOBI/9/lib" rel="http://opds-spec.org/acquisition"/>
+  </entry>
+</feed>"#;
+    let entry = &parse_catalog(xml).entries[0];
+    assert_eq!(entry.kind, EntryKind::Acquisition);
+    assert_eq!(entry.formats.len(), 1);
+    assert!(
+        entry.formats[0].ext.is_empty(),
+        "no extension ⇒ the shell must not offer it"
+    );
+}
+
+#[test]
+fn media_types_match_case_insensitively() {
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title><id>i</id><updated>2026-08-14T10:00:00+00:00</updated>
+  <entry>
+    <title>Shouty</title><id>e</id><updated>2026-08-14T10:00:00+00:00</updated>
+    <link type="APPLICATION/EPUB+ZIP" href="/get/EPUB/1/lib" rel="http://opds-spec.org/acquisition"/>
+  </entry>
+</feed>"#;
+    assert_eq!(parse_catalog(xml).entries[0].formats[0].ext, "epub");
+}
+
+#[test]
+fn malformed_input_yields_an_empty_catalog_and_never_panics() {
+    // RR21-FR3: junk in → benign out. Each of these reaches the parser from a hostile or broken
+    // server, and none may take the reader down.
+    for junk in [
+        "",
+        "   ",
+        "not xml at all",
+        "<feed",
+        "<html><body>404</body></html>",
+        "\u{feff}<feed>",
+    ] {
+        let catalog = parse_catalog(junk);
+        assert!(
+            catalog.entries.is_empty(),
+            "unexpected entries from {junk:?}"
+        );
+        assert!(catalog.next.is_empty());
+    }
+}
+
+#[test]
+fn json_form_round_trips_and_omits_absent_fields() {
+    let json = parse_catalog_json(ACQUISITION_FEED);
+    let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+
+    assert_eq!(value["title"], "calibre library");
+    assert_eq!(value["entries"][0]["kind"], "acquisition");
+    assert_eq!(value["entries"][0]["formats"][0]["ext"], "epub");
+    // `prev` is absent from the feed, so it must be absent from the JSON — the shell tests for the
+    // key's presence to decide whether to show a "previous page" control.
+    assert!(
+        value.get("prev").is_none(),
+        "empty links are omitted, not sent as \"\""
+    );
+    assert!(value["entries"][0].get("href").is_none());
+}
+
+#[test]
+fn empty_catalog_json_constant_matches_a_real_empty_catalog() {
+    // The defensive fallback in parse_catalog_json must not drift from the derived serialization.
+    assert_eq!(
+        serde_json::to_string(&Catalog::default()).unwrap(),
+        Catalog::EMPTY_JSON
+    );
+}

--- a/reader-core/Cargo.toml
+++ b/reader-core/Cargo.toml
@@ -29,6 +29,9 @@ inkread-daily = { workspace = true }
 # inkread-update (ADR-INKREAD-0014): the self-updater's pure decision, reached over the JNI bridge —
 # the shell fetches the GitHub release JSON, the core decides if it is newer. Pure Rust.
 inkread-update = { workspace = true }
+# inkread-opds (ADR-INKREAD-0016): OPDS catalog classification, reached over the JNI bridge — the
+# shell fetches the catalog document, the core says what is in it. Pure Rust.
+inkread-opds = { workspace = true }
 # EPUB backend: parsing + reflow layout + glyph rasterization (RR2-FR5). Pure Rust; the EpubBackend
 # adapter (document/reflow) maps it to the Document trait.
 inkread-epub = { workspace = true }

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -413,6 +413,24 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeUpdateDecid
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeOpdsParseCatalog(xml) : String — classify a fetched OPDS catalog document into the browse
+// model the shell renders (ADR-INKREAD-0016 / #175): navigation vs acquisition entries, each book's
+// formats ranked best-openable-first, cover art, and the paging/search links. Standalone (no
+// document handle): the shell fetches the catalog and resolves the relative hrefs, the core only
+// says what is in it. Junk in -> an empty catalog, never a throw (RR21-FR3).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeOpdsParseCatalog<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    xml: JString<'local>,
+) -> JString<'local> {
+    env.with_env(|env| -> jni::errors::Result<JString<'local>> {
+        let xml: String = xml.try_to_string(env)?;
+        env.new_string(inkread_opds::parse_catalog_json(&xml))
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // =====================================================================================
 // nativeRenderPage(handle, directBuffer) — render the current page into the direct
 // ByteBuffer the shell locked. The PixelBuffer borrow never outlives this call (Amendment 5).


### PR DESCRIPTION
Closes #175. Design: ADR-INKREAD-0016.

Point inkread at a calibre content server or a Calibre-Web instance, walk the library, search it, and pull a book straight onto the shelf.

## Why OPDS rather than the wireless device protocol

The issue asks for "Calibre / Calibre Web", and **one OPDS client reaches both**. `src/calibre/srv/opds.py` registers `/opds`, `/opds/navcatalog/{which}`, `/opds/category/{category}/{which}` and `/opds/search/{query}`; Calibre-Web's `cps/opds.py` serves the same entry point. The wireless device protocol talks only to the calibre desktop app, with the GUI running and a menu item clicked per session, whereas a content server runs headless.

The protocol's 20 opcodes (`smart_device_app/driver.py`) carry no reading position, bookmarks or annotations — it moves books and metadata one way and deletes them. Its one unique capability is format negotiation on send, which converting once in the library also achieves.

RSS comes along for free: calibre's news recipes land in the library as EPUB periodicals and arrive like any other book.

## Shape

Same split as the daily companion (#66) and the self-updater (ADR-INKREAD-0014) — the shell fetches bytes, the core decides on them.

- **`inkread-opds`** (new crate) classifies an OPDS document: navigation vs acquisition entries, each book's formats, cover art, paging and search links. Pure, IO-free, host-testable, names no product. OPDS 1.2 is Atom with extra link relations, so `feed-rs` parses it — already a dependency, and its `Link` carries `rel`, `media_type` and `length`, which is every field the classification needs. `feed-rs` moves to a workspace dependency, shared with `inkread-daily`.
- **`nativeOpdsParseCatalog`** mirrors `nativeDailyParseFeed`: standalone, junk in yields an empty catalog rather than a throw (RR21-FR3).
- **`OpdsController`** does the I/O and the URLs; **`OpdsActivity`** is the browse screen.

## Decisions worth review

- **Formats are ranked, not filtered.** EPUB before PDF because it reflows. Unopenable formats are still returned and shown marked, so a MOBI-only book does not silently vanish as though the library were missing books. Each format carries the extension the shell should save it as, since an acquisition href generally has none.
- **Only `http`/`https` are ever fetched.** A catalog is a remote party naming what the app opens next, so a `file:`/`jar:`/`content:` href is dropped at resolution rather than handed to the fetcher.
- **Search terms are percent-encoded, not plus-encoded.** calibre puts them in a path segment, where `URLEncoder`'s `+` would be searched for literally — a failure that returns no results rather than an error.
- **Relative hrefs resolve via `java.net.URL`**, which already implements RFC 3986. Re-implementing that would be new, subtle, security-relevant code for nothing.
- **Downloads land in a `.part` file and rename on success.** Writing straight to the destination truncates it, so an interrupted re-download would destroy the shelved copy and the annotations anchored to it.
- **No cover images are fetched.** A grid of images on a panel that repaints in whole frames costs a lot of flashing for little; the rows are typographic, like Daily and Home.
- **Basic auth only.** Calibre-Web authenticates OPDS this way. calibre's `auth_mode` (`srv/opts.py`) defaults to Digest without SSL, which Android's OkHttp-backed `HttpURLConnection` cannot answer — Settings names `--auth-mode=basic` rather than letting the login fail opaquely. A pure-Rust MD5 Digest responder is a clean follow-up.
- **The password is stored in plain text**, and Settings says so. On a sideloaded app already holding `MANAGE_EXTERNAL_STORAGE` on a single-user device, a keystore wrapper would imply a protection that isn't there.

The Home card appears only once a library is configured. No new manifest permission — `INTERNET` already covers it.

## How it was tested

- `cargo fmt --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --workspace`, `check-licenses.sh` — green.
- `:app:testDebugUnitTest` (51 tests), `:app:assembleDebug` — green.
- 10 Rust tests over fixtures shaped like real calibre/Calibre-Web output, and 14 Kotlin tests over the URL handling (resolution, scheme filtering, search encoding, address normalisation) — the half that fails silently rather than loudly.

**Not device-tested, and it needs a live server.** Could you run the new smoke section 7b against your calibre or Calibre-Web instance before this lands. 7b.8 (Calibre-Web with a login) is the only exercise of the Basic-auth path, and 7b.6 (kill Wi-Fi mid re-download) is the regression guard for the shelf-overwrite case.

## Follow-ups, not in scope

Digest auth; push-from-desktop, if anyone asks for it.