### PR TITLE
feat(shelf): see every book on the device, and remove one

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,13 @@
             android:exported="false"
             android:configChanges="orientation|screenSize|keyboardHidden" />
 
+        <!-- Every book on the device, and the only place to remove one; launched from the Home
+             shelf link (not exported). -->
+        <activity
+            android:name=".ShelfActivity"
+            android:exported="false"
+            android:configChanges="orientation|screenSize|keyboardHidden" />
+
         <!-- Self-update install callback (ADR-INKREAD-0014): receives the PackageInstaller session
              result and launches the OS install-confirmation intent. Internal only. -->
         <receiver

--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -98,6 +98,45 @@ object Books {
     /** A human title for a stored book file (drop the extension). */
     fun title(file: File): String = file.nameWithoutExtension
 
+    // ---- removing a book from the device (#175 follow-up) ----
+
+    /**
+     * A book's annotation sidecar: `book.epub` → sibling `book.inkread/` (RR10-FR2), the same
+     * mapping the core's `SidecarPaths::for_document` makes.
+     */
+    fun sidecarDir(file: File): File =
+        File(file.parentFile, "${file.nameWithoutExtension}.inkread")
+
+    /** Bytes this book occupies, its annotations included — what removing it actually frees. */
+    fun sizeOnDisk(file: File): Long =
+        file.length() + sidecarDir(file).walkBottomUp().filter { it.isFile }.sumOf { it.length() }
+
+    /**
+     * Remove [file] from the device.
+     *
+     * **Handwritten annotations are kept unless [alsoNotes].** The document is replaceable — one tap
+     * from the catalog, or a re-import — while the ink on it is not, and this app exists to make
+     * that ink worth having. The core re-associates a sidecar by content fingerprint (RR10-FR6), so
+     * re-downloading the same book lands the notes and the reading position straight back on it.
+     *
+     * With [alsoNotes] the sidecar, reading position and cached metadata go too — the "I am done
+     * with this book" case, which must leave nothing behind.
+     */
+    fun remove(context: Context, file: File, alsoNotes: Boolean): Boolean {
+        val id = file.name
+        val removed = runCatching { file.delete() }.getOrDefault(false)
+        // The thumbnail is a cache of the document, so it always goes with it.
+        runCatching { thumbFile(context, id).delete() }
+        if (alsoNotes) {
+            runCatching { sidecarDir(file).deleteRecursively() }
+            meta(context).edit().remove("$id.title").remove("$id.author")
+                .remove("$id.pages").remove("$id.page").apply()
+            context.getSharedPreferences("progress", Context.MODE_PRIVATE).edit().remove(id).apply()
+        }
+        // `recents` already skips entries whose file is gone, so it needs no repair here.
+        return removed
+    }
+
     // ---- real document metadata (title/author/page position), captured by the reader on open ----
 
     private fun meta(context: Context) =

--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -137,6 +137,19 @@ object Books {
         return removed
     }
 
+    /**
+     * Delete any stranded `.part` file left by a download that never finished.
+     *
+     * A catalog download writes to `.part` and renames on success (ADR-INKREAD-0016), so a `.part`
+     * that outlives its transfer — the app was killed mid-download — is unusable: nothing resumes
+     * it, and [list] filters it out, so it would sit there consuming storage that the shelf claims
+     * is free. Swept when the shelf is opened, which is where a reader goes to reclaim space.
+     */
+    fun sweepPartialDownloads(context: Context) {
+        dir(context).listFiles { f -> f.isFile && f.name.endsWith(".part") }
+            ?.forEach { runCatching { it.delete() } }
+    }
+
     // ---- real document metadata (title/author/page position), captured by the reader on open ----
 
     private fun meta(context: Context) =

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -91,9 +91,12 @@ class HomeActivity : Activity() {
         UpdateGate.maybeCheckOnLaunch(this) // throttled GitHub release check (ADR-INKREAD-0014)
     }
 
-    /** A stable digest of what the shelf renders — recents order + per-book read progress. */
+    /** A stable digest of what the shelf renders — recents order + per-book read progress, plus the
+     *  stored-book count so removing a book that was past the recents cut still refreshes the
+     *  "Your shelf · N books" line. */
     private fun shelfSignature(): String =
-        Books.recents(this).joinToString("|") { "${it.id}@${Books.progress(this, it.id)}" }
+        Books.recents(this).joinToString("|") { "${it.id}@${Books.progress(this, it.id)}" } +
+            "#${Books.list(this).size}"
 
     private fun buildView(): View {
         val w = resources.displayMetrics.widthPixels
@@ -142,6 +145,13 @@ class HomeActivity : Activity() {
         }
         column.addView(spacer(dim(28)))
         column.addView(openButton())
+        // Everything on the device, not just the recent handful — and the only route to removing a
+        // book. Shown whenever anything is stored, since a book past the recents cut is otherwise
+        // invisible while still taking up space.
+        allBooksLink()?.let {
+            column.addView(spacer(dim(12)))
+            column.addView(it)
+        }
         statChips()?.let {
             column.addView(spacer(dim(16)))
             column.addView(it)
@@ -513,6 +523,20 @@ class HomeActivity : Activity() {
         }
         isClickable = true; setOnClickListener { openPicker() }
         layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    /** "Your shelf · N books" → [ShelfActivity]; `null` when the device holds nothing yet. */
+    private fun allBooksLink(): View? {
+        val count = Books.list(this).size
+        if (count == 0) return null
+        return TextView(this).apply {
+            text = "Your shelf · $count ${if (count == 1) "book" else "books"}"
+            setTextColor(inkSoft); textSize = fs(13f); typeface = mono; letterSpacing = 0.08f
+            gravity = Gravity.CENTER
+            setPadding(dim(12), dim(8), dim(12), dim(8))
+            isClickable = true
+            setOnClickListener { startActivity(Intent(this@HomeActivity, ShelfActivity::class.java)) }
+        }
     }
 
     /** A small uppercase, letter-spaced mono eyebrow (the design's Space Mono labels). */

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -1,0 +1,193 @@
+package dev.jraghavan.inkread
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Intent
+import android.os.Bundle
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import android.widget.Toast
+import java.io.File
+
+/**
+ * **Your shelf** — every book on the device, and the only place to take one off again.
+ *
+ * The home screen shows the most recent handful, which is the right thing for *reading*; it is the
+ * wrong thing for *managing*, because a book that falls past the recents cut becomes invisible while
+ * still occupying storage. This screen is the complete list, so the device can be curated rather
+ * than only added to.
+ *
+ * Removing keeps handwritten annotations by default (see [Books.remove]) — the book is one tap from
+ * a catalog or an import, the ink on it is not. Typographic and flat, like [HomeActivity]; no covers
+ * are decoded, since a list on a panel that repaints in whole frames wants text.
+ */
+class ShelfActivity : Activity() {
+
+    private val density get() = resources.displayMetrics.density
+    private fun dp(v: Int) = (v * density).toInt()
+
+    private val serif = Ink.serif
+    private val serifItalic = Ink.serifItalic
+    private val mono = Ink.mono
+    private val ink = Ink.ink
+
+    private lateinit var column: LinearLayout
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Ink.uiScale = DisplayPrefs(this).uiScale
+        column = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(22), dp(20), dp(22), dp(28))
+        }
+        setContentView(ScrollView(this).apply { isFillViewport = true; addView(column) })
+        render()
+    }
+
+    private fun render() {
+        val books = Books.list(this)
+        column.removeAllViews()
+        column.addView(header(books))
+
+        if (books.isEmpty()) {
+            column.addView(TextView(this).apply {
+                text = "No books on the device yet."
+                setTextColor(Ink.inkSoft); textSize = Ink.sp(15f); typeface = serif
+                setPadding(0, dp(18), 0, 0)
+            })
+            return
+        }
+        for (book in books) column.addView(row(book))
+    }
+
+    private fun header(books: List<File>): View = LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        addView(Ink.eyebrow(this@ShelfActivity, "Your shelf"))
+        addView(TextView(this@ShelfActivity).apply {
+            text = if (books.size == 1) "1 book" else "${books.size} books"
+            setTextColor(ink); textSize = Ink.sp(28f); typeface = serif
+            setPadding(0, dp(4), 0, dp(2))
+        })
+        if (books.isNotEmpty()) {
+            val total = books.sumOf { Books.sizeOnDisk(it) }
+            addView(TextView(this@ShelfActivity).apply {
+                text = "${humanSize(total)} on this device"
+                setTextColor(Ink.muted); textSize = Ink.sp(11f); typeface = mono; letterSpacing = 0.08f
+                setPadding(0, 0, 0, dp(4))
+            })
+        }
+        addView(Ink.rule(this@ShelfActivity))
+        addView(spacer(dp(6)))
+    }
+
+    /** One book: tap the title to read it, tap Remove to take it off the device. */
+    private fun row(book: File): View = LinearLayout(this).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(0, dp(12), 0, dp(12))
+
+        addView(LinearLayout(this@ShelfActivity).apply {
+            orientation = LinearLayout.VERTICAL
+            isClickable = true
+            setOnClickListener { open(book) }
+            addView(TextView(this@ShelfActivity).apply {
+                text = Books.metaTitle(this@ShelfActivity, book.name) ?: Books.title(book)
+                setTextColor(ink); textSize = Ink.sp(18f); typeface = serif
+                maxLines = 2; setLineSpacing(0f, 1.1f)
+            })
+            Books.metaAuthor(this@ShelfActivity, book.name)?.let { author ->
+                addView(TextView(this@ShelfActivity).apply {
+                    text = author
+                    setTextColor(Ink.inkSoft); textSize = Ink.sp(14f); typeface = serifItalic
+                    setPadding(0, dp(3), 0, 0); maxLines = 1
+                })
+            }
+            addView(TextView(this@ShelfActivity).apply {
+                text = subtitleFor(book)
+                setTextColor(Ink.muted); textSize = Ink.sp(11f); typeface = mono; letterSpacing = 0.08f
+                setPadding(0, dp(5), 0, 0)
+            })
+        }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
+
+        addView(Ink.pillButton(this@ShelfActivity, "Remove", primary = false) { confirmRemove(book) })
+    }
+
+    /** Format · size · how far in you are — enough to decide whether it can go. */
+    private fun subtitleFor(book: File): String {
+        val bits = mutableListOf(book.extension.uppercase(), humanSize(Books.sizeOnDisk(book)))
+        val percent = Books.progress(this, book.name)
+        if (percent > 0) bits += "$percent% read"
+        if (Books.sidecarDir(book).exists()) bits += "HAS NOTES"
+        return bits.joinToString(" · ")
+    }
+
+    /**
+     * Confirm before deleting, and make the annotations an explicit, separate decision — a reader who
+     * is clearing space must not lose handwriting they did not think they were discarding.
+     */
+    private fun confirmRemove(book: File) {
+        val title = Books.metaTitle(this, book.name) ?: Books.title(book)
+        val hasNotes = Books.sidecarDir(book).exists()
+        val message = if (hasNotes) {
+            "Remove “$title” from this device? Your handwritten notes stay, and come back if you " +
+                "add the book again."
+        } else {
+            "Remove “$title” from this device? It frees ${humanSize(Books.sizeOnDisk(book))}."
+        }
+        val dialog = AlertDialog.Builder(this)
+            .setTitle("Remove from device")
+            .setMessage(message)
+            .setPositiveButton("Remove") { _, _ -> doRemove(book, alsoNotes = false) }
+            .setNegativeButton("Cancel", null)
+        if (hasNotes) dialog.setNeutralButton("Remove with notes") { _, _ -> confirmNotesToo(book, title) }
+        dialog.show()
+    }
+
+    /** Discarding handwriting is irreversible, so it gets its own confirmation. */
+    private fun confirmNotesToo(book: File, title: String) {
+        AlertDialog.Builder(this)
+            .setTitle("Delete the notes too?")
+            .setMessage("Your handwriting on “$title” will be deleted. This can't be undone.")
+            .setPositiveButton("Delete notes") { _, _ -> doRemove(book, alsoNotes = true) }
+            .setNegativeButton("Keep notes") { _, _ -> doRemove(book, alsoNotes = false) }
+            .show()
+    }
+
+    private fun doRemove(book: File, alsoNotes: Boolean) {
+        val freed = Books.sizeOnDisk(book)
+        if (Books.remove(this, book, alsoNotes)) {
+            Toast.makeText(this, "Removed · ${humanSize(freed)} free", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, "Could not remove that book", Toast.LENGTH_SHORT).show()
+        }
+        render()
+    }
+
+    private fun open(book: File) {
+        startActivity(
+            Intent(this, ReaderActivity::class.java)
+                .putExtra(ReaderActivity.EXTRA_BOOK_PATH, book.absolutePath)
+                .putExtra(ReaderActivity.EXTRA_BOOK_ID, book.name),
+        )
+    }
+
+    private fun spacer(h: Int): View = View(this).apply {
+        layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, h)
+    }
+
+    companion object {
+        /** Bytes as a short human string. Sizes are for deciding what to delete, so MB resolution
+         *  is the useful grain — nobody clears space one kilobyte at a time. Pure + host-testable. */
+        fun humanSize(bytes: Long): String = when {
+            bytes >= 1024L * 1024 * 1024 ->
+                String.format(java.util.Locale.US, "%.1f GB", bytes / (1024.0 * 1024 * 1024))
+            bytes >= 1024L * 1024 -> "${bytes / (1024 * 1024)} MB"
+            bytes > 0 -> "${(bytes / 1024).coerceAtLeast(1)} KB"
+            else -> "0 KB"
+        }
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -49,6 +49,7 @@ class ShelfActivity : Activity() {
     }
 
     private fun render() {
+        Books.sweepPartialDownloads(this)
         val books = Books.list(this)
         column.removeAllViews()
         column.addView(header(books))

--- a/app/src/test/java/dev/jraghavan/inkread/ShelfSizeTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ShelfSizeTest.kt
@@ -1,0 +1,51 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Host JVM tests for [ShelfActivity.humanSize] — the figure a reader decides on when clearing space.
+ *
+ * The grain is deliberate: sizes are shown to answer "is removing this worth it", so MB resolution
+ * is what matters and a book must never read as "0 MB" and look free to keep.
+ */
+class ShelfSizeTest {
+
+    @Test
+    fun booksReadInMegabytes() {
+        assertEquals("4 MB", ShelfActivity.humanSize(4L * 1024 * 1024))
+        assertEquals("512 MB", ShelfActivity.humanSize(512L * 1024 * 1024))
+    }
+
+    @Test
+    fun largeCollectionsReadInGigabytes() {
+        assertEquals("1.0 GB", ShelfActivity.humanSize(1024L * 1024 * 1024))
+        assertEquals("2.5 GB", ShelfActivity.humanSize((2.5 * 1024 * 1024 * 1024).toLong()))
+    }
+
+    @Test
+    fun smallFilesReadInKilobytesAndNeverRoundToZero() {
+        // A sidecar of a few hundred bytes is real; showing "0 KB" would suggest nothing is there.
+        assertEquals("1 KB", ShelfActivity.humanSize(200))
+        assertEquals("1 KB", ShelfActivity.humanSize(1024))
+        assertEquals("64 KB", ShelfActivity.humanSize(64L * 1024))
+    }
+
+    @Test
+    fun nothingIsZero() {
+        assertEquals("0 KB", ShelfActivity.humanSize(0))
+    }
+
+    /** Locale-independent: a comma decimal separator would be a formatting bug on a device set to
+     *  a European locale, and the string is parsed by eye, not by a machine. */
+    @Test
+    fun gigabytesUseADotWhateverTheLocale() {
+        val previous = java.util.Locale.getDefault()
+        try {
+            java.util.Locale.setDefault(java.util.Locale.GERMANY)
+            assertEquals("1.5 GB", ShelfActivity.humanSize((1.5 * 1024 * 1024 * 1024).toLong()))
+        } finally {
+            java.util.Locale.setDefault(previous)
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #175, prompted by the issue reporter: *"remove items from my device and still have them retained in my library… I don't have to keep /everything/ on device, just the stuff I want to read right now."*

The library half of that already worked — nothing on the device touches calibre. The device half did not exist.

## The gap

There was **no delete anywhere in the app**, and the shelf lives in `context.filesDir/books`, which is app-private internal storage that no file manager can reach. A book that landed on the device stayed there permanently, short of clearing app data.

Home compounded it: it renders only the most recent handful, so anything past that cut was invisible while still occupying storage. `Books.list()` had been written and never called.

## What this adds

`ShelfActivity` — the complete list, reached from a "Your shelf · N books" link on Home. Per book: title, format, size on disk, read progress, and whether it carries handwriting. Tap to read, Remove to take it off.

## Annotations are kept by default

Removing deletes the document, not the ink. The document is replaceable — one tap from a catalog, or a re-import — and the handwriting is not.

Because the core re-associates a sidecar by content fingerprint (RR10-FR6) and the sidecar is a sibling `book.inkread/` directory, adding the same book again brings the notes *and* the reading position straight back. That makes the reporter's loop work properly: pull it, read it, annotate it, remove it, pull it again months later with the notes intact.

Discarding the notes is a separate button with its own confirmation, since it can't be undone.

## Smaller things

- Sizes count the sidecar as well as the document — that's what removing actually frees.
- `humanSize` never rounds down to "0 KB". A figure read to decide whether a removal is worth doing must not make a real file look free to keep.
- The Home signature now includes the stored-book count, so removing a book that was past the recents cut still refreshes the shelf line.

## How it was tested

- `:app:testDebugUnitTest`, `:app:assembleDebug` — green. 5 new `ShelfSizeTest` cases cover the size formatting, including the locale-independence of the GB decimal separator.
- `cargo fmt --check`, `cargo test --workspace` — green (no core change).

**Not device-tested.** The step worth running is the round trip: remove a book that has handwriting on it, add the same book again, and confirm the notes and reading position come back. That is the behaviour this PR is really claiming.