### PR TITLE
perf(epub): parse chapters on demand, and stop opening on a black screen (#186)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         android:label="InkRead"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+        android:theme="@style/InkRead">
 
         <!-- Home screen + launcher: brand and entry points (Open / Library / Continue). -->
         <activity

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -541,7 +541,14 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     // ---- SurfaceHolder lifecycle → core (RR21-FR4) ----
 
-    override fun surfaceCreated(holder: SurfaceHolder) { /* size arrives in surfaceChanged */ }
+    override fun surfaceCreated(holder: SurfaceHolder) {
+        // Paint the surface white the instant it exists, on this thread. The size arrives in
+        // surfaceChanged, whose work is handed to the engine thread — so the "Loading…" frame can be
+        // queued behind whatever that thread is already doing. Until something is pushed, a
+        // SurfaceView shows black, and on this panel that is a full black refresh. One white frame
+        // here closes that window regardless of how busy the engine is.
+        blit { canvas -> canvas.drawColor(Color.WHITE) }
+    }
 
     override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
         // Hand the slow open+render to the engine thread; show feedback immediately.

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- The app theme. Its only job is the window background: the platform default is dark, and a
+         SurfaceView shows black until its first frame is pushed, so without this the very first
+         thing on screen at every launch is a black frame. On an LCD that is an imperceptible
+         flicker; on e-ink it is a full black page that forces a refresh before any content exists.
+         White costs nothing and matches the paper the whole app is drawn on. -->
+    <style name="InkRead" parent="@android:style/Theme.NoTitleBar.Fullscreen">
+        <item name="android:windowBackground">@android:color/white</item>
+    </style>
+
     <!-- Consistent dialog theme for the reader (ADR-INKREAD-0008): monochrome accents so buttons
          and controls read on e-ink instead of the platform's blue/teal default. -->
     <style name="InkDialog" parent="@android:style/Theme.Material.Light.Dialog.Alert">

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -113,10 +113,33 @@ impl Laid {
     }
 }
 
+/// A chapter's content: its source XHTML until something actually needs it, then the parsed blocks.
+///
+/// Parsing every chapter at open was the one cost no cache removed — paid in full on every open of
+/// every book, for chapters the reader never looks at. On a book whose pagination is already cached
+/// (the common case after the first open) nothing but the chapter being read has to be parsed at
+/// all (#186).
+enum Chapter {
+    /// Not yet needed; holds the XHTML the parse will consume.
+    Source(String),
+    /// Parsed. The source is dropped here, so a fully-read book costs what it always did.
+    Parsed(Vec<Block>),
+}
+
+impl Chapter {
+    /// The parsed blocks, or `&[]` if this chapter has not been through [`EpubBackend::parse_chapter`].
+    fn blocks(&self) -> &[Block] {
+        match self {
+            Chapter::Parsed(blocks) => blocks,
+            Chapter::Source(_) => &[],
+        }
+    }
+}
+
 /// The EPUB backend: parsed per-chapter content + the embedded reading face, with a cached layout.
 pub struct EpubBackend {
-    /// Reading-order chapters as content blocks.
-    chapters: Vec<Vec<Block>>,
+    /// Reading-order chapters, each parsed on first use (see [`Chapter`]).
+    chapters: RefCell<Vec<Chapter>>,
     /// Each chapter's resource basename (for matching TOC hrefs → chapter index).
     chapter_keys: Vec<String>,
     /// The table of contents from the package (resolved to page targets in [`Self::toc`]).
@@ -156,15 +179,20 @@ impl EpubBackend {
     pub fn open(bytes: Vec<u8>, viewport: crate::render::Viewport) -> CoreResult<Self> {
         let pkg = EpubPackage::open(bytes)
             .map_err(|e| CoreError::RenderBackend(format!("epub open: {e}")))?;
-        let chapters: Vec<Vec<Block>> =
-            pkg.chapters.iter().map(|c| parse_blocks(&c.html)).collect();
+        // Deliberately not parsed here: see [`Chapter`]. `open` only has to know how many chapters
+        // there are; what they contain is the reader's business, one chapter at a time.
+        let chapters: Vec<Chapter> = pkg
+            .chapters
+            .iter()
+            .map(|c| Chapter::Source(c.html.clone()))
+            .collect();
         let chapter_keys: Vec<String> = pkg.chapters.iter().map(|c| basename(&c.href)).collect();
         let meta = DocumentMetadata {
             title: pkg.title.clone(),
             author: pkg.author.clone(),
         };
         Ok(Self {
-            chapters,
+            chapters: RefCell::new(chapters),
             chapter_keys,
             nav: pkg.toc,
             meta,
@@ -189,11 +217,12 @@ impl EpubBackend {
     /// fixture cannot. Everything downstream — indexing, materialization, caching — is the real path.
     #[cfg(test)]
     fn from_chapters(chapters: Vec<Vec<Block>>, viewport: crate::render::Viewport) -> Self {
+        let chapters: Vec<Chapter> = chapters.into_iter().map(Chapter::Parsed).collect();
         let chapter_keys = (0..chapters.len())
             .map(|i| format!("ch{i}.xhtml"))
             .collect();
         Self {
-            chapters,
+            chapters: RefCell::new(chapters),
             chapter_keys,
             nav: Vec::new(),
             meta: DocumentMetadata {
@@ -214,14 +243,47 @@ impl EpubBackend {
         }
     }
 
+    /// How many chapters the book has — the one thing about them that needs no parsing.
+    fn chapter_count(&self) -> usize {
+        self.chapters.borrow().len()
+    }
+
+    /// Parse chapter `index` if it has not been parsed yet. Idempotent and cheap on a repeat call.
+    fn parse_chapter(&self, index: usize) {
+        let mut chapters = self.chapters.borrow_mut();
+        let Some(slot) = chapters.get_mut(index) else {
+            return;
+        };
+        if let Chapter::Source(html) = slot {
+            // `parse_blocks` takes the source by reference, so move it out first and let the old
+            // `Chapter` (and the XHTML inside it) drop as soon as the blocks exist.
+            let html = std::mem::take(html);
+            #[cfg(test)]
+            CHAPTER_PARSES.with(|c| c.set(c.get() + 1));
+            *slot = Chapter::Parsed(parse_blocks(&html));
+        }
+    }
+
+    /// Parse every chapter. Needed only where the whole book is unavoidably in play — building a
+    /// pagination index from scratch — which is why it is a distinct, obvious call rather than
+    /// something `open` does silently.
+    fn parse_all_chapters(&self) {
+        for index in 0..self.chapter_count() {
+            self.parse_chapter(index);
+        }
+    }
+
     /// Lay out chapter `index` on its own. Pagination is per chapter by construction — a chapter
     /// always starts a fresh page and nothing carries across the boundary — so a chapter laid out
     /// alone is identical to its slice of a whole-book pass. That is what makes materializing one
     /// chapter at a time sound rather than merely convenient.
     fn lay_out_chapter(&self, index: usize, opts: &LayoutOpts) -> Vec<Page> {
-        let Some(blocks) = self.chapters.get(index) else {
+        self.parse_chapter(index);
+        let chapters = self.chapters.borrow();
+        let Some(chapter) = chapters.get(index) else {
             return vec![Page::default()];
         };
+        let blocks = chapter.blocks();
         let face = self.font.borrow();
         let font = CachedMetrics::new(&*face);
         let hyph = CachedHyphenator::new(&self.hyph);
@@ -295,7 +357,7 @@ impl EpubBackend {
         };
         if stale {
             let opts = Self::opts_for(&request);
-            let key = layout_key(&opts, request.font_id, self.chapters.len());
+            let key = layout_key(&opts, request.font_id, self.chapter_count());
             let cache = self.pagination_cache.borrow();
 
             // A stored pagination is only usable if it describes this book's chapters — a count
@@ -304,17 +366,23 @@ impl EpubBackend {
             let cached = cache
                 .as_ref()
                 .and_then(|c| c.load(&key))
-                .filter(|pages| pages.len() == self.chapters.len());
+                .filter(|pages| pages.len() == self.chapter_count());
 
             let chapter_pages = match cached {
                 Some(hit) => Some(hit),
                 None => {
+                    // The only place the whole book is unavoidably in play: counting a book's pages
+                    // means laying every chapter out. A cache hit skips this entirely, and with it
+                    // the parse of every chapter the reader is not reading (#186).
+                    self.parse_all_chapters();
+                    let chapters = self.chapters.borrow();
+                    let blocks: Vec<&[Block]> = chapters.iter().map(Chapter::blocks).collect();
                     let progress = self.progress.borrow();
                     // A book being laid out for the first time has nothing to fall back to, so
                     // that pass reports progress but cannot be cancelled — only a re-layout can.
                     let cancellable = self.laid.borrow().is_some();
                     let counted = index_chapters(
-                        &self.chapters,
+                        &blocks,
                         &self.font.borrow(),
                         &self.hyph,
                         &opts,
@@ -629,6 +697,19 @@ fn clamp_line_spacing(mult: f32) -> f32 {
 #[cfg(test)]
 thread_local! {
     static LAYOUT_PASSES: Cell<usize> = const { Cell::new(0) };
+    /// Chapters parsed on this thread — the counter behind the laziness test (#186).
+    static CHAPTER_PARSES: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Chapters parsed on this thread since [`reset_chapter_parses`].
+#[cfg(test)]
+pub(crate) fn chapter_parses() -> usize {
+    CHAPTER_PARSES.with(Cell::get)
+}
+
+#[cfg(test)]
+pub(crate) fn reset_chapter_parses() {
+    CHAPTER_PARSES.with(|c| c.set(0));
 }
 
 /// Pagination passes performed on this thread since [`reset_layout_passes`].
@@ -671,7 +752,7 @@ fn layout_key(opts: &LayoutOpts, font_id: usize, chapters: usize) -> String {
 /// the pass — a book being laid out for the first time has nothing to fall back to, so that one
 /// always runs to completion. `None` means the pass was abandoned part-way (#161).
 fn index_chapters(
-    chapters: &[Vec<Block>],
+    chapters: &[&[Block]],
     font: &AbFont,
     hyph: &dyn Hyphenator,
     opts: &LayoutOpts,

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -552,7 +552,7 @@ fn a_stored_pagination_of_the_right_shape_is_used_verbatim() {
     // The flip side: a pagination that *does* match is trusted without a layout pass, which is
     // the entire saving in #162.
     let b = synthetic_book();
-    let chapters = b.chapters.len();
+    let chapters = b.chapter_count();
     b.set_pagination_cache(fake(Some(vec![7; chapters])).0);
     reset_layout_passes();
     assert_eq!(b.page_count(), 7 * chapters);
@@ -576,7 +576,7 @@ fn each_computed_pagination_is_stored_under_its_own_key() {
     assert_eq!(saved[1].1.iter().sum::<usize>(), second);
     assert_eq!(
         saved[0].1.len(),
-        b.chapters.len(),
+        b.chapter_count(),
         "one entry per chapter — the shape the load side validates"
     );
 }
@@ -658,7 +658,7 @@ fn progress_is_reported_once_per_chapter_and_counts_up_to_the_total() {
     let (w, seen) = watcher(None);
     b.set_pagination_progress(w);
     let _ = b.page_count(); // the first pagination reports, it just cannot be cancelled
-    let chapters = b.chapters.len();
+    let chapters = b.chapter_count();
 
     let seen = seen.borrow();
     assert_eq!(seen.len(), chapters, "one report per chapter");
@@ -926,4 +926,66 @@ fn an_out_of_range_pin_is_clamped_not_panicked() {
             );
         }
     }
+}
+
+// ---- lazy chapter parsing (#186) ---------------------------------------------------------
+
+/// The cost that no cache used to remove: opening a book parsed **every** chapter to blocks, in
+/// full, on every open — for chapters the reader never looked at. On a device that was measured at
+/// ~3.2s of a ~6s open, paid again on every reopen.
+///
+/// With a cached pagination there is nothing that needs the whole book, so only the chapter being
+/// read should be parsed.
+#[test]
+fn a_cached_pagination_parses_only_the_chapter_being_read() {
+    let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+    // A pagination the backend will accept: one entry per chapter, so the shape check passes.
+    let cached = vec![1usize; b.chapter_count()];
+    b.set_pagination_cache(fake(Some(cached)).0);
+
+    reset_chapter_parses();
+    let mut buf = vec![0u8; 400 * 600 * 4];
+    let mut px = PixelBuffer::from_rgba(&mut buf, 400, 600).unwrap();
+    b.render_page(0, &mut px).expect("render first page");
+
+    assert_eq!(
+        chapter_parses(),
+        1,
+        "only the chapter holding page 0 should have been parsed",
+    );
+}
+
+/// The counterpart: building a pagination from scratch genuinely needs every chapter, so that path
+/// must still parse them all. Without this a "fix" that simply never parsed would look correct here
+/// and produce a book with no pages.
+#[test]
+fn building_a_pagination_still_parses_every_chapter() {
+    let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+    let chapters = b.chapter_count();
+
+    reset_chapter_parses();
+    let pages = b.page_count();
+
+    assert_eq!(chapter_parses(), chapters, "every chapter parsed");
+    assert!(pages > 0, "and the book has pages");
+}
+
+/// Parsing is memoized: re-reading a chapter must not re-parse it.
+#[test]
+fn a_chapter_is_parsed_at_most_once() {
+    let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
+    let _ = b.page_count(); // parses everything once
+    reset_chapter_parses();
+
+    let mut buf = vec![0u8; 400 * 600 * 4];
+    let mut px = PixelBuffer::from_rgba(&mut buf, 400, 600).unwrap();
+    for page in 0..b.page_count().min(4) {
+        b.render_page(page, &mut px).expect("render");
+    }
+
+    assert_eq!(
+        chapter_parses(),
+        0,
+        "already-parsed chapters are not re-parsed"
+    );
 }


### PR DESCRIPTION
Two parts of what makes opening a book feel slow. Both device-verified on a Nomad.

## 1. Chapters are parsed when read, not all at open

Opening a book parsed **every** chapter's XHTML into the block model, in full, whether or not the reader ever looked at it. It was the one cost no cache removed — ~3.2s of a ~6s open, paid again on every reopen.

A chapter now holds its source until something needs it:

```rust
enum Chapter { Source(String), Parsed(Vec<Block>) }
```

Two things force a parse: rendering a page parses that chapter; building a pagination from scratch parses all of them, because counting a book's pages means laying every chapter out. That second case is the **first-ever open only** — every later open is served from the SQLite index and touches nothing else.

Measured on the host against the real 320-page book used for testing:

```
EpubBackend::open      215ms   (was ~365ms — the parse is gone)
page_count (cold)      418ms   first-ever open only
page_count (cached)      8us   0 chapters parsed
render_page(0)         108ms   1 chapter parsed
```

On device, activity start to `opened` went **3502ms → 2799ms** for the same book at the same layout, and page turns within a chapter now run at **~83ms**.

## 2. The reader no longer opens on a black screen

The first thing on screen at every launch was a black frame — on this panel a full black page that forces a refresh before any content exists, which is the most visible part of a slow open.

Two sources:

- The app used `Theme.NoTitleBar.Fullscreen` with no `windowBackground`, so it fell through to the platform default, which is dark. A new `InkRead` theme sets it white.
- A `SurfaceView` shows black until its first frame. The first white frame came from `drawLoading`, which `surfaceChanged` hands to the **engine thread** — busy for seconds during an open, so the "Loading…" frame queued behind it. `surfaceCreated` now paints white immediately on the calling thread.

Confirmed gone on device.

## Tests

Three guard the laziness, and the middle one is the important one:

- `a_cached_pagination_parses_only_the_chapter_being_read` — exactly 1 chapter parsed when rendering page 0 with a warm cache.
- `building_a_pagination_still_parses_every_chapter` — without this, a change that simply stopped parsing would pass the first test and produce a book with no pages.
- `a_chapter_is_parsed_at_most_once` — memoisation holds across page turns.

Full gate green: `cargo fmt --check`, `cargo clippy --all --all-targets -D warnings`, `cargo test --workspace`, `check-licenses.sh`, `:app:testDebugUnitTest`, `:app:assembleDebug`.

## What this does not fix

Still open under #186, and worth knowing before this is read as "opening is fixed":

- **`EpubPackage::open` reads and decodes every chapter's XHTML out of the container** — now the dominant term in the open path, and the same shape of problem one level down.
- **Page 0 is still rendered twice** (`ReaderActivity.kt:889` and `:710`).
- **Materialising a chapter still costs ~1.3s** on this hardware, so crossing into an unvisited chapter stalls. Re-visits are ~10ms, so the LRU is doing its job.