### PR TITLE
fix(opds): complete the Calibre-Web path — search, failure reporting, sizes

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -95,6 +95,20 @@ object Books {
     fun destinationFor(context: Context, title: String, ext: String): File =
         File(dir(context), "${sanitizeStem(title)}.${if (ext in SUPPORTED) ext else "pdf"}")
 
+    /**
+     * Bytes as a short human string, for a reader deciding whether something is worth keeping or
+     * worth downloading. MB resolution is the useful grain — nobody manages storage a kilobyte at a
+     * time — but a real file must never round down to "0", which would read as costing nothing.
+     * Pure + host-testable.
+     */
+    fun humanSize(bytes: Long): String = when {
+        bytes >= 1024L * 1024 * 1024 ->
+            String.format(java.util.Locale.US, "%.1f GB", bytes / (1024.0 * 1024 * 1024))
+        bytes >= 1024L * 1024 -> "${bytes / (1024 * 1024)} MB"
+        bytes > 0 -> "${(bytes / 1024).coerceAtLeast(1)} KB"
+        else -> "0 KB"
+    }
+
     /** A human title for a stored book file (drop the extension). */
     fun title(file: File): String = file.nameWithoutExtension
 

--- a/app/src/main/java/dev/jraghavan/inkread/HttpFetch.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HttpFetch.kt
@@ -38,21 +38,44 @@ object HttpFetch {
         timeoutMs: Int,
         capBytes: Int,
         authorization: String? = null,
-    ): String? {
-        if (url.isBlank()) return null
+    ): String? = getTextWithStatus(url, userAgent, accept, timeoutMs, capBytes, authorization).body
+
+    /**
+     * The same GET, reporting the HTTP [status] alongside the [body].
+     *
+     * Callers that only degrade to a no-op want [getText]; a caller that has to *explain* the
+     * failure to the reader needs to tell "the server said no" from "there was no server". A 401 is
+     * a wrong password, not an unreachable host, and telling someone to check their network when
+     * their password is wrong sends them to fix the wrong thing.
+     *
+     * [status] is `0` when the request never got a response at all.
+     */
+    fun getTextWithStatus(
+        url: String,
+        userAgent: String,
+        accept: String?,
+        timeoutMs: Int,
+        capBytes: Int,
+        authorization: String? = null,
+    ): Response {
+        if (url.isBlank()) return Response(0, null)
         return try {
             val conn = open(url, userAgent, accept, timeoutMs, authorization)
-            if (conn.responseCode !in 200..299) {
-                Log.w(TAG, "GET $url -> HTTP ${conn.responseCode}")
-                null
+            val code = conn.responseCode
+            if (code !in 200..299) {
+                Log.w(TAG, "GET $url -> HTTP $code")
+                Response(code, null)
             } else {
-                conn.inputStream.use { String(it.readCapped(capBytes), Charsets.UTF_8) }
+                Response(code, conn.inputStream.use { String(it.readCapped(capBytes), Charsets.UTF_8) })
             }
         } catch (e: Exception) {
             Log.w(TAG, "GET $url failed: ${e.message}")
-            null
+            Response(0, null)
         }
     }
+
+    /** An HTTP response: the [status] (`0` = never reached the server) and the body when 2xx. */
+    data class Response(val status: Int, val body: String?)
 
     /** Stream [url] to [dest], aborting past [capBytes]; `false` on non-2xx / IO error / oversize. */
     fun download(

--- a/app/src/main/java/dev/jraghavan/inkread/OpdsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/OpdsActivity.kt
@@ -106,24 +106,46 @@ class OpdsActivity : Activity() {
         val from = currentUrl
         showBusy("Opening the library…")
         io.execute {
-            val catalog = opds.fetchCatalog(url)
+            val result = opds.fetchCatalog(url)
             main.post {
                 if (gone) return@post
                 dismissBusy()
-                if (catalog == null) {
-                    render(
-                        message = "Could not reach the library.\n\nCheck that the server is running " +
-                            "and reachable from this device. If it asks for a login, calibre must be " +
-                            "started with --auth-mode=basic.",
-                    )
+                if (result !is OpdsController.Fetch.Ok) {
+                    render(message = explain(result))
                     return@post
                 }
                 if (pushTrail && from != null) trail.addLast(from)
                 currentUrl = url
-                current = catalog
+                current = result.catalog
                 render()
             }
         }
+    }
+
+    /**
+     * What to tell the reader about a failure — the point being to name the *one* thing worth
+     * checking. A wrong password and an unreachable host are not the same problem, and the advice
+     * for one is a waste of time for the other.
+     */
+    private fun explain(result: OpdsController.Fetch): String = when (result) {
+        is OpdsController.Fetch.Unauthorized ->
+            "The library refused the login.\n\nCheck the username and password in Settings → " +
+                "Library. If this is calibre's own content server rather than Calibre-Web, it also " +
+                "has to be started with --auth-mode=basic — its default login method is one this " +
+                "device cannot answer."
+        is OpdsController.Fetch.NotACatalog ->
+            "That address answered, but not with a library.\n\nIt is probably the server's web page " +
+                "rather than its catalog. Try the address on its own — inkread adds the catalog path " +
+                "itself."
+        is OpdsController.Fetch.Unreachable ->
+            if (result.status > 0) {
+                "The library answered with an error (HTTP ${result.status})." +
+                    "\n\nCheck the address in Settings → Library."
+            } else {
+                "Could not reach the library.\n\nCheck that the server is running and that this " +
+                    "device is on the same network."
+            }
+        is OpdsController.Fetch.Ok -> "" // not a failure; never rendered
     }
 
     // ── rendering ────────────────────────────────────────────────────────────────────────────────
@@ -198,8 +220,11 @@ class OpdsActivity : Activity() {
         if (entry.navigation) return "BROWSE →"
         val best = entry.best
             ?: return "UNSUPPORTED FORMAT" + entry.formats.firstOrNull()?.let { " · ${it.mime}" }.orEmpty()
-        val size = if (best.bytes > 0) " · ${best.bytes / 1024 / 1024} MB" else ""
-        return "DOWNLOAD ${best.ext.uppercase()}$size"
+        // Shared with the shelf so a book reads the same size in both places — and so a 400 KB EPUB
+        // does not show as "0 MB", which integer megabytes would have made of most books.
+        val size = if (best.bytes > 0) " · ${Books.humanSize(best.bytes)}" else ""
+        val already = if (Books.destinationFor(this, entry.title, best.ext).exists()) " · ON SHELF" else ""
+        return "DOWNLOAD ${best.ext.uppercase()}$size$already"
     }
 
     private fun onRowTapped(entry: OpdsController.Entry) {

--- a/app/src/main/java/dev/jraghavan/inkread/OpdsController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/OpdsController.kt
@@ -45,6 +45,8 @@ class OpdsController(private val context: Context) {
 
     /** One fetched feed, with its hrefs already resolved to absolute URLs. */
     data class Catalog(
+        /** The document really was a feed — see [Fetch.NotACatalog]. */
+        val isCatalog: Boolean,
         val title: String,
         val entries: List<Entry>,
         val next: String,
@@ -54,22 +56,41 @@ class OpdsController(private val context: Context) {
     )
 
     /**
-     * Fetch [url] and classify it. Returns null when the server is unreachable, refuses us, or
-     * answers with something that is not a catalog — the caller shows the failure; a null here is
-     * never a crash.
+     * What came back from asking the server for a feed.
+     *
+     * Failure is modelled rather than collapsed to `null` because the reader has to be told which
+     * thing to go and fix. "Could not reach the library" is the wrong sentence for a wrong password,
+     * and "your library is empty" is the wrong sentence for an address that is not a catalog — each
+     * sends someone to correct something that was never broken.
      */
-    fun fetchCatalog(url: String): Catalog? {
-        if (!isHttpUrl(url)) return null
-        val xml = HttpFetch.getText(url, USER_AGENT, ACCEPT, TIMEOUT_MS, MAX_CATALOG_BYTES, auth())
-            ?: return null
+    sealed interface Fetch {
+        data class Ok(val catalog: Catalog) : Fetch
+
+        /** The server answered 401/403: credentials are missing or wrong. */
+        data object Unauthorized : Fetch
+
+        /** Nothing answered, or it answered with an error status. */
+        data class Unreachable(val status: Int) : Fetch
+
+        /** Something answered, but it was not an OPDS feed — usually a web UI, not a catalog. */
+        data object NotACatalog : Fetch
+    }
+
+    /** Fetch [url] and classify it. Never throws; every failure is one of the [Fetch] cases. */
+    fun fetchCatalog(url: String): Fetch {
+        if (!isHttpUrl(url)) return Fetch.Unreachable(0)
+        val response =
+            HttpFetch.getTextWithStatus(url, USER_AGENT, ACCEPT, TIMEOUT_MS, MAX_CATALOG_BYTES, auth())
+        val xml = response.body ?: return failureFor(response.status)
         val json = runCatching { NativeBridge.nativeOpdsParseCatalog(xml) }.getOrElse {
             Log.e(TAG, "catalog parse failed: ${it.message}")
-            return null
+            return Fetch.NotACatalog
         }
-        return runCatching { parseCatalog(json, url) }.getOrElse {
+        val catalog = runCatching { parseCatalog(json, url) }.getOrElse {
             Log.e(TAG, "catalog decode failed: ${it.message}")
-            null
+            return Fetch.NotACatalog
         }
+        return if (catalog.isCatalog) Fetch.Ok(catalog) else Fetch.NotACatalog
     }
 
     /**
@@ -137,6 +158,7 @@ class OpdsController(private val context: Context) {
             }
         }
         return Catalog(
+            isCatalog = root.optBoolean("isCatalog", false),
             title = root.optString("title"),
             entries = entries,
             next = resolve(base, root.optString("next")),
@@ -163,6 +185,18 @@ class OpdsController(private val context: Context) {
 
         /** Matches the shelf's own import cap (the core refuses larger documents at open anyway). */
         private const val MAX_BOOK_BYTES = 2L shl 30
+
+        /**
+         * The failure a non-success HTTP [status] represents.
+         *
+         * 401 and 403 are the reader's credentials, everything else is the address or the network —
+         * a distinction worth getting right, because each sends someone to fix a different thing.
+         * Pure so the rule is tested rather than inferred from a `when` buried in an IO path.
+         */
+        fun failureFor(status: Int): Fetch = when (status) {
+            401, 403 -> Fetch.Unauthorized
+            else -> Fetch.Unreachable(status)
+        }
 
         /**
          * Resolve [href] against [base] into an absolute URL, or "" when it is absent or does not

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -76,7 +76,7 @@ class ShelfActivity : Activity() {
         if (books.isNotEmpty()) {
             val total = books.sumOf { Books.sizeOnDisk(it) }
             addView(TextView(this@ShelfActivity).apply {
-                text = "${humanSize(total)} on this device"
+                text = "${Books.humanSize(total)} on this device"
                 setTextColor(Ink.muted); textSize = Ink.sp(11f); typeface = mono; letterSpacing = 0.08f
                 setPadding(0, 0, 0, dp(4))
             })
@@ -119,7 +119,7 @@ class ShelfActivity : Activity() {
 
     /** Format · size · how far in you are — enough to decide whether it can go. */
     private fun subtitleFor(book: File): String {
-        val bits = mutableListOf(book.extension.uppercase(), humanSize(Books.sizeOnDisk(book)))
+        val bits = mutableListOf(book.extension.uppercase(), Books.humanSize(Books.sizeOnDisk(book)))
         val percent = Books.progress(this, book.name)
         if (percent > 0) bits += "$percent% read"
         if (Books.sidecarDir(book).exists()) bits += "HAS NOTES"
@@ -137,7 +137,7 @@ class ShelfActivity : Activity() {
             "Remove “$title” from this device? Your handwritten notes stay, and come back if you " +
                 "add the book again."
         } else {
-            "Remove “$title” from this device? It frees ${humanSize(Books.sizeOnDisk(book))}."
+            "Remove “$title” from this device? It frees ${Books.humanSize(Books.sizeOnDisk(book))}."
         }
         val dialog = AlertDialog.Builder(this)
             .setTitle("Remove from device")
@@ -161,7 +161,7 @@ class ShelfActivity : Activity() {
     private fun doRemove(book: File, alsoNotes: Boolean) {
         val freed = Books.sizeOnDisk(book)
         if (Books.remove(this, book, alsoNotes)) {
-            Toast.makeText(this, "Removed · ${humanSize(freed)} free", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, "Removed · ${Books.humanSize(freed)} free", Toast.LENGTH_SHORT).show()
         } else {
             Toast.makeText(this, "Could not remove that book", Toast.LENGTH_SHORT).show()
         }
@@ -180,15 +180,4 @@ class ShelfActivity : Activity() {
         layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, h)
     }
 
-    companion object {
-        /** Bytes as a short human string. Sizes are for deciding what to delete, so MB resolution
-         *  is the useful grain — nobody clears space one kilobyte at a time. Pure + host-testable. */
-        fun humanSize(bytes: Long): String = when {
-            bytes >= 1024L * 1024 * 1024 ->
-                String.format(java.util.Locale.US, "%.1f GB", bytes / (1024.0 * 1024 * 1024))
-            bytes >= 1024L * 1024 -> "${bytes / (1024 * 1024)} MB"
-            bytes > 0 -> "${(bytes / 1024).coerceAtLeast(1)} KB"
-            else -> "0 KB"
-        }
-    }
 }

--- a/app/src/test/java/dev/jraghavan/inkread/OpdsUrlTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/OpdsUrlTest.kt
@@ -132,6 +132,24 @@ class OpdsUrlTest {
         assertEquals("", OpdsController.searchUrl("/opds/search/{searchTerms}", ""))
     }
 
+    // ---- failure classification ----
+
+    @Test
+    fun aRefusedLoginIsNotAnUnreachableServer() {
+        // The reporter's server is Calibre-Web, which authenticates OPDS with Basic. Telling him to
+        // check his network when the password is wrong sends him to fix the wrong thing.
+        assertEquals(OpdsController.Fetch.Unauthorized, OpdsController.failureFor(401))
+        assertEquals(OpdsController.Fetch.Unauthorized, OpdsController.failureFor(403))
+    }
+
+    @Test
+    fun otherFailuresCarryTheirStatus() {
+        assertEquals(OpdsController.Fetch.Unreachable(404), OpdsController.failureFor(404))
+        assertEquals(OpdsController.Fetch.Unreachable(500), OpdsController.failureFor(500))
+        // 0 = nothing answered at all, which is a different sentence again.
+        assertEquals(OpdsController.Fetch.Unreachable(0), OpdsController.failureFor(0))
+    }
+
     // ---- catalogRoot ----
 
     @Test

--- a/app/src/test/java/dev/jraghavan/inkread/OpdsUrlTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/OpdsUrlTest.kt
@@ -85,6 +85,28 @@ class OpdsUrlTest {
         assertFalse(OpdsController.isHttpUrl("//a/b"))
     }
 
+    @Test
+    fun theSearchTemplateSurvivesResolution() {
+        // The template reaches resolve() before it is ever substituted, and it carries braces, which
+        // are not legal URL characters. If resolution rejected it the template would come back
+        // empty and the search box would silently never appear — so this pins that it survives with
+        // the placeholder intact and absolute.
+        assertEquals(
+            "http://192.168.1.20:8080/opds/search/{searchTerms}",
+            OpdsController.resolve(base, "/opds/search/{searchTerms}"),
+        )
+    }
+
+    @Test
+    fun aResolvedTemplateStillSubstitutes() {
+        // The two steps compose: resolve to absolute, then substitute the reader's query.
+        val template = OpdsController.resolve(base, "/opds/search/{searchTerms}")
+        assertEquals(
+            "http://192.168.1.20:8080/opds/search/le%20guin",
+            OpdsController.searchUrl(template, "le guin"),
+        )
+    }
+
     // ---- searchUrl ----
 
     @Test

--- a/app/src/test/java/dev/jraghavan/inkread/ShelfSizeTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ShelfSizeTest.kt
@@ -4,7 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Host JVM tests for [ShelfActivity.humanSize] — the figure a reader decides on when clearing space.
+ * Host JVM tests for [Books.humanSize] — the figure a reader decides on when clearing space.
  *
  * The grain is deliberate: sizes are shown to answer "is removing this worth it", so MB resolution
  * is what matters and a book must never read as "0 MB" and look free to keep.
@@ -13,27 +13,27 @@ class ShelfSizeTest {
 
     @Test
     fun booksReadInMegabytes() {
-        assertEquals("4 MB", ShelfActivity.humanSize(4L * 1024 * 1024))
-        assertEquals("512 MB", ShelfActivity.humanSize(512L * 1024 * 1024))
+        assertEquals("4 MB", Books.humanSize(4L * 1024 * 1024))
+        assertEquals("512 MB", Books.humanSize(512L * 1024 * 1024))
     }
 
     @Test
     fun largeCollectionsReadInGigabytes() {
-        assertEquals("1.0 GB", ShelfActivity.humanSize(1024L * 1024 * 1024))
-        assertEquals("2.5 GB", ShelfActivity.humanSize((2.5 * 1024 * 1024 * 1024).toLong()))
+        assertEquals("1.0 GB", Books.humanSize(1024L * 1024 * 1024))
+        assertEquals("2.5 GB", Books.humanSize((2.5 * 1024 * 1024 * 1024).toLong()))
     }
 
     @Test
     fun smallFilesReadInKilobytesAndNeverRoundToZero() {
         // A sidecar of a few hundred bytes is real; showing "0 KB" would suggest nothing is there.
-        assertEquals("1 KB", ShelfActivity.humanSize(200))
-        assertEquals("1 KB", ShelfActivity.humanSize(1024))
-        assertEquals("64 KB", ShelfActivity.humanSize(64L * 1024))
+        assertEquals("1 KB", Books.humanSize(200))
+        assertEquals("1 KB", Books.humanSize(1024))
+        assertEquals("64 KB", Books.humanSize(64L * 1024))
     }
 
     @Test
     fun nothingIsZero() {
-        assertEquals("0 KB", ShelfActivity.humanSize(0))
+        assertEquals("0 KB", Books.humanSize(0))
     }
 
     /** Locale-independent: a comma decimal separator would be a formatting bug on a device set to
@@ -43,7 +43,7 @@ class ShelfSizeTest {
         val previous = java.util.Locale.getDefault()
         try {
             java.util.Locale.setDefault(java.util.Locale.GERMANY)
-            assertEquals("1.5 GB", ShelfActivity.humanSize((1.5 * 1024 * 1024 * 1024).toLong()))
+            assertEquals("1.5 GB", Books.humanSize((1.5 * 1024 * 1024 * 1024).toLong()))
         } finally {
             java.util.Locale.setDefault(previous)
         }

--- a/inkread-opds/src/lib.rs
+++ b/inkread-opds/src/lib.rs
@@ -48,7 +48,12 @@ pub fn parse_catalog(xml: &str) -> Catalog {
 }
 
 /// One OPDS feed, flattened into what a browse screen needs.
+///
+/// Serialized **camelCase**: this JSON is read by the Kotlin shell, and a Rust-side `snake_case`
+/// field silently reaches it as a key it never looks up — the value is simply absent, with no error
+/// anywhere. [`tests::the_json_keys_are_exactly_what_the_shell_reads`] pins the whole contract.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Catalog {
     /// Feed title, for the screen's heading.
     pub title: String,
@@ -69,7 +74,7 @@ pub struct Catalog {
 
 impl Catalog {
     /// The serialization of an empty catalog — the defensive fallback in [`parse_catalog_json`].
-    const EMPTY_JSON: &'static str = r#"{"title":"","entries":[]}"#;
+    pub(crate) const EMPTY_JSON: &'static str = r#"{"title":"","entries":[]}"#;
 }
 
 /// What tapping an entry does: load another feed, or download a book.

--- a/inkread-opds/src/lib.rs
+++ b/inkread-opds/src/lib.rs
@@ -35,6 +35,7 @@ pub fn parse_catalog(xml: &str) -> Catalog {
         Err(_) => return Catalog::default(),
     };
     Catalog {
+        is_catalog: true,
         title: feed
             .title
             .map(|t| t.content.trim().to_string())
@@ -55,6 +56,13 @@ pub fn parse_catalog(xml: &str) -> Catalog {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Catalog {
+    /// Whether the document parsed as a feed at all.
+    ///
+    /// An empty catalog is ambiguous without this: a genuinely empty shelf and a URL pointing at
+    /// something that is not OPDS — a server's HTML UI, an error page — both yield no entries. The
+    /// shell needs to tell a reader "your library is empty" from "that address is not a catalog",
+    /// because only one of them is their mistake to fix.
+    pub is_catalog: bool,
     /// Feed title, for the screen's heading.
     pub title: String,
     pub entries: Vec<CatalogEntry>,
@@ -74,7 +82,7 @@ pub struct Catalog {
 
 impl Catalog {
     /// The serialization of an empty catalog — the defensive fallback in [`parse_catalog_json`].
-    pub(crate) const EMPTY_JSON: &'static str = r#"{"title":"","entries":[]}"#;
+    pub(crate) const EMPTY_JSON: &'static str = r#"{"isCatalog":false,"title":"","entries":[]}"#;
 }
 
 /// What tapping an entry does: load another feed, or download a book.

--- a/inkread-opds/src/tests.rs
+++ b/inkread-opds/src/tests.rs
@@ -271,6 +271,57 @@ fn a_calibre_web_feed_classifies_and_stays_downloadable() {
     );
 }
 
+/// Calibre-Web's **root** `/opds` feed (`cps/templates/index.xml`) — the first screen a reader
+/// sees. Its navigation links carry a catalog `type` and **no `rel` at all**, which is the shape
+/// most likely to be mishandled: a classifier that keyed on `rel` would render this as an empty
+/// library, and the reader would conclude the server was unreachable.
+const CALIBRE_WEB_ROOT: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>urn:uuid:2853dacf</id>
+  <updated>2026-08-16T10:00:00+00:00</updated>
+  <link rel="self" href="/opds" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
+  <link rel="start" title="Start" href="/opds" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
+  <link rel="search" href="/opds/osd" type="application/opensearchdescription+xml"/>
+  <link type="application/atom+xml" rel="search" title="Search" href="/opds/search/{searchTerms}"/>
+  <title>Calibre-Web</title>
+  <entry>
+    <title>Alphabetical Books</title>
+    <link href="/opds/books" type="application/atom+xml;profile=opds-catalog"/>
+    <id>/opds/books</id>
+    <updated>2026-08-16T10:00:00+00:00</updated>
+    <content type="text">Books sorted alphabetically</content>
+  </entry>
+  <entry>
+    <title>Recently added Books</title>
+    <link href="/opds/new" type="application/atom+xml;profile=opds-catalog"/>
+    <id>/opds/new</id>
+    <updated>2026-08-16T10:00:00+00:00</updated>
+    <content type="text">The latest books</content>
+  </entry>
+</feed>"#;
+
+#[test]
+fn the_calibre_web_root_feed_is_navigable() {
+    let catalog = parse_catalog(CALIBRE_WEB_ROOT);
+    assert_eq!(catalog.title, "Calibre-Web");
+    assert_eq!(
+        catalog.entries.len(),
+        2,
+        "the root feed's shelves are listed"
+    );
+
+    let first = &catalog.entries[0];
+    assert_eq!(first.kind, EntryKind::Navigation);
+    assert_eq!(first.title, "Alphabetical Books");
+    // The destination is what makes the row tappable; without it the library is a dead end.
+    assert_eq!(
+        first.href, "/opds/books",
+        "a rel-less catalog link is still followed"
+    );
+    assert_eq!(first.summary, "Books sorted alphabetically");
+    assert_eq!(catalog.entries[1].href, "/opds/new");
+}
+
 #[test]
 fn the_search_link_chosen_is_the_one_that_can_be_searched() {
     // Calibre-Web advertises the OpenSearch *description document* first and the query template
@@ -322,6 +373,43 @@ fn a_query_string_cannot_smuggle_a_format_into_the_href() {
   </entry>
 </feed>"#;
     assert!(parse_catalog(xml).entries[0].formats[0].ext.is_empty());
+}
+
+/// The JSON contract the Kotlin shell reads, key by key.
+///
+/// This is the seam with no compiler and no runtime error behind it: a key the core renames, or
+/// spells in a different convention, reaches the shell as a value that is simply *absent*. Nothing
+/// throws, nothing logs — the feature just quietly does nothing. That is exactly how the search
+/// template was lost (emitted `search_template`, read `searchTemplate`), so every key the shell
+/// looks up is pinned here.
+#[test]
+fn the_json_keys_are_exactly_what_the_shell_reads() {
+    let value: serde_json::Value =
+        serde_json::from_str(&parse_catalog_json(CALIBRE_WEB_FEED)).expect("valid JSON");
+
+    // Feed level — mirrors OpdsController.parseCatalog.
+    for key in ["title", "entries", "next", "searchTemplate"] {
+        assert!(value.get(key).is_some(), "feed key `{key}` is missing");
+    }
+    assert_eq!(value["searchTemplate"], "/opds/search/{searchTerms}");
+
+    // Entry level.
+    let book = &value["entries"][0];
+    for key in ["kind", "title", "author", "published", "cover", "formats"] {
+        assert!(book.get(key).is_some(), "entry key `{key}` is missing");
+    }
+
+    // Format level.
+    let format = &book["formats"][0];
+    for key in ["mime", "href", "bytes", "ext"] {
+        assert!(format.get(key).is_some(), "format key `{key}` is missing");
+    }
+
+    // A navigation entry's destination.
+    assert!(
+        value["entries"][1].get("href").is_some(),
+        "navigation `href` is missing"
+    );
 }
 
 #[test]

--- a/inkread-opds/src/tests.rs
+++ b/inkread-opds/src/tests.rs
@@ -388,7 +388,7 @@ fn the_json_keys_are_exactly_what_the_shell_reads() {
         serde_json::from_str(&parse_catalog_json(CALIBRE_WEB_FEED)).expect("valid JSON");
 
     // Feed level — mirrors OpdsController.parseCatalog.
-    for key in ["title", "entries", "next", "searchTemplate"] {
+    for key in ["isCatalog", "title", "entries", "next", "searchTemplate"] {
         assert!(value.get(key).is_some(), "feed key `{key}` is missing");
     }
     assert_eq!(value["searchTemplate"], "/opds/search/{searchTerms}");
@@ -410,6 +410,33 @@ fn the_json_keys_are_exactly_what_the_shell_reads() {
         value["entries"][1].get("href").is_some(),
         "navigation `href` is missing"
     );
+}
+
+#[test]
+fn an_empty_shelf_and_a_non_catalog_are_told_apart() {
+    // Both produce zero entries, and only one of them is the reader's mistake to fix. Pointing at a
+    // server's HTML UI instead of its catalog must not report "your library is empty".
+    let empty_feed = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Calibre-Web</title><id>i</id><updated>2026-08-16T10:00:00+00:00</updated>
+</feed>"#;
+    let empty = parse_catalog(empty_feed);
+    assert!(
+        empty.is_catalog,
+        "a real feed with no books is still a catalog"
+    );
+    assert!(empty.entries.is_empty());
+
+    for not_a_catalog in [
+        "<html><body><h1>Calibre-Web</h1></body></html>",
+        "404 Not Found",
+        "",
+    ] {
+        assert!(
+            !parse_catalog(not_a_catalog).is_catalog,
+            "{not_a_catalog:?} is not a catalog",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Everything remaining for the reporter's two requirements on #175: *"If I can pull from Calibre web and delete books off my device that satisfies my requirements."*

Deleting landed in #182; pulling landed in #181 and #183. Tracing the whole path end to end — rather than each half separately — turned up four more defects. They are all here.

## 1. Search never worked, on any server

The core emitted `search_template` (serde's default from the Rust field name); the shell reads `searchTemplate`. The value was always absent, so `if (searchTemplate.isNotEmpty())` never fired and the box never rendered. No error, no log. #183's fix to *which* search link gets chosen was correct and entirely unreachable.

`Catalog` now serializes camelCase, and `the_json_keys_are_exactly_what_the_shell_reads` pins every key the shell looks up — feed, entry and format level. This seam has no compiler and no runtime error behind it: a renamed key arrives as a missing value and the feature silently stops.

## 2. A refused login read as an unreachable server

`HttpFetch` collapses every failure to `null`, so a 401 from Calibre-Web — which authenticates OPDS with Basic, and is the reporter's server — produced *"Could not reach the library"* plus advice about calibre's `--auth-mode` flag. That is a different product and a different problem: someone with a wrong password was being told to check their network.

The GET now reports its status, and failure is modelled — `Unauthorized`, `Unreachable(status)`, `NotACatalog` — each with the sentence that names the one thing worth checking. The 401 rule is a pure `failureFor` so it is tested rather than buried in an IO path.

## 3. An empty library and a wrong address looked identical

Both yield zero entries, so pointing at a server's web UI instead of its catalog reported *"Nothing here"* — reading as an empty library rather than a wrong address. The core now reports whether the document parsed as a feed at all (`isCatalog`), and the screen tells them apart.

## 4. Books advertised themselves as "0 MB"

The catalog row computed integer megabytes, so every book under a megabyte — and a 400 KB EPUB is ordinary — showed as costing nothing. The shelf already had a formatter that handles this; it moves to `Books` and both screens share it. Rows now also mark a book that is already on the shelf.

## Verified rather than assumed

Each of these came from checking real server output or crossing a boundary, not from unit tests on either side:

- **The Calibre-Web root feed** (`cps/templates/index.xml` — a different template from the book feed) has navigation links with **no `rel` attribute at all**. Our classifier keys on media type so it works, but that is the reporter's very first screen and it is now pinned by a fixture.
- **The search template survives `resolve()`.** It carries `{` and `}`, which are not legal URL characters; had `java.net.URL` rejected it the box would have vanished again for a different reason. Covered resolve-then-substitute.
- **An empty feed is still a catalog**, while HTML, a 404 body and an empty body are not.

## How it was tested

`cargo fmt --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --workspace`, `check-licenses.sh`, `:app:testDebugUnitTest`, `:app:assembleDebug` — all green.

18 Rust tests in `inkread-opds`, 18 Kotlin in `OpdsUrlTest`, 5 in `ShelfSizeTest`.

## What still needs you

Smoke section 7b, against your Calibre-Web. Three steps matter most:

- **7b.8** — a login. This is the only exercise of the Basic-auth path, and now of the 401 message.
- **7b.4** — a search with a space in it. Search has never once run against a real server.
- **7b.6** — kill Wi-Fi mid re-download; the shelved copy must survive.