### PR TITLE
refactor(epub): match selectors with a real CSS engine (#201)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "hyphenation",
  "rbook",
  "scraper",
+ "simplecss",
  "unicode-linebreak",
  "zip",
 ]
@@ -1439,6 +1440,15 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "siphasher"

--- a/inkread-epub/Cargo.toml
+++ b/inkread-epub/Cargo.toml
@@ -28,3 +28,9 @@ hyphenation = { version = "0.8.4", features = ["embed_en-us"] }
 # (CJK) wrap between characters with the standard's prohibition rules (a line never starts with 。)
 # instead of overflowing as one unbreakable "word".
 unicode-linebreak = "0.1"
+# simplecss (MIT/Apache-2.0) — CSS selector parsing + matching for the narrow block-styling subset
+# (#188/#201). We keep the policy (which properties are honoured); the crate owns selectors,
+# combinators and specificity, which the previous hand-rolled matcher dropped. Deliberately not
+# scraper's own cssparser/selectors stack: scraper keeps its SelectorList private, so specificity is
+# unreachable through it.
+simplecss = "0.2.2"

--- a/inkread-epub/src/content.rs
+++ b/inkread-epub/src/content.rs
@@ -16,7 +16,7 @@ use ego_tree::NodeRef;
 use scraper::node::Node;
 use scraper::{Html, Selector};
 
-use crate::css::{BlockStyle, Stylesheet};
+use crate::css::{self, BlockStyle, StyledNode, Stylesheet};
 
 /// Inline-level content within a [`Block`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -118,11 +118,20 @@ pub fn parse_blocks_with(html: &str, sheet: &Stylesheet) -> Vec<Block> {
         merged = s;
         &merged
     };
+    // Parsed once per chapter, not once per block: the selector engine borrows this source, which
+    // is why `Stylesheet` holds owned text.
+    let parsed = simplecss::StyleSheet::parse(sheet.source());
 
     let start = find_body(root).unwrap_or(root);
     let mut out = Vec::new();
     let mut pending: Vec<Inline> = Vec::new();
-    walk_blocks(start, &mut out, &mut pending, sheet, BlockStyle::default());
+    walk_blocks(
+        start,
+        &mut out,
+        &mut pending,
+        &parsed,
+        BlockStyle::default(),
+    );
     flush_paragraph(&mut out, &mut pending, BlockStyle::default());
     out
 }
@@ -145,13 +154,22 @@ fn style_text(doc: &Html) -> String {
 /// Resolve an element's declared style against `sheet`, folding it over what it inherits from its
 /// containers. All three properties in [`BlockStyle`] are inherited ones in CSS, and books routinely
 /// declare them on a wrapping `<div>` rather than on each block inside it.
-fn declared(el: &scraper::node::Element, sheet: &Stylesheet, inherited: BlockStyle) -> BlockStyle {
+///
+/// Note this is *narrower* than what the selector engine can express: a rule matching a container
+/// styles the blocks nested inside it, which is inheritance — the engine resolves descendant
+/// selectors such as `div.titlepage p` on its own.
+fn declared(
+    node: NodeRef<Node>,
+    el: &scraper::node::Element,
+    sheet: &simplecss::StyleSheet<'_>,
+    inherited: BlockStyle,
+) -> BlockStyle {
     let style_attr = el.attr("style");
     // Fast path for the overwhelmingly common block: no book CSS and no inline style to apply.
-    if sheet.is_empty() && style_attr.is_none() {
+    if sheet.rules.is_empty() && style_attr.is_none() {
         return inherited;
     }
-    let own = sheet.resolve(el.name(), el.attr("class"), style_attr);
+    let own = css::resolve(sheet, &StyledNode(node), style_attr);
     inherited.overlaid_with(&own)
 }
 
@@ -177,7 +195,7 @@ fn walk_blocks(
     node: NodeRef<Node>,
     out: &mut Vec<Block>,
     pending: &mut Vec<Inline>,
-    sheet: &Stylesheet,
+    sheet: &simplecss::StyleSheet<'_>,
     inherited: BlockStyle,
 ) {
     for child in node.children() {
@@ -192,7 +210,7 @@ fn walk_blocks(
                         if !is_blank(&content) {
                             out.push(Block::Paragraph {
                                 content,
-                                style: declared(el, sheet, inherited),
+                                style: declared(child, el, sheet, inherited),
                             });
                         }
                     }
@@ -204,7 +222,7 @@ fn walk_blocks(
                             out.push(Block::Heading {
                                 level,
                                 content,
-                                style: declared(el, sheet, inherited),
+                                style: declared(child, el, sheet, inherited),
                             });
                         }
                     }
@@ -220,7 +238,7 @@ fn walk_blocks(
                             name == "ol",
                             out,
                             sheet,
-                            declared(el, sheet, inherited),
+                            declared(child, el, sheet, inherited),
                         );
                     }
                     "img" => {
@@ -243,7 +261,7 @@ fn walk_blocks(
                     // blocks rather than merging across the boundary. Its declared style descends
                     // with it — a `<div class="titlepage">` styles the blocks it wraps.
                     _ => {
-                        let inner = declared(el, sheet, inherited);
+                        let inner = declared(child, el, sheet, inherited);
                         flush_paragraph(out, pending, inherited);
                         walk_blocks(child, out, pending, sheet, inner);
                         flush_paragraph(out, pending, inner);
@@ -261,7 +279,7 @@ fn walk_list(
     node: NodeRef<Node>,
     ordered: bool,
     out: &mut Vec<Block>,
-    sheet: &Stylesheet,
+    sheet: &simplecss::StyleSheet<'_>,
     inherited: BlockStyle,
 ) {
     let mut index = 0usize;
@@ -275,7 +293,7 @@ fn walk_list(
                         ordered,
                         index,
                         content,
-                        style: declared(el, sheet, inherited),
+                        style: declared(child, el, sheet, inherited),
                     });
                 }
             }
@@ -584,6 +602,29 @@ mod tests {
         };
         assert_eq!(style.align, Some(Align::Center));
         assert_eq!(style.indent, Some(false));
+    }
+
+    /// #201: `div.titlepage p` is ordinary Sigil/InDesign/calibre output. The previous hand-rolled
+    /// subset dropped every selector that reached past one element, so books written that way still
+    /// showed #188's symptom after it was "fixed".
+    #[test]
+    fn a_descendant_selector_reaches_the_block_it_matches() {
+        let sheet = Stylesheet::parse("div.titlepage p { text-align: center; text-indent: 0 }");
+        let b = parse_blocks_with(
+            &body(r#"<div class="titlepage"><p>Title</p></div><p>Ordinary prose.</p>"#),
+            &sheet,
+        );
+        let Block::Paragraph { style, .. } = &b[0] else {
+            panic!("expected the title paragraph, got {b:?}")
+        };
+        assert_eq!(style.align, Some(Align::Center));
+        assert_eq!(style.indent, Some(false));
+
+        // …and the prose outside the container is untouched by it.
+        let Block::Paragraph { style, .. } = &b[1] else {
+            panic!()
+        };
+        assert!(style.is_empty(), "{style:?}");
     }
 
     #[test]

--- a/inkread-epub/src/css.rs
+++ b/inkread-epub/src/css.rs
@@ -1,4 +1,4 @@
-//! A deliberately tiny **CSS subset** for EPUB block styling (#188).
+//! A deliberately tiny **CSS subset** for EPUB block styling (#188, widened in #201).
 //!
 //! `ADR-INKREAD-0007` / `ADR-RUST-READER` Decision 1 chose a simplified block/inline content model
 //! over an arbitrary CSS box tree, and that stays true here: this module does **not** implement the
@@ -7,10 +7,13 @@
 //! declarations is what makes a normal trade EPUB's title page render as left-aligned bold
 //! fragments instead of a centred title block.
 //!
-//! Scope, deliberately: **type and class selectors only** (`h1`, `.c`, `h1.c`), three properties
-//! ([`BlockStyle`]), and specificity/order tie-breaking. Anything else — descendant combinators,
-//! ids, attribute and pseudo selectors, `@media` blocks, inheritance, lengths — is *ignored rather
-//! than approximated*, because a mis-applied rule is worse than an unstyled one.
+//! Selector matching is [`simplecss`]'s, not ours: it handles descendant/child/sibling combinators,
+//! ids, attribute and pseudo-class selectors, and specificity ordering. What stays inkread's is the
+//! *policy* — which three properties are honoured, and what their values mean here.
+
+use ego_tree::NodeRef;
+use scraper::node::Node;
+use simplecss::{AttributeOperator, DeclarationTokenizer, Element as CssElement, PseudoClass};
 
 use crate::layout::Align;
 
@@ -43,12 +46,6 @@ impl BlockStyle {
     /// to fold a container's declared style into the block nested inside it.
     #[must_use]
     pub(crate) fn overlaid_with(mut self, higher: &BlockStyle) -> BlockStyle {
-        self.overlay(higher);
-        self
-    }
-
-    /// Overlay `higher` onto `self`; every property `higher` declares wins.
-    fn overlay(&mut self, higher: &BlockStyle) {
         if higher.align.is_some() {
             self.align = higher.align;
         }
@@ -58,162 +55,11 @@ impl BlockStyle {
         if higher.bold.is_some() {
             self.bold = higher.bold;
         }
-    }
-}
-
-/// One parsed rule: a simple selector plus the declarations it carries.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct Rule {
-    /// Element name to match (`h1`), or `None` for "any element" (`.c`, `*`).
-    tag: Option<String>,
-    /// Class to match (`c`), or `None` for "any class" (`h1`, `*`).
-    class: Option<String>,
-    /// CSS specificity, coarsely: `*` = 0, tag = 1, class = 10, tag.class = 11.
-    specificity: u8,
-    /// Source order, so equal-specificity rules resolve last-wins.
-    order: usize,
-    style: BlockStyle,
-}
-
-/// A parsed stylesheet — the book's declarations, queryable by element name + class attribute.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct Stylesheet {
-    rules: Vec<Rule>,
-}
-
-impl Stylesheet {
-    /// Parse a stylesheet. Malformed input yields fewer rules, never an error and never a panic —
-    /// a book with broken CSS must still open (RR21-FR3).
-    #[must_use]
-    pub fn parse(css: &str) -> Self {
-        let mut sheet = Self::default();
-        sheet.add(css);
-        sheet
+        self
     }
 
-    /// Append another stylesheet's rules after this one's, so later sources win ties. Used to layer
-    /// a chapter's in-document `<style>` over the book-wide linked stylesheets.
-    pub fn add(&mut self, css: &str) {
-        let stripped = strip_comments(css);
-        let mut rest = stripped.as_str();
-        while let Some(brace) = rest.find('{') {
-            let head = rest[..brace].trim();
-            let (body, tail) = take_block(&rest[brace + 1..]);
-            rest = tail;
-            // `@charset "x"; p` / `@import url(y); p` leave a statement before the real selector;
-            // keep only the part after the last `;` so those don't swallow the following rule.
-            let selectors = head.rsplit(';').next().unwrap_or(head).trim();
-            // An at-rule's own block (`@media`, `@font-face`, `@page`) is skipped whole: honouring
-            // its nested rules would mean modelling the conditions they are nested under.
-            if selectors.starts_with('@') || selectors.is_empty() {
-                continue;
-            }
-            let style = parse_declarations(body);
-            if style.is_empty() {
-                continue;
-            }
-            for sel in selectors.split(',') {
-                if let Some((tag, class, specificity)) = parse_selector(sel.trim()) {
-                    let order = self.rules.len();
-                    self.rules.push(Rule {
-                        tag,
-                        class,
-                        specificity,
-                        order,
-                        style,
-                    });
-                }
-            }
-        }
-        // Sorted once here rather than on every lookup: `resolve` runs per block per chapter, and
-        // `order` is monotonic across `add` calls, so a later source re-sorts correctly.
-        self.rules.sort_by_key(|r| (r.specificity, r.order));
-    }
-
-    /// True when no rule was understood (an absent, empty, or entirely unsupported stylesheet).
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.rules.is_empty()
-    }
-
-    /// Resolve the declared style for an element: every matching rule folded in specificity order,
-    /// then the element's own `style="…"` attribute on top.
-    #[must_use]
-    pub fn resolve(
-        &self,
-        tag: &str,
-        class_attr: Option<&str>,
-        style_attr: Option<&str>,
-    ) -> BlockStyle {
-        let mut out = BlockStyle::default();
-        // `rules` is already in specificity order, so this is a single allocation-free pass.
-        for rule in self.rules.iter().filter(|r| r.matches(tag, class_attr)) {
-            out.overlay(&rule.style);
-        }
-        if let Some(inline) = style_attr {
-            out.overlay(&parse_declarations(inline));
-        }
-        out
-    }
-}
-
-impl Rule {
-    /// True when this rule's tag and class constraints both admit the element.
-    fn matches(&self, tag: &str, class_attr: Option<&str>) -> bool {
-        if let Some(want) = &self.tag {
-            if !want.eq_ignore_ascii_case(tag) {
-                return false;
-            }
-        }
-        if let Some(want) = &self.class {
-            let has = class_attr
-                .unwrap_or_default()
-                .split_whitespace()
-                .any(|c| c == want);
-            if !has {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-/// Parse one simple selector into `(tag, class, specificity)`. Returns `None` for anything beyond
-/// `tag`, `.class`, `tag.class`, and `*` — combinators, ids, attributes and pseudo-classes are
-/// skipped rather than approximated.
-fn parse_selector(sel: &str) -> Option<(Option<String>, Option<String>, u8)> {
-    if sel.is_empty() || sel.contains([' ', '>', '+', '~', '#', '[', ':', '(', '*']) {
-        // `*` alone would be legal, but a universal rule carries no information we act on beyond
-        // what a tag rule gives us, and `*` inside a longer selector is unsupported anyway.
-        return None;
-    }
-    let (tag, class) = match sel.split_once('.') {
-        Some((t, c)) => {
-            if c.is_empty() || c.contains('.') {
-                return None; // `.` alone, or a multi-class selector (`.a.b`) we don't model
-            }
-            let tag = (!t.is_empty()).then(|| t.to_ascii_lowercase());
-            (tag, Some(c.to_string()))
-        }
-        None => (Some(sel.to_ascii_lowercase()), None),
-    };
-    let specificity = match (&tag, &class) {
-        (Some(_), Some(_)) => 11,
-        (None, Some(_)) => 10,
-        (Some(_), None) => 1,
-        (None, None) => 0,
-    };
-    Some((tag, class, specificity))
-}
-
-/// Parse a declaration block body (`prop: value; …`) into the properties we honour.
-fn parse_declarations(body: &str) -> BlockStyle {
-    let mut style = BlockStyle::default();
-    for decl in body.split(';') {
-        let Some((prop, value)) = decl.split_once(':') else {
-            continue;
-        };
-        let prop = prop.trim().to_ascii_lowercase();
+    /// Fold one declaration in, ignoring the properties inkread does not honour.
+    fn apply(&mut self, name: &str, value: &str) {
         // `!important` is stripped rather than modelled: within the tiny subset here, honouring it
         // would only reorder rules that already agree in practice.
         let value = value
@@ -221,14 +67,157 @@ fn parse_declarations(body: &str) -> BlockStyle {
             .trim_end_matches("!important")
             .trim()
             .to_ascii_lowercase();
-        match prop.as_str() {
-            "text-align" => style.align = parse_align(&value),
-            "text-indent" => style.indent = Some(!is_zero_length(&value)),
-            "font-weight" => style.bold = parse_font_weight(&value),
+        match name.trim().to_ascii_lowercase().as_str() {
+            "text-align" => {
+                if let Some(a) = parse_align(&value) {
+                    self.align = Some(a);
+                }
+            }
+            "text-indent" => self.indent = Some(!is_zero_length(&value)),
+            "font-weight" => {
+                if let Some(b) = parse_font_weight(&value) {
+                    self.bold = Some(b);
+                }
+            }
             _ => {}
         }
     }
-    style
+
+    /// Fold in a `style="…"` attribute body — declarations alone, no selector.
+    fn apply_inline(&mut self, style_attr: &str) {
+        for d in DeclarationTokenizer::from(style_attr) {
+            self.apply(d.name, d.value);
+        }
+    }
+}
+
+/// The book's CSS, kept as owned source.
+///
+/// [`simplecss::StyleSheet`] borrows the text it parses, so it cannot live in [`crate::EpubPackage`]
+/// (which is owned, `Clone` and `Eq`). Holding the source instead lets a chapter parse build the
+/// borrowed sheet once, for the duration of that parse.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Stylesheet {
+    css: String,
+}
+
+impl Stylesheet {
+    /// A stylesheet over `css`.
+    #[must_use]
+    pub fn parse(css: &str) -> Self {
+        let mut sheet = Self::default();
+        sheet.add(css);
+        sheet
+    }
+
+    /// Append another source after this one, so later sources win ties at equal specificity.
+    pub fn add(&mut self, css: &str) {
+        if css.trim().is_empty() {
+            return;
+        }
+        if !self.css.is_empty() {
+            self.css.push('\n');
+        }
+        self.css.push_str(css);
+    }
+
+    /// True when the book declared no CSS at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.css.trim().is_empty()
+    }
+
+    /// The accumulated source, for [`simplecss::StyleSheet::parse`].
+    #[must_use]
+    pub(crate) fn source(&self) -> &str {
+        &self.css
+    }
+}
+
+/// Resolve the declared style for `el`: every matching rule folded in specificity order, then the
+/// element's own `style="…"` attribute on top.
+pub(crate) fn resolve<E: CssElement>(
+    sheet: &simplecss::StyleSheet<'_>,
+    el: &E,
+    style_attr: Option<&str>,
+) -> BlockStyle {
+    let mut out = BlockStyle::default();
+    // simplecss sorts `rules` by specificity at parse time, and a stable sort keeps source order
+    // within a specificity — which is exactly the CSS tie-break.
+    for rule in &sheet.rules {
+        if rule.selector.matches(el) {
+            for d in &rule.declarations {
+                out.apply(d.name, d.value);
+            }
+        }
+    }
+    if let Some(inline) = style_attr {
+        out.apply_inline(inline);
+    }
+    out
+}
+
+/// Bridges the transient html5ever tree the content walker holds to simplecss's matching, so
+/// selectors that reach beyond a single element (`div.titlepage p`, `p:first-child`) resolve
+/// against the real document rather than being dropped.
+#[derive(Clone, Copy)]
+pub(crate) struct StyledNode<'a>(pub NodeRef<'a, Node>);
+
+impl<'a> StyledNode<'a> {
+    fn element(&self) -> Option<&'a scraper::node::Element> {
+        self.0.value().as_element()
+    }
+}
+
+impl CssElement for StyledNode<'_> {
+    fn parent_element(&self) -> Option<Self> {
+        let mut node = self.0.parent()?;
+        loop {
+            if node.value().is_element() {
+                return Some(StyledNode(node));
+            }
+            node = node.parent()?;
+        }
+    }
+
+    fn prev_sibling_element(&self) -> Option<Self> {
+        self.0
+            .prev_siblings()
+            .find(|n| n.value().is_element())
+            .map(StyledNode)
+    }
+
+    fn has_local_name(&self, name: &str) -> bool {
+        // Element names are case-insensitive in HTML; html5ever already lowercases them, but a
+        // stylesheet may still write `H1`.
+        self.element()
+            .is_some_and(|el| el.name().eq_ignore_ascii_case(name))
+    }
+
+    fn attribute_matches(&self, local_name: &str, operator: AttributeOperator<'_>) -> bool {
+        self.element()
+            .and_then(|el| el.attr(local_name))
+            .is_some_and(|value| {
+                // `Contains` (`[class~=x]`, which is what `.x` compiles to) splits on a single
+                // space, so a prettified `class="a\n  b"` would not match `.b`. Collapse runs of
+                // whitespace first, which is how a browser reads a class list.
+                let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
+                operator.matches(&normalized)
+            })
+    }
+
+    fn pseudo_class_matches(&self, class: PseudoClass<'_>) -> bool {
+        match class {
+            PseudoClass::FirstChild => self.prev_sibling_element().is_none(),
+            // :lang() is the only other one a book might reasonably use on a block; link/visited/
+            // hover/active/focus have no meaning in a paginated reader.
+            PseudoClass::Lang(want) => self
+                .element()
+                .and_then(|el| el.attr("lang"))
+                .is_some_and(|got| got.eq_ignore_ascii_case(want)),
+            _ => false,
+        }
+    }
 }
 
 /// `text-align` → [`Align`]. `start`/`end` are the EPUB 3 logical forms; inkread is horizontal
@@ -262,300 +251,6 @@ fn parse_font_weight(value: &str) -> Option<bool> {
     }
 }
 
-/// Remove `/* … */` comments. An unterminated comment swallows the rest, as a browser does.
-fn strip_comments(css: &str) -> String {
-    let mut out = String::with_capacity(css.len());
-    let mut rest = css;
-    while let Some(start) = rest.find("/*") {
-        out.push_str(&rest[..start]);
-        match rest[start + 2..].find("*/") {
-            Some(end) => rest = &rest[start + 2 + end + 2..],
-            None => return out,
-        }
-    }
-    out.push_str(rest);
-    out
-}
-
-/// Split off a brace-balanced block body, returning `(body, rest_after_closing_brace)`. The opening
-/// brace is already consumed. An unclosed block runs to end of input.
-fn take_block(after_open: &str) -> (&str, &str) {
-    let mut depth = 1usize;
-    for (i, ch) in after_open.char_indices() {
-        match ch {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return (&after_open[..i], &after_open[i + 1..]);
-                }
-            }
-            _ => {}
-        }
-    }
-    (after_open, "")
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The stylesheet from #188 — Project Gutenberg's *Pride and Prejudice* (#1342), the book whose
-    /// title page rendered as left-aligned bold fragments.
-    const PG_CSS: &str = r#"
-        h1        { margin-top: 5%; text-align: center; clear: both; font-weight: normal }
-        .c        { text-align: center; text-indent: 0% }
-        .cbig250  { text-align: center; text-indent: 0%; font-weight: normal; font-size: 200% }
-    "#;
-
-    #[test]
-    fn the_pride_and_prejudice_title_resolves_centred_unbolded_and_unindented() {
-        let sheet = Stylesheet::parse(PG_CSS);
-        // The reported case: a bare <h1> with no class.
-        let h1 = sheet.resolve("h1", None, None);
-        assert_eq!(h1.align, Some(Align::Center), "text-align was dropped");
-        assert_eq!(h1.bold, Some(false), "font-weight: normal was dropped");
-
-        // A classed decorative block opts out of the paragraph indent.
-        let c = sheet.resolve("p", Some("c"), None);
-        assert_eq!(c.align, Some(Align::Center));
-        assert_eq!(c.indent, Some(false), "text-indent: 0% was dropped");
-    }
-
-    #[test]
-    fn class_beats_element_and_later_beats_earlier_at_equal_specificity() {
-        let sheet = Stylesheet::parse(
-            "p { text-align: left } .mid { text-align: center } p { font-weight: bold }",
-        );
-        assert_eq!(
-            sheet.resolve("p", Some("mid"), None).align,
-            Some(Align::Center)
-        );
-        assert_eq!(sheet.resolve("p", None, None).align, Some(Align::Left));
-        assert_eq!(sheet.resolve("p", None, None).bold, Some(true));
-
-        let last_wins = Stylesheet::parse("p { text-align: left } p { text-align: right }");
-        assert_eq!(last_wins.resolve("p", None, None).align, Some(Align::Right));
-    }
-
-    #[test]
-    fn a_tag_qualified_class_outranks_a_bare_class() {
-        let sheet = Stylesheet::parse("h1.t { text-align: right } .t { text-align: center }");
-        assert_eq!(
-            sheet.resolve("h1", Some("t"), None).align,
-            Some(Align::Right)
-        );
-        assert_eq!(
-            sheet.resolve("p", Some("t"), None).align,
-            Some(Align::Center)
-        );
-    }
-
-    #[test]
-    fn an_inline_style_attribute_outranks_every_rule() {
-        let sheet = Stylesheet::parse("p { text-align: left }");
-        let s = sheet.resolve("p", None, Some("text-align: center; text-indent: 0"));
-        assert_eq!(s.align, Some(Align::Center));
-        assert_eq!(s.indent, Some(false));
-    }
-
-    #[test]
-    fn a_class_only_matches_its_own_element_and_one_of_several_classes() {
-        let sheet = Stylesheet::parse(".c { text-align: center }");
-        assert_eq!(
-            sheet.resolve("p", Some("first c last"), None).align,
-            Some(Align::Center)
-        );
-        assert_eq!(
-            sheet.resolve("p", Some("cc"), None).align,
-            None,
-            "no prefix match"
-        );
-        assert_eq!(sheet.resolve("p", None, None).align, None);
-    }
-
-    #[test]
-    fn unsupported_selectors_are_ignored_not_approximated() {
-        // Each of these would change the wrong blocks if we pretended to understand it.
-        for sel in [
-            "div p",
-            "div > p",
-            "p + p",
-            "p ~ p",
-            "#id",
-            "p[lang]",
-            "p:first-child",
-            "*",
-        ] {
-            let sheet = Stylesheet::parse(&format!("{sel} {{ text-align: center }}"));
-            assert!(sheet.is_empty(), "{sel} should be skipped, got {sheet:?}");
-        }
-    }
-
-    #[test]
-    fn at_rules_are_skipped_whole_without_losing_the_rules_around_them() {
-        let sheet = Stylesheet::parse(
-            r#"@charset "utf-8";
-               @import url(other.css);
-               h1 { text-align: center }
-               @media print { h1 { text-align: right } p { text-align: right } }
-               @font-face { font-family: x; src: url(x.ttf) }
-               p { text-indent: 0 }"#,
-        );
-        assert_eq!(
-            sheet.resolve("h1", None, None).align,
-            Some(Align::Center),
-            "@media leaked"
-        );
-        assert_eq!(
-            sheet.resolve("p", None, None).indent,
-            Some(false),
-            "rule after @font-face lost"
-        );
-        assert_eq!(sheet.resolve("p", None, None).align, None);
-    }
-
-    #[test]
-    fn comments_are_stripped_including_an_unterminated_one() {
-        let sheet = Stylesheet::parse("/* c */ h1 { text-align: /* mid */ center }");
-        assert_eq!(sheet.resolve("h1", None, None).align, Some(Align::Center));
-        // An unterminated comment swallows the rest, as a browser does.
-        assert!(!Stylesheet::parse("h1 { text-align: center } /* oops").is_empty());
-        assert!(Stylesheet::parse("/* oops h1 { text-align: center }").is_empty());
-    }
-
-    #[test]
-    fn text_indent_is_a_zero_opt_out_not_a_measurement() {
-        for zero in ["0", "0em", "0%", "0.0px", "+0em", "-0em"] {
-            let s = Stylesheet::parse(&format!("p {{ text-indent: {zero} }}"));
-            assert_eq!(s.resolve("p", None, None).indent, Some(false), "{zero}");
-        }
-        for nonzero in ["1.5em", "5%", "12px", "inherit"] {
-            let s = Stylesheet::parse(&format!("p {{ text-indent: {nonzero} }}"));
-            assert_eq!(s.resolve("p", None, None).indent, Some(true), "{nonzero}");
-        }
-    }
-
-    #[test]
-    fn font_weight_splits_at_600_like_css() {
-        for normal in ["normal", "lighter", "100", "400", "500"] {
-            let s = Stylesheet::parse(&format!("h1 {{ font-weight: {normal} }}"));
-            assert_eq!(s.resolve("h1", None, None).bold, Some(false), "{normal}");
-        }
-        for bold in ["bold", "bolder", "600", "700", "900"] {
-            let s = Stylesheet::parse(&format!("h1 {{ font-weight: {bold} }}"));
-            assert_eq!(s.resolve("h1", None, None).bold, Some(true), "{bold}");
-        }
-        assert_eq!(
-            Stylesheet::parse("h1 { font-weight: wat }")
-                .resolve("h1", None, None)
-                .bold,
-            None,
-            "an unparseable weight declares nothing"
-        );
-    }
-
-    #[test]
-    fn important_is_stripped_and_alignment_keywords_map() {
-        let s = Stylesheet::parse("p { text-align: center !important }");
-        assert_eq!(s.resolve("p", None, None).align, Some(Align::Center));
-        for (css, want) in [
-            ("left", Align::Left),
-            ("start", Align::Left),
-            ("right", Align::Right),
-            ("end", Align::Right),
-            ("justify", Align::Justify),
-        ] {
-            let s = Stylesheet::parse(&format!("p {{ text-align: {css} }}"));
-            assert_eq!(s.resolve("p", None, None).align, Some(want), "{css}");
-        }
-    }
-
-    #[test]
-    fn selectors_and_properties_are_case_insensitive() {
-        let sheet = Stylesheet::parse("H1 { TEXT-ALIGN: CENTER }");
-        assert_eq!(sheet.resolve("h1", None, None).align, Some(Align::Center));
-    }
-
-    #[test]
-    fn malformed_css_yields_no_rules_and_never_panics() {
-        for junk in [
-            "",
-            "   ",
-            "}}}{{{",
-            "p {",
-            "p { text-align",
-            "{ }",
-            ";;;",
-            "p { : center }",
-            "p { text-align: }",
-            "@media {",
-            "\u{0}\u{1}",
-        ] {
-            let _ = Stylesheet::parse(junk); // must not panic
-        }
-        assert!(
-            Stylesheet::parse("p { color: red }").is_empty(),
-            "no honoured property"
-        );
-        // An unclosed block still contributes its declarations rather than being lost.
-        assert_eq!(
-            Stylesheet::parse("p { text-align: center")
-                .resolve("p", None, None)
-                .align,
-            Some(Align::Center)
-        );
-    }
-
-    /// Every index this parser takes is either a `find` on an ASCII delimiter or a `char_indices`
-    /// offset, so slices land on char boundaries — but a book's CSS is arbitrary bytes, and a slice
-    /// off a boundary panics. Pin it: non-ASCII in comments, selectors, values and class names, and
-    /// unterminated constructs around them (RR21-FR3).
-    #[test]
-    fn multibyte_css_never_panics_and_still_parses() {
-        for css in [
-            "/* коммент */ h1 { text-align: center }",
-            "/* незакрытый h1 { text-align: center }",
-            ".Ünicöde { text-align: center }",
-            "h1 { text-align: cëntre }",
-            "h1 { font-family: \"日本語\"; text-align: center }",
-            "日本語 { text-align: center }",
-            "h1 { text-indent: 0日 }",
-            "/*日*/{日}h1{text-align:center}",
-            "h1 { text-align: center /* 日",
-            "🙂 { text-align: center } h1 { text-align: right }",
-        ] {
-            let sheet = Stylesheet::parse(css); // must not panic
-            let _ = sheet.resolve("h1", Some("Ünicöde"), Some("text-align: 日"));
-        }
-        // Non-ASCII around a rule must not stop the rule itself being understood.
-        let sheet = Stylesheet::parse("/* коммент */ h1 { text-align: center }");
-        assert_eq!(sheet.resolve("h1", None, None).align, Some(Align::Center));
-        // A non-ASCII class name still matches itself.
-        let sheet = Stylesheet::parse(".Ünicöde { text-align: right }");
-        assert_eq!(
-            sheet.resolve("p", Some("Ünicöde"), None).align,
-            Some(Align::Right)
-        );
-    }
-
-    #[test]
-    fn multiple_sources_layer_with_later_winning() {
-        let mut sheet = Stylesheet::parse("p { text-align: left }");
-        sheet.add("p { text-align: center }");
-        assert_eq!(sheet.resolve("p", None, None).align, Some(Align::Center));
-    }
-
-    #[test]
-    fn a_comma_separated_selector_list_applies_to_every_branch() {
-        let sheet = Stylesheet::parse("h1, h2, .t { text-align: center }");
-        for (tag, class) in [("h1", None), ("h2", None), ("p", Some("t"))] {
-            assert_eq!(
-                sheet.resolve(tag, class, None).align,
-                Some(Align::Center),
-                "{tag}"
-            );
-        }
-        assert_eq!(sheet.resolve("h3", None, None).align, None);
-    }
-}
+#[path = "css_tests.rs"]
+mod tests;

--- a/inkread-epub/src/css_tests.rs
+++ b/inkread-epub/src/css_tests.rs
@@ -1,0 +1,418 @@
+//! Tests for the CSS subset (#188/#201), split out to keep `css.rs` nearer the size guideline.
+//! Included via `#[path]` so `super::*` resolves to the css module.
+
+use super::*;
+use scraper::Html;
+
+/// Resolve the declared style of the element carrying `data-t` in `html`, against `css`.
+/// Going through a real parsed document is the point: matching now sees the whole tree.
+fn styled(css: &str, html: &str) -> BlockStyle {
+    let owned = Stylesheet::parse(css);
+    let sheet = simplecss::StyleSheet::parse(owned.source());
+    let doc = Html::parse_document(html);
+    let node = target(doc.tree.root()).expect("no element carries data-t");
+    let style_attr = node.value().as_element().and_then(|el| el.attr("style"));
+    resolve(&sheet, &StyledNode(node), style_attr)
+}
+
+fn target(node: NodeRef<'_, Node>) -> Option<NodeRef<'_, Node>> {
+    for child in node.children() {
+        if child
+            .value()
+            .as_element()
+            .is_some_and(|el| el.attr("data-t").is_some())
+        {
+            return Some(child);
+        }
+        if let Some(found) = target(child) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// The stylesheet from #188 — Project Gutenberg's *Pride and Prejudice* (#1342), the book whose
+/// title page rendered as left-aligned bold fragments.
+const PG_CSS: &str = r"
+    h1        { margin-top: 5%; text-align: center; clear: both; font-weight: normal }
+    .c        { text-align: center; text-indent: 0% }
+    .cbig250  { text-align: center; text-indent: 0%; font-weight: normal; font-size: 200% }
+";
+
+#[test]
+fn the_pride_and_prejudice_title_resolves_centred_unbolded_and_unindented() {
+    let h1 = styled(PG_CSS, "<body><h1 data-t>PRIDE</h1></body>");
+    assert_eq!(h1.align, Some(Align::Center), "text-align was dropped");
+    assert_eq!(h1.bold, Some(false), "font-weight: normal was dropped");
+
+    let c = styled(PG_CSS, r#"<body><p class="c" data-t>x</p></body>"#);
+    assert_eq!(c.align, Some(Align::Center));
+    assert_eq!(c.indent, Some(false), "text-indent: 0% was dropped");
+}
+
+/// #201: the selectors the hand-rolled subset dropped. `div.titlepage p` is ordinary Sigil,
+/// InDesign and calibre output, so these are not an exotic tail.
+#[test]
+fn selectors_beyond_a_single_element_now_resolve() {
+    let cases: [(&str, &str); 5] = [
+        (
+            "div.titlepage p { text-align: center }",
+            r#"<body><div class="titlepage"><p data-t>x</p></div></body>"#,
+        ),
+        (
+            "div > p { text-align: center }",
+            "<body><div><p data-t>x</p></div></body>",
+        ),
+        (
+            "#title { text-align: center }",
+            r#"<body><p id="title" data-t>x</p></body>"#,
+        ),
+        (
+            "p[lang] { text-align: center }",
+            r#"<body><p lang="fr" data-t>x</p></body>"#,
+        ),
+        (
+            "p:first-child { text-align: center }",
+            "<body><div><p data-t>x</p><p>y</p></div></body>",
+        ),
+    ];
+    for (css, html) in cases {
+        assert_eq!(
+            styled(css, html).align,
+            Some(Align::Center),
+            "selector dropped: {css}"
+        );
+    }
+    // …and they still discriminate: the same rules must not match the wrong element.
+    assert_eq!(
+        styled(
+            "div.titlepage p { text-align: center }",
+            r#"<body><div class="other"><p data-t>x</p></div></body>"#
+        )
+        .align,
+        None
+    );
+    assert_eq!(
+        styled(
+            "p:first-child { text-align: center }",
+            "<body><div><p>y</p><p data-t>x</p></div></body>"
+        )
+        .align,
+        None
+    );
+}
+
+#[test]
+fn class_beats_element_and_later_beats_earlier_at_equal_specificity() {
+    let css = "p { text-align: left } .mid { text-align: center } p { font-weight: bold }";
+    assert_eq!(
+        styled(css, r#"<body><p class="mid" data-t>x</p></body>"#).align,
+        Some(Align::Center)
+    );
+    let plain = styled(css, "<body><p data-t>x</p></body>");
+    assert_eq!(plain.align, Some(Align::Left));
+    assert_eq!(plain.bold, Some(true));
+
+    assert_eq!(
+        styled(
+            "p { text-align: left } p { text-align: right }",
+            "<body><p data-t>x</p></body>"
+        )
+        .align,
+        Some(Align::Right)
+    );
+}
+
+#[test]
+fn a_tag_qualified_class_outranks_a_bare_class() {
+    let css = ".t { text-align: center } h1.t { text-align: right }";
+    assert_eq!(
+        styled(css, r#"<body><h1 class="t" data-t>x</h1></body>"#).align,
+        Some(Align::Right)
+    );
+    assert_eq!(
+        styled(css, r#"<body><p class="t" data-t>x</p></body>"#).align,
+        Some(Align::Center)
+    );
+}
+
+#[test]
+fn an_inline_style_attribute_outranks_every_rule() {
+    let s = styled(
+        "p { text-align: left }",
+        r#"<body><p style="text-align: center; text-indent: 0" data-t>x</p></body>"#,
+    );
+    assert_eq!(s.align, Some(Align::Center));
+    assert_eq!(s.indent, Some(false));
+}
+
+#[test]
+fn a_class_matches_one_of_several_including_across_newlines() {
+    let css = ".c { text-align: center }";
+    assert_eq!(
+        styled(css, r#"<body><p class="first c last" data-t>x</p></body>"#).align,
+        Some(Align::Center)
+    );
+    // A prettified class list is whitespace, not necessarily single spaces.
+    assert_eq!(
+        styled(css, "<body><p class=\"first\n  c\" data-t>x</p></body>").align,
+        Some(Align::Center)
+    );
+    assert_eq!(
+        styled(css, r#"<body><p class="cc" data-t>x</p></body>"#).align,
+        None,
+        "no prefix match"
+    );
+}
+
+#[test]
+fn at_rules_do_not_lose_the_rules_around_them() {
+    let sheet = r#"@charset "utf-8";
+                   @import url(other.css);
+                   h1 { text-align: center }
+                   @font-face { font-family: x; src: url(x.ttf) }
+                   p { text-indent: 0 }"#;
+    assert_eq!(
+        styled(sheet, "<body><h1 data-t>x</h1></body>").align,
+        Some(Align::Center)
+    );
+    assert_eq!(
+        styled(sheet, "<body><p data-t>x</p></body>").indent,
+        Some(false),
+        "rule after @font-face lost"
+    );
+}
+
+#[test]
+fn comments_are_stripped() {
+    assert_eq!(
+        styled(
+            "/* c */ h1 { text-align: /* mid */ center }",
+            "<body><h1 data-t>x</h1></body>"
+        )
+        .align,
+        Some(Align::Center)
+    );
+}
+
+#[test]
+fn text_indent_is_a_zero_opt_out_not_a_measurement() {
+    for zero in ["0", "0em", "0%", "0.0px", "+0em", "-0em"] {
+        let css = format!("p {{ text-indent: {zero} }}");
+        assert_eq!(
+            styled(&css, "<body><p data-t>x</p></body>").indent,
+            Some(false),
+            "{zero}"
+        );
+    }
+    for nonzero in ["1.5em", "5%", "12px", "inherit"] {
+        let css = format!("p {{ text-indent: {nonzero} }}");
+        assert_eq!(
+            styled(&css, "<body><p data-t>x</p></body>").indent,
+            Some(true),
+            "{nonzero}"
+        );
+    }
+}
+
+#[test]
+fn font_weight_splits_at_600_like_css() {
+    for normal in ["normal", "lighter", "100", "400", "500"] {
+        let css = format!("h1 {{ font-weight: {normal} }}");
+        assert_eq!(
+            styled(&css, "<body><h1 data-t>x</h1></body>").bold,
+            Some(false),
+            "{normal}"
+        );
+    }
+    for bold in ["bold", "bolder", "600", "700", "900"] {
+        let css = format!("h1 {{ font-weight: {bold} }}");
+        assert_eq!(
+            styled(&css, "<body><h1 data-t>x</h1></body>").bold,
+            Some(true),
+            "{bold}"
+        );
+    }
+    assert_eq!(
+        styled("h1 { font-weight: wat }", "<body><h1 data-t>x</h1></body>").bold,
+        None,
+        "an unparseable weight declares nothing"
+    );
+}
+
+#[test]
+fn important_is_stripped_and_alignment_keywords_map() {
+    assert_eq!(
+        styled(
+            "p { text-align: center !important }",
+            "<body><p data-t>x</p></body>"
+        )
+        .align,
+        Some(Align::Center)
+    );
+    for (css, want) in [
+        ("left", Align::Left),
+        ("start", Align::Left),
+        ("right", Align::Right),
+        ("end", Align::Right),
+        ("justify", Align::Justify),
+    ] {
+        let rule = format!("p {{ text-align: {css} }}");
+        assert_eq!(
+            styled(&rule, "<body><p data-t>x</p></body>").align,
+            Some(want),
+            "{css}"
+        );
+    }
+}
+
+#[test]
+fn selectors_and_properties_are_case_insensitive() {
+    assert_eq!(
+        styled(
+            "H1 { TEXT-ALIGN: CENTER }",
+            "<body><h1 data-t>x</h1></body>"
+        )
+        .align,
+        Some(Align::Center)
+    );
+}
+
+#[test]
+fn malformed_css_yields_no_rules_and_never_panics() {
+    for junk in [
+        "",
+        "   ",
+        "}}}{{{",
+        "p {",
+        "p { text-align",
+        "{ }",
+        ";;;",
+        "p { : center }",
+        "p { text-align: }",
+        "@media {",
+        "\u{0}\u{1}",
+    ] {
+        let _ = styled(junk, "<body><p data-t>x</p></body>"); // must not panic
+    }
+    assert!(
+        styled("p { color: red }", "<body><p data-t>x</p></body>").is_empty(),
+        "no honoured property"
+    );
+}
+
+/// A book's CSS is arbitrary bytes; nothing here may panic on non-ASCII, and a rule beside the
+/// non-ASCII must still be understood (RR21-FR3).
+#[test]
+fn multibyte_css_never_panics_and_still_parses() {
+    for css in [
+        "/* коммент */ h1 { text-align: center }",
+        "/* незакрытый h1 { text-align: center }",
+        ".Ünicöde { text-align: center }",
+        "h1 { text-align: cëntre }",
+        "h1 { font-family: \"日本語\"; text-align: center }",
+        "日本語 { text-align: center }",
+        "h1 { text-indent: 0日 }",
+        "h1 { text-align: center /* 日",
+        "🙂 { text-align: center } h1 { text-align: right }",
+    ] {
+        let _ = styled(css, r#"<body><h1 class="Ünicöde" data-t>x</h1></body>"#);
+    }
+    assert_eq!(
+        styled(
+            "/* коммент */ h1 { text-align: center }",
+            "<body><h1 data-t>x</h1></body>"
+        )
+        .align,
+        Some(Align::Center)
+    );
+    // Non-ASCII *values* are fine, and a rule beside them still resolves.
+    assert_eq!(
+        styled(
+            "h1 { font-family: \"日本語\"; text-align: right }",
+            "<body><h1 data-t>x</h1></body>"
+        )
+        .align,
+        Some(Align::Right)
+    );
+}
+
+/// A known limitation of the selector engine, pinned so it is a decision rather than a surprise.
+///
+/// simplecss 0.2.2 treats a character as identifier-legal only when `c as u32 > 237`
+/// (`stream.rs::is_non_ascii`), where CSS says `>= 0x80`. Identifiers holding U+0080–U+00ED —
+/// which is most Western European accented letters, `Ü` (U+00DC) among them — therefore fail to
+/// parse, and a rule keyed on such a class is dropped rather than mis-applied.
+///
+/// Accepted deliberately: ASCII class names are what calibre, Sigil and InDesign emit, and the
+/// combinator/id/attribute/pseudo selectors gained in exchange are far commoner in real books.
+/// Above the threshold (`ö`, U+00F6) it already works, which is why this pins both sides.
+#[test]
+fn a_latin1_class_name_is_a_known_selector_engine_limitation() {
+    assert_eq!(
+        styled(
+            ".Ünicöde { text-align: right }",
+            r#"<body><p class="Ünicöde" data-t>x</p></body>"#
+        )
+        .align,
+        None,
+        "if this now matches, simplecss fixed is_non_ascii — drop this test and the caveat"
+    );
+    // Dropped, never mis-applied: the surrounding rules still resolve.
+    assert_eq!(
+        styled(
+            ".Ünicöde { text-align: right } p { text-align: center }",
+            r#"<body><p class="Ünicöde" data-t>x</p></body>"#
+        )
+        .align,
+        Some(Align::Center)
+    );
+    // A class name above the threshold parses and matches normally.
+    assert_eq!(
+        styled(
+            ".öbig { text-align: right }",
+            r#"<body><p class="öbig" data-t>x</p></body>"#
+        )
+        .align,
+        Some(Align::Right)
+    );
+}
+
+#[test]
+fn multiple_sources_layer_with_later_winning() {
+    let mut sheet = Stylesheet::parse("p { text-align: left }");
+    sheet.add("p { text-align: center }");
+    let parsed = simplecss::StyleSheet::parse(sheet.source());
+    let doc = Html::parse_document("<body><p data-t>x</p></body>");
+    let node = target(doc.tree.root()).unwrap();
+    assert_eq!(
+        resolve(&parsed, &StyledNode(node), None).align,
+        Some(Align::Center)
+    );
+}
+
+#[test]
+fn a_comma_separated_selector_list_applies_to_every_branch() {
+    let css = "h1, h2, .t { text-align: center }";
+    for html in [
+        "<body><h1 data-t>x</h1></body>",
+        "<body><h2 data-t>x</h2></body>",
+        r#"<body><p class="t" data-t>x</p></body>"#,
+    ] {
+        assert_eq!(styled(css, html).align, Some(Align::Center), "{html}");
+    }
+    assert_eq!(styled(css, "<body><h3 data-t>x</h3></body>").align, None);
+}
+
+#[test]
+fn an_empty_stylesheet_is_empty_and_adding_blank_sources_keeps_it_so() {
+    let mut sheet = Stylesheet::default();
+    assert!(sheet.is_empty());
+    sheet.add("   \n  ");
+    assert!(
+        sheet.is_empty(),
+        "blank source should not make it non-empty"
+    );
+    sheet.add("p { text-align: center }");
+    assert!(!sheet.is_empty());
+}


### PR DESCRIPTION
## What & why

#188 landed a hand-rolled CSS subset that matched type and class selectors only. Everything
reaching past a single element was ignored by design — and that is where a large share of real
books declare their title pages:

```css
div.titlepage p { text-align: center }   /* dropped */
#title          { text-align: center }   /* dropped */
p:first-child   { text-indent: 0 }       /* dropped */
```

`div.titlepage p` is ordinary Sigil, InDesign and calibre output, so books written that way still
showed #188's symptom after it was fixed. This replaces our matcher with a real one.

Closes #201

## Requirements / design refs

- ADR-INKREAD-0007 Decision 1 / `ADR-RUST-READER` Decision 1 — unchanged. Still no cascade, no box
  model, no lengths; the simplified content model stands. What moved is *selector matching*, which
  was never the part the ADR was protecting.
- RR21-FR3 — malformed and non-ASCII CSS still yields fewer rules, never an error or a panic.

## How it works

`simplecss` (MIT OR Apache-2.0) owns selector parsing, matching and specificity ordering. inkread
keeps the policy: which three properties are honoured (`text-align`, `text-indent`, `font-weight`)
and what their values mean here.

A `StyledNode` bridges the html5ever tree the content walker already holds to the library's
`Element` trait, so matching resolves against the real document rather than a single element in
isolation. Class matching normalises whitespace first, because `simplecss` splits a class list on
single spaces while prettified XHTML wraps them across lines.

`Stylesheet` now holds owned CSS source, because `simplecss::StyleSheet` borrows what it parses and
`EpubPackage` is owned/`Clone`/`Eq`. The borrowed sheet is built once per chapter parse, not once
per block.

Deliberately **not** scraper's own `cssparser`/`selectors` stack, though both are already in the
tree: scraper keeps its inner `SelectorList` private, so `specificity()` is unreachable through it,
and getting at it means taking `selectors` as a direct dependency plus scraper's parser types —
more plumbing than three properties justify.

`css.rs` drops from 561 lines to 256, with its tests moved into `css_tests.rs` alongside the
`layout_tests.rs` split.

## Known limitation

`simplecss` 0.2.2 treats a character as identifier-legal only when `c as u32 > 237`
(`stream.rs::is_non_ascii`), where CSS says `>= 0x80`. A class name holding U+0080–U+00ED — most
Western European accented letters, `Ü` (U+00DC) among them — therefore fails to parse, and its rule
is **dropped rather than mis-applied**; surrounding rules still resolve. Above the threshold (`ö`,
U+00F6) it works normally.

The old hand-rolled matcher handled those. Accepted deliberately: ASCII class names are what the
common tooling emits, and the combinator/id/attribute/pseudo selectors gained in exchange are far
more frequent in real books. A test pins both sides of the threshold, and says to delete itself if
upstream fixes `is_non_ascii`.

## How it was tested

- [x] `cargo test --workspace` is green — 586 passing, 0 failing
- [x] Added/updated a test that fails without this change
- [ ] Verified on a device (Supernote) — host-only change to parsing/layout; the #188 device check
      covers the rendered result

- `css_tests.rs` — the five selector forms the old subset dropped, each asserted to match *and* to
  not match the wrong element; specificity and source order; at-rules; `!important`; case
  insensitivity; the zero-indent opt-out; the 600 weight split; malformed and multibyte input.
- `content.rs` — `div.titlepage p` reaching a real `Block`, with prose outside the container
  untouched.
- `./scripts/check-licenses.sh` — clean; simplecss is MIT/Apache-2.0.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `cargo llvm-cov --workspace` — coverage holds
- [x] `./scripts/check-licenses.sh` — no new/unvetted dependency licenses
- [x] The Rust core still builds host-only
- [x] The core names no vendor (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
