### PR TITLE
fix(opds): make the catalog client work against a real Calibre-Web (#175)

### DIFF
--- a/inkread-opds/src/lib.rs
+++ b/inkread-opds/src/lib.rs
@@ -42,7 +42,7 @@ pub fn parse_catalog(xml: &str) -> Catalog {
         next: feed_href(&feed.links, &["next"]),
         prev: feed_href(&feed.links, &["previous", "prev"]),
         start: feed_href(&feed.links, &["start"]),
-        search_template: feed_href(&feed.links, &["search"]),
+        search_template: search_template(&feed.links),
         entries: feed.entries.into_iter().map(catalog_entry).collect(),
     }
 }
@@ -128,6 +128,10 @@ pub struct Format {
 
 /// Formats the reader opens, in the order it prefers them. EPUB first: it reflows, so it is the
 /// format that actually reads well on a small panel. Kept in step with the shell's supported set.
+const EXT_ORDER: [&str; 4] = ["epub", "pdf", "cbz", "txt"];
+
+/// Media types that identify those formats. Several servers get this wrong (see
+/// [`extension_for`]), so it is the first source consulted, not the only one.
 const PREFERRED: [(&str, &str); 5] = [
     ("application/epub+zip", "epub"),
     ("application/pdf", "pdf"),
@@ -210,33 +214,71 @@ fn acquisition_formats(links: &[Link]) -> Vec<Format> {
         })
         .map(|l| {
             let mime = l.media_type.clone().unwrap_or_default();
+            let href = l.href.trim().to_string();
             Format {
-                ext: extension_for(&mime).unwrap_or_default().to_string(),
+                ext: extension_for(&mime, l.title.as_deref().unwrap_or_default(), &href)
+                    .unwrap_or_default()
+                    .to_string(),
                 mime,
-                href: l.href.trim().to_string(),
+                href,
                 bytes: l.length,
             }
         })
         .collect();
     // Stable sort by preference rank, so equally-ranked formats keep the server's order.
-    formats.sort_by_key(|f| rank(&f.mime));
+    formats.sort_by_key(|f| rank(&f.ext));
     formats
 }
 
-/// Preference rank of a media type: its index in [`PREFERRED`], or past the end when unsupported.
-fn rank(mime: &str) -> usize {
-    PREFERRED
+/// Preference rank of a resolved extension: its index in [`EXT_ORDER`], or past the end when the
+/// reader cannot open it. Ranking on the *resolved* extension rather than the media type matters —
+/// a server that labels its EPUBs `application/octet-stream` must still have them sort first.
+fn rank(ext: &str) -> usize {
+    EXT_ORDER
         .iter()
-        .position(|(m, _)| mime.eq_ignore_ascii_case(m))
-        .unwrap_or(PREFERRED.len())
+        .position(|e| *e == ext)
+        .unwrap_or(EXT_ORDER.len())
 }
 
-/// The file extension this reader would save `mime` as, or `None` when it cannot open it.
-fn extension_for(mime: &str) -> Option<&'static str> {
-    PREFERRED
+/// The file extension this reader would save a download as, or `None` when it cannot open it.
+///
+/// Three sources, in descending order of authority, because **the media type alone is not reliable
+/// in the field**. Servers commonly derive it from the host's mime database, and where that database
+/// has no entry for a format the link goes out as `application/octet-stream` — a correctly-served
+/// EPUB that a mime-only reader would refuse to download.
+///
+/// 1. The declared media type — right when present, and the only standards-blessed source.
+/// 2. The link's `title`, which acquisition links conventionally set to the format name ("EPUB").
+/// 3. A format token in the href, since download URLs usually name the format they serve.
+///
+/// Every source must match a format this reader actually opens, so a wrong guess degrades to
+/// "cannot open" rather than to a download that fails on the way in.
+fn extension_for(mime: &str, title: &str, href: &str) -> Option<&'static str> {
+    if let Some(ext) = PREFERRED
         .iter()
         .find(|(m, _)| mime.eq_ignore_ascii_case(m))
         .map(|(_, ext)| *ext)
+    {
+        return Some(ext);
+    }
+    if let Some(ext) = format_token(title) {
+        return Some(ext);
+    }
+    // Path segments only — a query string may carry anything, including a title.
+    href.split(['?', '#'])
+        .next()
+        .unwrap_or_default()
+        .split('/')
+        .find_map(format_token)
+}
+
+/// `token` as one of the formats this reader opens, ignoring case and any leading dot.
+fn format_token(token: &str) -> Option<&'static str> {
+    let cleaned = token.trim().trim_start_matches('.');
+    EXT_ORDER
+        .iter()
+        .find(|e| cleaned.eq_ignore_ascii_case(e))
+        .copied()
 }
 
 /// Where a navigation entry leads: a link explicitly marked as a catalog feed, else the first link
@@ -266,6 +308,30 @@ fn image_href(links: &[Link]) -> String {
         .map(|l| l.href.trim().to_string())
         .unwrap_or_default()
 }
+
+/// The searchable URL template — a `search` link whose href actually carries `{searchTerms}`.
+///
+/// A feed may advertise **several** `search` links: one pointing at an OpenSearch *description
+/// document* (which describes how to search, and is not itself a query) and one carrying the query
+/// template. Taking whichever came first would send the search to the description document, which
+/// answers with metadata rather than results — a search that quietly returns nothing rather than
+/// failing. Requiring the placeholder picks the usable link regardless of order, and yields nothing
+/// when only a description document is offered, which correctly hides the search box.
+fn search_template(links: &[Link]) -> String {
+    links
+        .iter()
+        .find(|l| {
+            l.rel
+                .as_deref()
+                .is_some_and(|r| r.eq_ignore_ascii_case("search"))
+                && l.href.contains(SEARCH_TERMS)
+        })
+        .map(|l| l.href.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// The OpenSearch placeholder the shell substitutes the reader's query into.
+const SEARCH_TERMS: &str = "{searchTerms}";
 
 /// The feed-level href for the first of `rels` the feed carries (paging / start / search).
 fn feed_href(links: &[Link], rels: &[&str]) -> String {

--- a/inkread-opds/src/tests.rs
+++ b/inkread-opds/src/tests.rs
@@ -204,6 +204,126 @@ fn json_form_round_trips_and_omits_absent_fields() {
     assert!(value["entries"][0].get("href").is_none());
 }
 
+/// A **Calibre-Web** feed, shaped from `cps/templates/feed.xml` rather than from calibre desktop.
+/// The two servers differ in ways that matter, and this is the one the issue reporter runs:
+/// navigation uses `rel="subsection"`, covers use `image`/`image/thumbnail`, there are *two*
+/// `search` links, and the acquisition media type comes from the host's mime database — so an EPUB
+/// arrives as `application/octet-stream` wherever that database has no entry for it.
+const CALIBRE_WEB_FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dcterms="http://purl.org/dc/terms/">
+  <id>urn:uuid:2853dacf</id>
+  <updated>2026-08-16T10:00:00+00:00</updated>
+  <link rel="start" href="/opds" type="application/atom+xml;profile=opds-catalog;type=feed;kind=navigation"/>
+  <link rel="next" title="Next" href="/opds/new?offset=60" type="application/atom+xml;profile=opds-catalog;type=feed;kind=navigation"/>
+  <link rel="search" href="/opds/osd" type="application/opensearchdescription+xml"/>
+  <link type="application/atom+xml" rel="search" title="Search" href="/opds/search/{searchTerms}"/>
+  <title>Calibre-Web</title>
+  <entry>
+    <title>A Wizard of Earthsea</title>
+    <id>urn:uuid:9c1f</id>
+    <updated>2026-08-01T09:00:00+00:00</updated>
+    <author><name>Ursula K. Le Guin</name></author>
+    <published>1968-11-01T00:00:00+00:00</published>
+    <content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml">TAGS: fantasy</div></content>
+    <link type="image/jpeg" href="/opds/cover/7" rel="http://opds-spec.org/image"/>
+    <link type="image/jpeg" href="/opds/cover/7" rel="http://opds-spec.org/image/thumbnail"/>
+    <link rel="http://opds-spec.org/acquisition" href="/opds/download/7/epub/"
+          length="402118" title="EPUB" type="application/octet-stream"/>
+    <link rel="http://opds-spec.org/acquisition" href="/opds/download/7/pdf/"
+          length="9100000" title="PDF" type="application/pdf"/>
+  </entry>
+  <entry>
+    <title>Fantasy</title>
+    <id>/opds/category/3</id>
+    <updated>2026-08-16T10:00:00+00:00</updated>
+    <link rel="subsection" type="application/atom+xml;profile=opds-catalog" href="/opds/category/3"/>
+  </entry>
+</feed>"#;
+
+#[test]
+fn a_calibre_web_feed_classifies_and_stays_downloadable() {
+    let catalog = parse_catalog(CALIBRE_WEB_FEED);
+    assert_eq!(catalog.entries.len(), 2);
+
+    let book = &catalog.entries[0];
+    assert_eq!(book.kind, EntryKind::Acquisition);
+    assert_eq!(book.author, "Ursula K. Le Guin");
+    // The EPUB is served as application/octet-stream because the host mime database has no entry
+    // for it. Refusing it on that basis would make the reader useless against a real Calibre-Web,
+    // so the link's title and href are consulted before giving up.
+    let exts: Vec<&str> = book.formats.iter().map(|f| f.ext.as_str()).collect();
+    assert_eq!(
+        exts,
+        ["epub", "pdf"],
+        "octet-stream EPUB still resolves, and still sorts first"
+    );
+    assert_eq!(book.formats[0].href, "/opds/download/7/epub/");
+    assert_eq!(book.formats[0].bytes, Some(402_118));
+
+    // `rel="subsection"` with an opds-catalog profile is a navigation row.
+    let nav = &catalog.entries[1];
+    assert_eq!(nav.kind, EntryKind::Navigation);
+    assert_eq!(nav.href, "/opds/category/3");
+
+    assert_eq!(
+        book.cover, "/opds/cover/7",
+        "image/thumbnail is offered and preferred"
+    );
+}
+
+#[test]
+fn the_search_link_chosen_is_the_one_that_can_be_searched() {
+    // Calibre-Web advertises the OpenSearch *description document* first and the query template
+    // second. Picking the first would send every search to a metadata document and return nothing.
+    let catalog = parse_catalog(CALIBRE_WEB_FEED);
+    assert_eq!(catalog.search_template, "/opds/search/{searchTerms}");
+}
+
+#[test]
+fn a_description_only_search_link_yields_no_template() {
+    // With nothing searchable advertised, the shell must get "" and hide the search box rather than
+    // offer a control that silently does nothing.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title><id>i</id><updated>2026-08-14T10:00:00+00:00</updated>
+  <link rel="search" href="/opds/osd" type="application/opensearchdescription+xml"/>
+</feed>"#;
+    assert_eq!(parse_catalog(xml).search_template, "");
+}
+
+#[test]
+fn a_format_is_never_guessed_into_something_unopenable() {
+    // A MOBI served as octet-stream must stay unopenable: neither its title nor its href names a
+    // format this reader handles, so the fallbacks must not manufacture one.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title><id>i</id><updated>2026-08-14T10:00:00+00:00</updated>
+  <entry>
+    <title>Only MOBI</title><id>e</id><updated>2026-08-14T10:00:00+00:00</updated>
+    <link rel="http://opds-spec.org/acquisition" href="/opds/download/9/mobi/"
+          title="MOBI" type="application/octet-stream"/>
+  </entry>
+</feed>"#;
+    let entry = &parse_catalog(xml).entries[0];
+    assert!(entry.formats[0].ext.is_empty(), "no format was invented");
+}
+
+#[test]
+fn a_query_string_cannot_smuggle_a_format_into_the_href() {
+    // Only path segments are scanned: a title in the query must not make an unopenable download
+    // look openable.
+    let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>t</title><id>i</id><updated>2026-08-14T10:00:00+00:00</updated>
+  <entry>
+    <title>Trap</title><id>e</id><updated>2026-08-14T10:00:00+00:00</updated>
+    <link rel="http://opds-spec.org/acquisition" href="/dl/9?name=epub"
+          type="application/octet-stream"/>
+  </entry>
+</feed>"#;
+    assert!(parse_catalog(xml).entries[0].formats[0].ext.is_empty());
+}
+
 #[test]
 fn empty_catalog_json_constant_matches_a_real_empty_catalog() {
     // The defensive fallback in parse_catalog_json must not drift from the derived serialization.


### PR DESCRIPTION
Follow-up to #181. The issue reporter confirmed his setup is **Calibre-Web**: *"If I can pull from Calibre web and delete books off my device that satisfies my requirements."*

#181 was built and tested against fixtures shaped from calibre desktop's `srv/opds.py`. Checking it against Calibre-Web's own `cps/templates/feed.xml` turned up two defects, each of which would have broken exactly that use case.

## 1. EPUBs were marked unopenable

Calibre-Web derives an acquisition link's media type from the host's mime database:

```python
@jinjia.app_template_filter('mimetype')
def mimetype_filter(val):
    return mimetypes.types_map.get('.' + val, 'application/octet-stream')
```

Where that database has no entry for a format, the link goes out as `application/octet-stream`. `.epub` is absent from Python's built-in map on many versions, and `mimetypes` otherwise reads system files that slim container images often lack — so a correctly-served EPUB arrives unlabelled.

`#181` classified openability on the media type alone, so that EPUB would have rendered as `UNSUPPORTED FORMAT` and refused to download. The one thing he asked for.

The extension is now resolved from, in descending order of authority:

1. the declared media type — right when present, and the only standards-blessed source;
2. the link's `title`, which acquisition links conventionally set to the format name (`title="EPUB"`);
3. a format token in the href path — Calibre-Web's download route is `/opds/download/<book_id>/<book_format>/`.

Every source must match a format the reader actually opens, so a wrong guess degrades to "cannot open" rather than to a download that fails on the way in. Query strings are excluded from the href scan so a `?name=epub` can't smuggle a format past. Ranking moved onto the resolved extension as well — otherwise an octet-stream EPUB would still have sorted behind a PDF and not been the default download.

## 2. Search went to the wrong URL

Calibre-Web advertises **two** `rel="search"` links:

```xml
<link rel="search" href="{{url_for('opds.feed_osd')}}" type="application/opensearchdescription+xml"/>
<link type="application/atom+xml" rel="search" href="{{...feed_normal_search}}/{searchTerms}"/>
```

The first is the OpenSearch *description document*. `#181` took whichever came first, so every search hit a metadata document and came back with no results — a failure that looks like an empty library rather than an error.

The template is now chosen by requiring the `{searchTerms}` placeholder. That also yields nothing when a server offers only a description document, which correctly hides the search box instead of showing one that does nothing.

## How it was tested

- `cargo fmt --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --workspace`, `:app:testDebugUnitTest`, `:app:assembleDebug` — green.
- A Calibre-Web-shaped fixture built from its actual `feed.xml` — `rel="subsection"` navigation, `image`/`image/thumbnail` covers, two search links, an octet-stream EPUB — now sits alongside the calibre-desktop one. Both new tests fail without this change.
- Two negative tests pin that no format is ever invented: a MOBI stays unopenable, and a format name in a query string is ignored.

## Scope

Still not verified against a live server — smoke section 7b remains the real check, and 7b.8 (Calibre-Web with a login) now matters more than it did.