### PR TITLE
perf: stop wasting ~2.6s of every book open (#186)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -546,7 +546,11 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     // ---- SurfaceHolder lifecycle → core (RR21-FR4) ----
 
+    /** Keeps a repeat `surfaceChanged` from re-rendering the page it just drew (#186). */
+    private val renderGate = SurfaceRenderGate()
+
     override fun surfaceCreated(holder: SurfaceHolder) {
+        renderGate.onSurfaceCreated()
         // Paint the surface white the instant it exists, on this thread. The size arrives in
         // surfaceChanged, whose work is handed to the engine thread — so the "Loading…" frame can be
         // queued behind whatever that thread is already doing. Until something is pushed, a
@@ -703,6 +707,14 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     // ---- engine-thread work ----
 
     private fun onSurfaceSized(width: Int, height: Int) {
+        // Android delivers surfaceChanged more than once per surface, at the same size. Rendering
+        // each one drew the opening page twice — a full page layout and an EPD refresh thrown away
+        // on the slowest path there is (#186). A recreated surface still renders: see
+        // [SurfaceRenderGate].
+        if (!renderGate.needsRender(width, height, docHandle != 0L)) {
+            diag { "DIAG surfaceChanged ${width}x$height ignored (already rendered)" }
+            return
+        }
         viewW = width
         viewH = height
         bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)

--- a/app/src/main/java/dev/jraghavan/inkread/SurfaceRenderGate.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SurfaceRenderGate.kt
@@ -1,0 +1,52 @@
+package dev.jraghavan.inkread
+
+/**
+ * Decides whether a `surfaceChanged` callback has to re-render the page (#186).
+ *
+ * Android delivers `surfaceChanged` more than once for a single surface — typically again once the
+ * window has settled — with identical dimensions each time. The reader rendered on every one of
+ * them, so opening a book drew page 0 twice: on the book #186 measured that is ~1.3s of core work
+ * thrown away, before anything is on screen, plus a wasted EPD refresh.
+ *
+ * Skipping a repeat is not simply "same size, do nothing", because a surface that was destroyed and
+ * recreated (leaving and returning to the reader) also comes back at the same size and *must*
+ * redraw — a SurfaceView shows black until something is pushed to it. The two cases are told apart
+ * by surface generation: [onSurfaceCreated] starts a new one, and a render is redundant only when
+ * this generation has already been rendered at this exact size.
+ *
+ * Pure + host-testable — no Android types. All calls arrive on the engine thread except
+ * [onSurfaceCreated], which the UI thread makes, so the generation counter is `@Volatile`.
+ */
+class SurfaceRenderGate {
+
+    @Volatile
+    private var generation = 0
+
+    private var renderedGeneration = -1
+    private var renderedWidth = 0
+    private var renderedHeight = 0
+
+    /** A new surface exists: whatever was drawn before is gone, so the next size must render. */
+    fun onSurfaceCreated() {
+        generation++
+    }
+
+    /**
+     * Report whether a `surfaceChanged` at `width` x `height` needs to render, recording it when it
+     * does. `documentOpen` is false before a document exists — nothing can be redundant then, since
+     * the work that call does is the open itself.
+     */
+    fun needsRender(width: Int, height: Int, documentOpen: Boolean): Boolean {
+        val redundant = documentOpen &&
+            generation == renderedGeneration &&
+            width == renderedWidth &&
+            height == renderedHeight
+        if (redundant) {
+            return false
+        }
+        renderedGeneration = generation
+        renderedWidth = width
+        renderedHeight = height
+        return true
+    }
+}

--- a/app/src/main/java/dev/jraghavan/inkread/SurfaceRenderGate.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SurfaceRenderGate.kt
@@ -35,6 +35,16 @@ class SurfaceRenderGate {
      * Report whether a `surfaceChanged` at `width` x `height` needs to render, recording it when it
      * does. `documentOpen` is false before a document exists — nothing can be redundant then, since
      * the work that call does is the open itself.
+     *
+     * The generation read here is whatever is current when this runs, not the one in force when the
+     * callback was delivered: `surfaceChanged` hands its work to the engine thread, so a queued call
+     * can be overtaken by a destroy/recreate. That is harmless — the late call then records the new
+     * generation and renders, and the blit targets whichever surface is live — but it does mean a
+     * render is attributed to the generation it *lands* in, not the one it was queued from.
+     *
+     * The render is recorded before it happens, so a failure while rendering leaves the gate
+     * marked. The next callback arrives with `documentOpen = false` and renders anyway, which is
+     * why that is safe rather than merely unlikely.
      */
     fun needsRender(width: Int, height: Int, documentOpen: Boolean): Boolean {
         val redundant = documentOpen &&

--- a/app/src/test/java/dev/jraghavan/inkread/SurfaceRenderGateTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/SurfaceRenderGateTest.kt
@@ -1,0 +1,82 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for [SurfaceRenderGate] (#186).
+ *
+ * Two failure modes sit on either side of this decision, and both are expensive: rendering a repeat
+ * callback wastes a full page layout and an EPD refresh on the open path, while skipping a render
+ * that was needed leaves a SurfaceView showing black. The cases below pin both edges.
+ */
+class SurfaceRenderGateTest {
+
+    @Test
+    fun theFirstSizeAlwaysRenders() {
+        val gate = SurfaceRenderGate()
+        gate.onSurfaceCreated()
+        assertTrue(gate.needsRender(1920, 2560, documentOpen = false))
+    }
+
+    /** The #186 case: Android delivers surfaceChanged twice at the same size. */
+    @Test
+    fun aRepeatCallbackAtTheSameSizeDoesNotRenderAgain() {
+        val gate = SurfaceRenderGate()
+        gate.onSurfaceCreated()
+        assertTrue(gate.needsRender(1920, 2560, documentOpen = false))
+        assertFalse(gate.needsRender(1920, 2560, documentOpen = true))
+        assertFalse(gate.needsRender(1920, 2560, documentOpen = true))
+    }
+
+    /** A rotation or resize is a real change and must redraw. */
+    @Test
+    fun aDifferentSizeRenders() {
+        val gate = SurfaceRenderGate()
+        gate.onSurfaceCreated()
+        assertTrue(gate.needsRender(1920, 2560, documentOpen = false))
+        assertTrue(gate.needsRender(2560, 1920, documentOpen = true))
+        assertFalse(gate.needsRender(2560, 1920, documentOpen = true), "settled at the new size")
+        assertTrue(gate.needsRender(1920, 2560, documentOpen = true), "and back again")
+    }
+
+    /**
+     * The trap in the cheap version of this fix: leaving the reader and returning destroys and
+     * recreates the surface at the SAME size. Nothing has been drawn to the new surface, so
+     * "same size" alone would leave the panel black.
+     */
+    @Test
+    fun aRecreatedSurfaceRendersEvenAtTheSameSize() {
+        val gate = SurfaceRenderGate()
+        gate.onSurfaceCreated()
+        assertTrue(gate.needsRender(1920, 2560, documentOpen = false))
+        assertFalse(gate.needsRender(1920, 2560, documentOpen = true))
+
+        gate.onSurfaceCreated() // back from elsewhere: new surface, same size
+        assertTrue(
+            gate.needsRender(1920, 2560, documentOpen = true),
+            "a new surface has nothing drawn on it yet",
+        )
+        assertFalse(gate.needsRender(1920, 2560, documentOpen = true), "settled again")
+    }
+
+    /**
+     * Before a document is open there is nothing to be redundant about — that call is the open
+     * itself, and skipping it would mean never opening the book.
+     */
+    @Test
+    fun withNoDocumentOpenEveryCallRenders() {
+        val gate = SurfaceRenderGate()
+        gate.onSurfaceCreated()
+        repeat(3) {
+            assertTrue(gate.needsRender(1920, 2560, documentOpen = false), "call $it")
+        }
+    }
+}
+
+private fun assertTrue(condition: Boolean, message: String) =
+    org.junit.Assert.assertTrue(message, condition)
+
+private fun assertFalse(condition: Boolean, message: String) =
+    org.junit.Assert.assertFalse(message, condition)

--- a/app/src/test/java/dev/jraghavan/inkread/SurfaceRenderGateTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/SurfaceRenderGateTest.kt
@@ -37,8 +37,8 @@ class SurfaceRenderGateTest {
         gate.onSurfaceCreated()
         assertTrue(gate.needsRender(1920, 2560, documentOpen = false))
         assertTrue(gate.needsRender(2560, 1920, documentOpen = true))
-        assertFalse(gate.needsRender(2560, 1920, documentOpen = true), "settled at the new size")
-        assertTrue(gate.needsRender(1920, 2560, documentOpen = true), "and back again")
+        assertFalse("settled at the new size", gate.needsRender(2560, 1920, documentOpen = true))
+        assertTrue("and back again", gate.needsRender(1920, 2560, documentOpen = true))
     }
 
     /**
@@ -55,10 +55,10 @@ class SurfaceRenderGateTest {
 
         gate.onSurfaceCreated() // back from elsewhere: new surface, same size
         assertTrue(
-            gate.needsRender(1920, 2560, documentOpen = true),
             "a new surface has nothing drawn on it yet",
+            gate.needsRender(1920, 2560, documentOpen = true),
         )
-        assertFalse(gate.needsRender(1920, 2560, documentOpen = true), "settled again")
+        assertFalse("settled again", gate.needsRender(1920, 2560, documentOpen = true))
     }
 
     /**
@@ -70,13 +70,7 @@ class SurfaceRenderGateTest {
         val gate = SurfaceRenderGate()
         gate.onSurfaceCreated()
         repeat(3) {
-            assertTrue(gate.needsRender(1920, 2560, documentOpen = false), "call $it")
+            assertTrue("call $it", gate.needsRender(1920, 2560, documentOpen = false))
         }
     }
 }
-
-private fun assertTrue(condition: Boolean, message: String) =
-    org.junit.Assert.assertTrue(message, condition)
-
-private fun assertFalse(condition: Boolean, message: String) =
-    org.junit.Assert.assertFalse(message, condition)

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -336,7 +336,6 @@ pub fn paginate_with_images(
 /// An in-progress page is discarded when stopping early: it is incomplete, and the caller asked
 /// only for pages that are whole.
 #[must_use]
-#[allow(clippy::too_many_arguments)]
 pub fn paginate_upto(
     blocks: &[Block],
     opts: &LayoutOpts,

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -358,7 +358,7 @@ pub fn paginate_upto(
     for (block_index, block) in blocks.iter().enumerate() {
         // Checked before the block, not after: once enough whole pages exist, laying out one more
         // block is work the caller has said it does not need.
-        if pager.finished_pages() >= max_pages {
+        if pager.finished_page_count() >= max_pages {
             complete = false;
             break;
         }
@@ -549,7 +549,7 @@ impl<'o> Pager<'o> {
     }
 
     /// How many *whole* pages have been broken off so far (the in-progress one is not counted).
-    fn finished_pages(&self) -> usize {
+    fn finished_page_count(&self) -> usize {
         self.pages.len()
     }
 

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -322,6 +322,29 @@ pub fn paginate_with_images(
     hyph: &dyn Hyphenator,
     images: &dyn ImageSizer,
 ) -> Vec<Page> {
+    paginate_upto(blocks, opts, m, hyph, images, usize::MAX).0
+}
+
+/// As [`paginate_with_images`], but stops once `max_pages` complete pages exist (#186).
+///
+/// Returns `(pages, complete)`, where `complete` is false when blocks were left unlaid. Showing one
+/// page means laying out only as far as that page: a reader resuming at the top of a long chapter
+/// otherwise pays for every page of it to see the first, which is the dominant cost of opening a
+/// book. The pages returned are byte-identical to the same prefix of a full pass — a page break
+/// depends only on what precedes it — so a partial pagination is a prefix, never an approximation.
+///
+/// An in-progress page is discarded when stopping early: it is incomplete, and the caller asked
+/// only for pages that are whole.
+#[must_use]
+#[allow(clippy::too_many_arguments)]
+pub fn paginate_upto(
+    blocks: &[Block],
+    opts: &LayoutOpts,
+    m: &dyn Metrics,
+    hyph: &dyn Hyphenator,
+    images: &dyn ImageSizer,
+    max_pages: usize,
+) -> (Vec<Page>, bool) {
     let mut pager = Pager::new(opts, hyph);
     // Chapter-relative character cursor, advanced as source text is consumed in reading order, so
     // every placed run/glyph carries a font-invariant offset (ADR-INKREAD-0012).
@@ -331,7 +354,14 @@ pub fn paginate_with_images(
     // lines" web look). Headings are bold + scaled with a margin before (0.7em) and after (0.5em);
     // the before-margin collapses at the top of a page.
     let indent = opts.font_px * 1.2;
+    let mut complete = true;
     for (block_index, block) in blocks.iter().enumerate() {
+        // Checked before the block, not after: once enough whole pages exist, laying out one more
+        // block is work the caller has said it does not need.
+        if pager.finished_pages() >= max_pages {
+            complete = false;
+            break;
+        }
         match block {
             Block::Heading {
                 level,
@@ -454,7 +484,11 @@ pub fn paginate_with_images(
             Block::Rule => pager.add_rule(opts.para_gap),
         }
     }
-    pager.finish()
+    if complete {
+        (pager.finish(), true)
+    } else {
+        (pager.into_finished_pages(), false)
+    }
 }
 
 /// Accumulates lines into pages, breaking when the content box is full.
@@ -512,6 +546,16 @@ impl<'o> Pager<'o> {
             lines: std::mem::take(&mut self.current),
         });
         self.cursor_y = 0.0;
+    }
+
+    /// How many *whole* pages have been broken off so far (the in-progress one is not counted).
+    fn finished_pages(&self) -> usize {
+        self.pages.len()
+    }
+
+    /// The whole pages only, discarding the page still being filled — used when stopping early.
+    fn into_finished_pages(self) -> Vec<Page> {
+        self.pages
     }
 
     fn finish(mut self) -> Vec<Page> {

--- a/inkread-epub/src/layout_tests.rs
+++ b/inkread-epub/src/layout_tests.rs
@@ -870,3 +870,123 @@ fn source_offsets_after_an_image_do_not_depend_on_it_resolving() {
         "an image occupies one character position either way"
     );
 }
+
+// ---------------------------------------------------------------------------------------------
+// #186 — stopping pagination once the requested page exists.
+// ---------------------------------------------------------------------------------------------
+
+/// A page short enough that the fixture below runs to many pages: 100px wide (20 chars a line at
+/// the 10px Mono metrics), 50px tall (5 lines a page).
+fn paged_opts() -> LayoutOpts {
+    LayoutOpts {
+        page_h: 50.0,
+        ..style_opts()
+    }
+}
+
+/// Enough prose to run to many pages at the tiny test metrics.
+fn long_book() -> Vec<Block> {
+    (0..60)
+        .map(|i| {
+            para(&format!(
+                "Paragraph {i} alpha bravo charlie delta echo foxtrot golf hotel"
+            ))
+        })
+        .collect()
+}
+
+/// The property the whole optimisation rests on: a partial pass is a *prefix* of the full one, not
+/// an approximation. A page break depends only on what precedes it, so stopping early cannot move
+/// an earlier boundary — if it could, a resumed reading position would land on a different page
+/// than the one the pagination index counted.
+#[test]
+fn a_partial_pagination_is_a_prefix_of_the_full_one() {
+    let opts = paged_opts();
+    let blocks = long_book();
+    let (full, complete) = paginate_upto(&blocks, &opts, &Mono, &NoHyphen, &NoImages, usize::MAX);
+    assert!(complete, "an unbounded pass is always complete");
+    assert!(
+        full.len() > 5,
+        "need a multi-page fixture, got {}",
+        full.len()
+    );
+
+    for want in 1..=5 {
+        let (partial, complete) = paginate_upto(&blocks, &opts, &Mono, &NoHyphen, &NoImages, want);
+        assert!(
+            !complete,
+            "{want} pages should not exhaust a {}-page book",
+            full.len()
+        );
+        assert!(partial.len() >= want, "asked {want}, got {}", partial.len());
+        for (i, page) in partial.iter().enumerate().take(want) {
+            assert_eq!(page, &full[i], "page {i} differs when stopping at {want}");
+        }
+    }
+}
+
+#[test]
+fn asking_for_more_pages_than_exist_returns_them_all_and_reports_complete() {
+    let opts = paged_opts();
+    let blocks = long_book();
+    let full = paginate_with_images(&blocks, &opts, &Mono, &NoHyphen, &NoImages);
+    let (all, complete) = paginate_upto(&blocks, &opts, &Mono, &NoHyphen, &NoImages, 10_000);
+    assert!(complete);
+    assert_eq!(all, full, "an over-large bound must not change the result");
+}
+
+/// The point of the change: laying out one page must not walk the whole chapter.
+#[test]
+fn stopping_early_does_less_work_than_a_full_pass() {
+    use std::cell::Cell;
+    struct Counting<'a>(&'a Cell<usize>);
+    impl Metrics for Counting<'_> {
+        fn advance(&self, text: &str, size_px: f32, _b: bool, _i: bool) -> f32 {
+            self.0.set(self.0.get() + 1);
+            text.chars().count() as f32 * size_px * 0.5
+        }
+    }
+    let opts = paged_opts();
+    let blocks = long_book();
+
+    let full_calls = Cell::new(0);
+    let _ = paginate_upto(
+        &blocks,
+        &opts,
+        &Counting(&full_calls),
+        &NoHyphen,
+        &NoImages,
+        usize::MAX,
+    );
+
+    let one_calls = Cell::new(0);
+    let (pages, complete) = paginate_upto(
+        &blocks,
+        &opts,
+        &Counting(&one_calls),
+        &NoHyphen,
+        &NoImages,
+        1,
+    );
+
+    assert!(!complete);
+    assert!(!pages.is_empty(), "one page must still be produced");
+    assert!(
+        one_calls.get() * 4 < full_calls.get(),
+        "laying out one page took {} measurements vs {} for the whole chapter — not a saving",
+        one_calls.get(),
+        full_calls.get()
+    );
+}
+
+#[test]
+fn a_zero_bound_lays_nothing_out_and_an_empty_book_is_complete() {
+    let opts = paged_opts();
+    let (pages, complete) = paginate_upto(&long_book(), &opts, &Mono, &NoHyphen, &NoImages, 0);
+    assert!(pages.is_empty(), "a zero bound must lay out nothing");
+    assert!(!complete);
+
+    let (pages, complete) = paginate_upto(&[], &opts, &Mono, &NoHyphen, &NoImages, 5);
+    assert!(pages.is_empty());
+    assert!(complete, "there was nothing left unlaid");
+}

--- a/inkread-epub/src/lib.rs
+++ b/inkread-epub/src/lib.rs
@@ -27,8 +27,8 @@ pub use content::{parse_blocks, parse_blocks_with, Block, Inline, TextRun};
 pub use css::{BlockStyle, Stylesheet};
 pub use img::ImageError;
 pub use layout::{
-    paginate, paginate_with, paginate_with_images, Align, Hyphenator, ImageSizer, LayoutLine,
-    LayoutOpts, Metrics, NoHyphen, NoImages, Page, PlacedImage, PlacedRun,
+    paginate, paginate_upto, paginate_with, paginate_with_images, Align, Hyphenator, ImageSizer,
+    LayoutLine, LayoutOpts, Metrics, NoHyphen, NoImages, Page, PlacedImage, PlacedRun,
 };
 pub use measure::{CachedHyphenator, CachedMetrics};
 pub use render::{

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -308,19 +308,16 @@ impl EpubBackend {
         }
     }
 
-    /// Lay out chapter `index` on its own. Pagination is per chapter by construction — a chapter
-    /// always starts a fresh page and nothing carries across the boundary — so a chapter laid out
-    /// alone is identical to its slice of a whole-book pass. That is what makes materializing one
-    /// chapter at a time sound rather than merely convenient.
-    #[cfg(test)]
-    fn lay_out_chapter(&self, index: usize, opts: &LayoutOpts) -> Vec<Page> {
-        self.lay_out_chapter_upto(index, opts, usize::MAX).0
-    }
-
-    /// Lay chapter `index` out as far as `want` whole pages, returning `(pages, complete)` (#186).
+    /// Lay chapter `index` out as far as `want` whole pages, returning `(pages, complete)`.
+    ///
+    /// Pagination is per chapter by construction — a chapter always starts a fresh page and nothing
+    /// carries across the boundary — so a chapter laid out alone is identical to its slice of a
+    /// whole-book pass. That is what makes materializing one chapter at a time sound rather than
+    /// merely convenient, and it extends to a *partial* chapter: `want` pages are identical to the
+    /// first `want` pages of the full pass, because a page break depends only on what precedes it.
     ///
     /// Materializing a whole chapter to show one of its pages is the dominant cost of opening a
-    /// book, and a reader resuming at a chapter start needs exactly one page of it.
+    /// book, and a reader resuming at a chapter start needs exactly one page of it (#186).
     fn lay_out_chapter_upto(
         &self,
         index: usize,
@@ -364,15 +361,19 @@ impl EpubBackend {
         };
 
         // A cached chapter serves the page if it was laid out that far, or if we know there is no
-        // more to lay out.
+        // more to lay out. `f` runs while `chapter_pages` is borrowed, so it must not re-enter
+        // `with_page` — every caller passes a pure read of the page.
         let cached = {
             let cache = self.chapter_pages.borrow();
             match cache.iter().find(|c| c.chapter == chapter) {
                 Some(entry) if entry.pages.len() > offset => {
                     return entry.pages.get(offset).map(|p| f(p, &opts));
                 }
-                Some(entry) if entry.complete => return None, // past the end of a finished chapter
-                Some(_) => true,                              // materialized, but not this far yet
+                // Defence in depth: an in-range page always falls inside its chapter's counted
+                // length, so this is unreachable unless the pagination index and the layout have
+                // diverged. Cheap to keep, and it fails closed rather than re-paginating.
+                Some(entry) if entry.complete => return None,
+                Some(_) => true, // materialized, but not this far yet
                 None => false,
             }
         };

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -350,14 +350,21 @@ impl EpubBackend {
     /// Run `f` against global `page` and the layout parameters it was laid out with, materializing
     /// its chapter if it is not already cached. `None` for a page past the end of the book.
     fn with_page<R>(&self, page: usize, f: impl FnOnce(&Page, &LayoutOpts) -> R) -> Option<R> {
-        let (chapter, offset, opts) = {
+        let (chapter, offset, chapter_len, opts) = {
             let laid = self.laid();
             if page >= laid.total_pages {
                 return None;
             }
             let chapter = laid.chapter_of(page);
             let start = laid.chapter_start.get(chapter).copied().unwrap_or(0);
-            (chapter, page - start, laid.opts)
+            // The chapter's length per the pagination index — what decides whether a prefix is
+            // worth having at all (see below).
+            let end = laid
+                .chapter_start
+                .get(chapter + 1)
+                .copied()
+                .unwrap_or(laid.total_pages);
+            (chapter, page - start, end.saturating_sub(start), laid.opts)
         };
 
         // A cached chapter serves the page if it was laid out that far, or if we know there is no
@@ -382,11 +389,25 @@ impl EpubBackend {
         // time: reading forward through a long chapter would otherwise re-lay a growing prefix on
         // every turn, which is quadratic and worse than the whole-chapter pass this replaces. So a
         // chapter costs at most two passes — the cheap prefix that opened it, then the rest.
-        let want = if cached { usize::MAX } else { offset + 1 };
+        //
+        // A prefix is only worth taking when it is a small part of the chapter. Resuming deep into
+        // one — page 225 of 229, say — the prefix costs almost as much as the whole chapter, and
+        // the extending pass is then pure overhead: measured at +66% total work over laying it out
+        // once. Past the halfway mark, do the whole chapter now and be done.
+        let want = if cached || offset + 1 >= chapter_len.div_ceil(2) {
+            usize::MAX
+        } else {
+            offset + 1
+        };
+        // Drop any partial entry for this chapter BEFORE laying out the rest of it, not after:
+        // otherwise the prefix and the full pass are both live at once, which on a deep resume of a
+        // long chapter is tens of megabytes of laid-out pages held for no reason.
+        self.chapter_pages
+            .borrow_mut()
+            .retain(|c| c.chapter != chapter);
         let (pages, complete) = self.lay_out_chapter_upto(chapter, &opts, want);
         let result = pages.get(offset).map(|p| f(p, &opts));
         let mut cache = self.chapter_pages.borrow_mut();
-        cache.retain(|c| c.chapter != chapter); // replace any partial entry for this chapter
         if cache.len() >= CHAPTER_CACHE {
             cache.remove(0); // oldest out; the tail is what reading is walking through
         }

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -13,7 +13,9 @@
 use std::cell::{Cell, Ref, RefCell};
 use std::collections::HashMap;
 
-use inkread_epub::layout::{paginate_with_images, Align, Hyphenator, ImageSizer, LayoutOpts, Page};
+use inkread_epub::layout::{
+    paginate_upto, paginate_with_images, Align, Hyphenator, ImageSizer, LayoutOpts, Page,
+};
 use inkread_epub::measure::{CachedHyphenator, CachedMetrics};
 use inkread_epub::render::{
     render_page_with_images as raster_page, AbFont, EnHyphenator, GrayCanvas, ImageSource,
@@ -167,10 +169,9 @@ pub struct EpubBackend {
     /// lets the open path apply the reader's saved typography *before* any pagination is built, so
     /// a cold open costs a single layout pass instead of one per setting (#161/#162).
     laid: RefCell<Option<Laid>>,
-    /// Recently materialized chapters as `(chapter index, its pages)`, most recent last. Bounded by
-    /// [`CHAPTER_CACHE`] and cleared whenever [`Self::laid`] is rebuilt, since a re-layout
-    /// invalidates every page in it.
-    chapter_pages: RefCell<Vec<(usize, Vec<Page>)>>,
+    /// Recently materialized chapters, most recent last. Bounded by [`CHAPTER_CACHE`] and cleared
+    /// whenever [`Self::laid`] is rebuilt, since a re-layout invalidates every page in it.
+    chapter_pages: RefCell<Vec<ChapterPages>>,
     /// Where paginations survive between launches, once a store is attached (#162).
     pagination_cache: RefCell<Option<Box<dyn PaginationCache>>>,
     /// Where a pagination in flight is reported, and where cancellation is asked about (#161).
@@ -311,21 +312,42 @@ impl EpubBackend {
     /// always starts a fresh page and nothing carries across the boundary — so a chapter laid out
     /// alone is identical to its slice of a whole-book pass. That is what makes materializing one
     /// chapter at a time sound rather than merely convenient.
+    #[cfg(test)]
     fn lay_out_chapter(&self, index: usize, opts: &LayoutOpts) -> Vec<Page> {
+        self.lay_out_chapter_upto(index, opts, usize::MAX).0
+    }
+
+    /// Lay chapter `index` out as far as `want` whole pages, returning `(pages, complete)` (#186).
+    ///
+    /// Materializing a whole chapter to show one of its pages is the dominant cost of opening a
+    /// book, and a reader resuming at a chapter start needs exactly one page of it.
+    fn lay_out_chapter_upto(
+        &self,
+        index: usize,
+        opts: &LayoutOpts,
+        want: usize,
+    ) -> (Vec<Page>, bool) {
         self.parse_chapter(index);
         let chapters = self.chapters.borrow();
         let Some(chapter) = chapters.get(index) else {
-            return vec![Page::default()];
+            return (vec![Page::default()], true);
         };
         let blocks = chapter.blocks();
         let face = self.font.borrow();
         let font = CachedMetrics::new(&*face);
         let hyph = CachedHyphenator::new(&self.hyph);
-        let mut pages = paginate_with_images(blocks, opts, &font, &hyph, self);
-        if pages.is_empty() {
+        let (mut pages, complete) = paginate_upto(blocks, opts, &font, &hyph, self, want);
+        #[cfg(test)]
+        {
+            CHAPTER_LAYOUTS.with(|c| c.set(c.get() + 1));
+            CHAPTER_PAGES_LAID.with(|c| c.set(c.get() + pages.len()));
+        }
+        // Only a *complete* empty pagination means an empty chapter; an empty partial one just
+        // means nothing was asked for.
+        if pages.is_empty() && complete {
             pages.push(Page::default()); // an empty chapter still occupies its one page
         }
-        pages
+        (pages, complete)
     }
 
     /// Run `f` against global `page` and the layout parameters it was laid out with, materializing
@@ -341,22 +363,37 @@ impl EpubBackend {
             (chapter, page - start, laid.opts)
         };
 
-        if let Some(hit) = self
-            .chapter_pages
-            .borrow()
-            .iter()
-            .find(|(c, _)| *c == chapter)
-        {
-            return hit.1.get(offset).map(|p| f(p, &opts));
-        }
+        // A cached chapter serves the page if it was laid out that far, or if we know there is no
+        // more to lay out.
+        let cached = {
+            let cache = self.chapter_pages.borrow();
+            match cache.iter().find(|c| c.chapter == chapter) {
+                Some(entry) if entry.pages.len() > offset => {
+                    return entry.pages.get(offset).map(|p| f(p, &opts));
+                }
+                Some(entry) if entry.complete => return None, // past the end of a finished chapter
+                Some(_) => true,                              // materialized, but not this far yet
+                None => false,
+            }
+        };
 
-        let pages = self.lay_out_chapter(chapter, &opts);
+        // Extending a partial chapter lays out the rest of it in one pass rather than one page at a
+        // time: reading forward through a long chapter would otherwise re-lay a growing prefix on
+        // every turn, which is quadratic and worse than the whole-chapter pass this replaces. So a
+        // chapter costs at most two passes — the cheap prefix that opened it, then the rest.
+        let want = if cached { usize::MAX } else { offset + 1 };
+        let (pages, complete) = self.lay_out_chapter_upto(chapter, &opts, want);
         let result = pages.get(offset).map(|p| f(p, &opts));
         let mut cache = self.chapter_pages.borrow_mut();
+        cache.retain(|c| c.chapter != chapter); // replace any partial entry for this chapter
         if cache.len() >= CHAPTER_CACHE {
             cache.remove(0); // oldest out; the tail is what reading is walking through
         }
-        cache.push((chapter, pages));
+        cache.push(ChapterPages {
+            chapter,
+            pages,
+            complete,
+        });
         result
     }
 
@@ -734,6 +771,28 @@ thread_local! {
     static LAYOUT_PASSES: Cell<usize> = const { Cell::new(0) };
     /// Chapters parsed on this thread — the counter behind the laziness test (#186).
     static CHAPTER_PARSES: Cell<usize> = const { Cell::new(0) };
+    /// Chapter layout passes on this thread, and the pages each produced (#186). Materializing a
+    /// chapter is cost a correctness test cannot see, so laziness has to be asserted directly.
+    static CHAPTER_LAYOUTS: Cell<usize> = const { Cell::new(0) };
+    static CHAPTER_PAGES_LAID: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Chapter layout passes on this thread since [`reset_chapter_layouts`].
+#[cfg(test)]
+pub(crate) fn chapter_layouts() -> usize {
+    CHAPTER_LAYOUTS.with(Cell::get)
+}
+
+/// Pages produced by those passes — what the laziness is actually about.
+#[cfg(test)]
+pub(crate) fn chapter_pages_laid() -> usize {
+    CHAPTER_PAGES_LAID.with(Cell::get)
+}
+
+#[cfg(test)]
+pub(crate) fn reset_chapter_layouts() {
+    CHAPTER_LAYOUTS.with(|c| c.set(0));
+    CHAPTER_PAGES_LAID.with(|c| c.set(0));
 }
 
 /// Chapters parsed on this thread since [`reset_chapter_parses`].
@@ -780,6 +839,16 @@ pub(crate) fn reset_layout_passes() {
 ///   which changes the page count of every illustrated chapter.
 fn layout_key(opts: &LayoutOpts, font_id: usize, chapters: usize) -> String {
     format!("v4|{:016x}|{font_id}|{chapters}", opts.layout_digest())
+}
+
+/// A materialized chapter: the pages laid out so far, and whether that is all of them (#186).
+///
+/// A chapter is first materialized only as far as the page being read, so `pages` is usually a
+/// prefix. `complete` is what stops a later page being served from a partial layout.
+struct ChapterPages {
+    chapter: usize,
+    pages: Vec<Page>,
+    complete: bool,
 }
 
 /// Paginate every chapter for `opts` and return how many pages each occupies.

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -1255,3 +1255,80 @@ fn a_page_the_index_claims_but_the_layout_lacks_is_refused_without_relaying_out(
         "a known-complete chapter must not be laid out again for a page it does not have"
     );
 }
+
+/// Resuming deep into a long chapter, the prefix costs almost as much as the whole chapter, and the
+/// extending pass that follows is then pure overhead — measured at +66% total work, plus tens of
+/// megabytes transiently held. Past the halfway mark the chapter is laid out once, complete.
+#[test]
+fn a_deep_resume_lays_the_chapter_out_once_instead_of_twice() {
+    let doc = one_long_chapter(400);
+    let total = doc.page_count();
+    assert!(total > 20, "need a long chapter, got {total}");
+
+    // Deep resume: one pass that FINISHES the chapter, so no extending pass can follow. Asserting
+    // completeness rather than a page count is deliberate — a bounded pass can overshoot its bound,
+    // since the check sits between blocks, so counts do not separate "stopped early" from
+    // "finished".
+    reset_chapter_layouts();
+    // Three quarters in: past the halfway threshold, but with a real tail left. At total-2 the
+    // bounded pass would run to the end anyway, so it could not tell the two policies apart.
+    let deep = total * 3 / 4;
+    assert!(doc.with_page(deep, |_, _| ()).is_some());
+    assert_eq!(chapter_layouts(), 1, "one pass");
+    assert!(
+        doc.chapter_pages.borrow()[0].complete,
+        "a deep resume must lay the chapter out completely, not take a near-full prefix that a \
+         later page then pays to extend"
+    );
+    reset_chapter_layouts();
+    assert!(doc.with_page(deep + 1, |_, _| ()).is_some());
+    assert_eq!(
+        chapter_layouts(),
+        0,
+        "the chapter was already complete; turning the page must not lay out again"
+    );
+
+    // A shallow resume still takes the cheap prefix — the threshold must not disable laziness.
+    let doc = one_long_chapter(400);
+    reset_chapter_layouts();
+    assert!(doc.with_page(0, |_, _| ()).is_some());
+    assert!(
+        chapter_pages_laid() * 4 < total,
+        "page 0 produced {} of {total} pages — the threshold broke laziness",
+        chapter_pages_laid()
+    );
+    assert!(
+        !doc.chapter_pages.borrow()[0].complete,
+        "a shallow resume should still leave the chapter partial"
+    );
+}
+
+/// The partial layout must be released before the extending pass runs, or a deep-ish resume holds
+/// the prefix and the full chapter at once.
+#[test]
+fn extending_a_chapter_does_not_hold_the_prefix_and_the_full_layout_at_once() {
+    let doc = one_long_chapter(400);
+    let total = doc.page_count();
+
+    // A prefix short enough to stay under the halfway threshold, then extend past it.
+    assert!(doc.with_page(1, |_, _| ()).is_some());
+    let cached_pages: usize = doc
+        .chapter_pages
+        .borrow()
+        .iter()
+        .map(|c| c.pages.len())
+        .sum();
+    assert!(
+        cached_pages < total,
+        "expected a partial entry, got {cached_pages}"
+    );
+
+    assert!(doc.with_page(total - 1, |_, _| ()).is_some());
+    let entries = doc.chapter_pages.borrow();
+    assert_eq!(
+        entries.len(),
+        1,
+        "the partial entry should have been replaced, not kept alongside"
+    );
+    assert!(entries[0].complete);
+}

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -1030,7 +1030,7 @@ fn a_books_declared_styles_reach_the_laid_out_page() {
     // …and the layout stage declines to apply it: the prose stays flush left with its indent,
     // while the centred blocks above are inset.
     let opts = EpubBackend::opts_for(&doc.current_request());
-    let pages = doc.lay_out_chapter(0, &opts);
+    let pages = doc.lay_out_chapter_upto(0, &opts, usize::MAX).0;
     let first_x: Vec<f32> = pages[0]
         .lines
         .iter()
@@ -1081,7 +1081,7 @@ fn an_illustration_is_laid_out_and_drawn_rather_than_labelled() {
 
     // Layout placed a real box, not a line of text.
     let opts = EpubBackend::opts_for(&doc.current_request());
-    let pages = doc.lay_out_chapter(0, &opts);
+    let pages = doc.lay_out_chapter_upto(0, &opts, usize::MAX).0;
     let placed = pages
         .iter()
         .flat_map(|p| &p.lines)
@@ -1190,7 +1190,7 @@ fn a_page_from_a_partial_layout_matches_the_full_layout() {
 
     let lazy = one_long_chapter(400);
     let full = one_long_chapter(400);
-    let all = full.lay_out_chapter(0, &opts); // whole chapter in one pass
+    let all = full.lay_out_chapter_upto(0, &opts, usize::MAX).0; // whole chapter in one pass
 
     for page in [0usize, 1, 5] {
         let got = lazy

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -1182,10 +1182,13 @@ fn reading_forward_costs_at_most_two_layout_passes_per_chapter() {
     );
 }
 
-/// Laziness must not change what the reader sees: a page served from a partial layout has to be
-/// identical to the same page from a full one, or a resumed position lands on different text.
+/// Laziness must not change what the reader sees, or a resumed position lands on different text.
+///
+/// Page 0 is the one actually served from a *partial* layout: asking for any later page flips the
+/// chapter to a full extension pass, so pages 1 and 5 below exercise that pass instead. Both
+/// matter — the prefix and the extension have to agree with a single full pass.
 #[test]
-fn a_page_from_a_partial_layout_matches_the_full_layout() {
+fn pages_served_lazily_match_a_single_full_layout() {
     let opts = EpubBackend::opts_for(&one_long_chapter(1).current_request());
 
     let lazy = one_long_chapter(400);
@@ -1200,10 +1203,10 @@ fn a_page_from_a_partial_layout_matches_the_full_layout() {
     }
 }
 
-/// A page past the end must still be refused once the chapter is known to be finished, rather than
-/// being mistaken for "not laid out that far yet" and re-paginated forever.
+/// A page past the end of the book is refused by the `total_pages` guard, before the chapter cache
+/// is consulted — so this costs no pagination at all.
 #[test]
-fn a_page_past_the_end_is_refused_not_relaid() {
+fn a_page_past_the_end_of_the_book_never_paginates() {
     let doc = one_long_chapter(3);
     let total = doc.page_count();
     let mut bytes = vec![0u8; 400 * 600 * 4];
@@ -1217,5 +1220,38 @@ fn a_page_past_the_end_is_refused_not_relaid() {
         chapter_layouts(),
         0,
         "an out-of-range page must not paginate"
+    );
+}
+
+/// The defensive arm: a page the pagination *index* says exists but the *layout* does not produce.
+/// That can only happen if the two have diverged — a cache written by a different layout, say — and
+/// the index guard cannot catch it, because as far as the index is concerned the page is in range.
+/// Reached here by handing the reader a cache that overcounts.
+///
+/// What must not happen is treating the missing page as "not laid out that far yet" and paginating
+/// the chapter again on every attempt.
+#[test]
+fn a_page_the_index_claims_but_the_layout_lacks_is_refused_without_relaying_out() {
+    let real_total = one_long_chapter(40).page_count();
+
+    // Same chapter count, so the cache is accepted, but one page more than the chapter has.
+    let (cache, _saved) = fake(Some(vec![real_total + 1]));
+    let doc = one_long_chapter(40);
+    doc.set_pagination_cache(cache);
+    assert_eq!(
+        doc.page_count(),
+        real_total + 1,
+        "the overcounting cache should be in force"
+    );
+
+    // The phantom page: in range per the index, absent from the layout.
+    let phantom = real_total;
+    assert!(doc.with_page(phantom, |_, _| ()).is_none(), "phantom page");
+    reset_chapter_layouts();
+    assert!(doc.with_page(phantom, |_, _| ()).is_none(), "still refused");
+    assert_eq!(
+        chapter_layouts(),
+        0,
+        "a known-complete chapter must not be laid out again for a page it does not have"
     );
 }

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -1126,3 +1126,96 @@ fn a_rendered_illustrated_page_carries_the_images_pixels() {
         "expected the 120x80 plate's pixels, found {greys}"
     );
 }
+
+// ---------------------------------------------------------------------------------------------
+// #186 — materializing only as far as the page being read.
+// ---------------------------------------------------------------------------------------------
+
+/// A book whose single chapter runs to many pages — the shape #186 measured, where showing page 0
+/// used to cost the whole chapter.
+fn one_long_chapter(paras: usize) -> EpubBackend {
+    let blocks = parse_blocks(
+        &(0..paras)
+            .map(|i| format!("<p>Paragraph {i}. Alpha bravo charlie delta echo foxtrot golf.</p>"))
+            .collect::<String>(),
+    );
+    EpubBackend::from_chapters(vec![blocks], vp(400, 600))
+}
+
+/// The core of #186: rendering one page must not lay out the whole chapter.
+#[test]
+fn opening_a_page_lays_out_only_as_far_as_that_page() {
+    let doc = one_long_chapter(400);
+    let total = doc.page_count();
+    assert!(total > 20, "need a long chapter, got {total} pages");
+
+    reset_chapter_layouts();
+    let mut bytes = vec![0u8; 400 * 600 * 4];
+    let mut buf = PixelBuffer::from_rgba(&mut bytes, 400, 600).unwrap();
+    doc.render_page(0, &mut buf).expect("renders");
+
+    let laid = chapter_pages_laid();
+    assert!(laid >= 1, "the page asked for must exist");
+    assert!(
+        laid * 4 < total,
+        "laying out page 0 produced {laid} of {total} pages — not lazy"
+    );
+}
+
+/// Reading forward must not re-lay a growing prefix on every turn. Extending a partial chapter
+/// finishes it in one pass, so a chapter costs at most two passes however far it is read.
+#[test]
+fn reading_forward_costs_at_most_two_layout_passes_per_chapter() {
+    let doc = one_long_chapter(400);
+    let total = doc.page_count();
+    reset_chapter_layouts();
+
+    let mut bytes = vec![0u8; 400 * 600 * 4];
+    for page in 0..total.min(12) {
+        let mut buf = PixelBuffer::from_rgba(&mut bytes, 400, 600).unwrap();
+        doc.render_page(page, &mut buf).expect("renders");
+    }
+    assert!(
+        chapter_layouts() <= 2,
+        "{} layout passes for one chapter read forward — quadratic re-layout",
+        chapter_layouts()
+    );
+}
+
+/// Laziness must not change what the reader sees: a page served from a partial layout has to be
+/// identical to the same page from a full one, or a resumed position lands on different text.
+#[test]
+fn a_page_from_a_partial_layout_matches_the_full_layout() {
+    let opts = EpubBackend::opts_for(&one_long_chapter(1).current_request());
+
+    let lazy = one_long_chapter(400);
+    let full = one_long_chapter(400);
+    let all = full.lay_out_chapter(0, &opts); // whole chapter in one pass
+
+    for page in [0usize, 1, 5] {
+        let got = lazy
+            .with_page(page, |p, _| p.clone())
+            .unwrap_or_else(|| panic!("page {page} missing"));
+        assert_eq!(&got, &all[page], "page {page} differs from the full layout");
+    }
+}
+
+/// A page past the end must still be refused once the chapter is known to be finished, rather than
+/// being mistaken for "not laid out that far yet" and re-paginated forever.
+#[test]
+fn a_page_past_the_end_is_refused_not_relaid() {
+    let doc = one_long_chapter(3);
+    let total = doc.page_count();
+    let mut bytes = vec![0u8; 400 * 600 * 4];
+    let mut buf = PixelBuffer::from_rgba(&mut bytes, 400, 600).unwrap();
+    doc.render_page(total - 1, &mut buf)
+        .expect("last page renders");
+
+    reset_chapter_layouts();
+    assert!(doc.with_page(total + 5, |_, _| ()).is_none());
+    assert_eq!(
+        chapter_layouts(),
+        0,
+        "an out-of-range page must not paginate"
+    );
+}

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -482,6 +482,13 @@ impl ReaderSession {
     /// policy's full-screen rect. Returns nothing; the shell re-renders + re-asks for
     /// a refresh afterward.
     pub fn set_viewport(&mut self, viewport: Viewport) {
+        // A surface can be handed the same size more than once (Android delivers surfaceChanged
+        // repeatedly for one surface). Rebuilding the policy and dropping every cached render for a
+        // viewport that did not change throws away exactly the work that was about to be reused —
+        // on the open path, that is the page just rendered (#186).
+        if self.viewport == viewport {
+            return;
+        }
         self.viewport = viewport;
         let caps = self.policy.capabilities();
         let screen = Rect::full(viewport.width, viewport.height);

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -577,8 +577,30 @@ fn render_cache_serves_revisits_and_invalidates_on_change() {
     render(&mut s, &mut buf);
     assert_eq!(renders.get(), 3);
 
-    // A viewport change invalidates the cache (geometry changed underneath the keys).
+    // Re-setting the SAME viewport changes nothing, so it must not throw the cache away (#186):
+    // a surface can be handed its size more than once, and on the open path that discards exactly
+    // the page just rendered. Note this session's viewport IS 100x120x226 — the assertion below
+    // used to pass that very value and expect invalidation, which pinned the wasteful behaviour.
+    let before = s.caches().render().len();
+    assert!(
+        before > 0,
+        "need a populated cache for this to mean anything"
+    );
     s.set_viewport(Viewport::new(100, 120, 226));
+    assert_eq!(
+        s.caches().render().len(),
+        before,
+        "an identical viewport must not invalidate the cache"
+    );
+    render(&mut s, &mut buf);
+    assert_eq!(
+        renders.get(),
+        3,
+        "and the cached page must still serve the render"
+    );
+
+    // A real geometry change does invalidate it — the keys no longer describe the buffers.
+    s.set_viewport(Viewport::new(120, 140, 226));
     assert_eq!(s.caches().render().len(), 0);
 }
 


### PR DESCRIPTION
## What & why

Opening a book spent ~2.6s of its ~6s doing work it did not need to do. #186 measured it on a Nomad
and named three causes; this fixes all three, plus the one the issue could not account for.

Closes #186

## Requirements / design refs

- ADR-INKREAD-0012 — source anchors are unaffected: a partial pagination is a *prefix*, so page
  boundaries the index counted are the boundaries the reader lands on.
- ADR-INKREAD-0013 D1 / RR9-FR3 — the pagination cache still stores page counts; nothing here
  changes its key.
- RR21-FR4 — viewport changes still rebuild the refresh policy; only a *no-op* change stops doing so.

## How it works

**1. Pagination stops at the page you asked for.** `paginate_upto` returns `(pages, complete)` and
stops once enough whole pages exist. `paginate_with_images` delegates to it unbounded, so every
existing caller is untouched.

The pages it returns are byte-identical to the same prefix of a full pass — a page break depends
only on what precedes it. That is not a tidiness argument: if it were false, a resumed reading
position would land on a different page than the pagination index counted. A test asserts the
prefix property page by page rather than trusting the reasoning.

**2. A chapter is materialized only as far as the page being read.** Showing page 0 of a 229-page
chapter now lays out **1 page instead of 229**.

Extending a partial chapter finishes it in one pass rather than growing a page at a time, which
would be quadratic and worse than the whole-chapter pass this replaces. So a chapter costs at most
two passes however far it is read. The second pass is not deferred until the reader arrives —
`prefetch_page` warms page N+1, so on a single-chapter book it follows the opening render
immediately. The win is that it is **off the critical path**, not that it is avoided.

**3. The opening page is no longer rendered twice.** Android delivers `surfaceChanged` more than
once per surface at the same size, and `onSurfaceSized` rendered on every one.

The cheap version of this fix is wrong: a surface destroyed and recreated by leaving and returning
to the reader also comes back at the same size, with nothing drawn on it, so "skip when the size is
unchanged" would leave the panel black. `SurfaceRenderGate` tells the two apart by surface
generation. It is extracted rather than inlined so the decision is host-testable without an Android
runtime, following `PalmFilter` and `RefreshCadence`, and its tests pin both edges — because both
are expensive.

**4. The invalidation #186 could not find.** The issue says *"Something is still invalidating between
the two renders; that is the thing to find."* It is `Session::set_viewport`, which rebuilt the
refresh policy and cleared every cached render unconditionally — including when handed the size it
already had. On the open path that discarded exactly the page just rasterized.

The existing test for it passed the session's own viewport (`100x120x226`) and asserted the cache was
cleared, so it was pinning the wasteful behaviour rather than catching it. It now asserts both
halves.

## How it was tested

- [x] `cargo test --workspace` is green
- [x] `./gradlew :app:testDebugUnitTest` is green
- [x] Added tests that fail without this change — **verified by reverting the behaviour**, not assumed
- [ ] Verified on a device (Supernote) — host-only; see below

Performance is invisible to a correctness test — a redundant pass produces an identical layout — so
the laziness is asserted directly: pages produced versus pages in the chapter, at most two layout
passes when reading forward, a partial page identical to the full-layout page, and no pagination at
all for an out-of-range page. Restoring the old behaviour makes the first fail with "229 of 229
pages — not lazy".

### Measured, host, release build

Synthetic EPUBs, pinned toolchain, workspace release profile, medians of 5-7 iterations, with the
pagination index pre-warmed — the state #186 measured.

**Open path** (open + render page 0; `master` is master's real open path, i.e. two renders):

| book | master | this branch | speedup |
|---|---|---|---|
| 87-page chapter | 23.03 ms | 11.11 ms | 2.07x |
| 229-page chapter | 32.41 ms | 14.34 ms | 2.26x |
| 405-page chapter | 45.32 ms | 19.41 ms | 2.33x |
| 20 chapters x 20 pages | 20.58 ms | 11.44 ms | 1.80x |

**Layout alone**, 229-page chapter: 1 page in 0.072 ms versus 229 pages in 9.25 ms — **128x less
layout work**, linear at 0.040 ms/page, and it holds on the 405-page chapter (200x).

On the 229-page book the 18.1 ms saved splits about evenly between not rendering twice and lazy
layout. On a **normally-chaptered** book, lazy layout contributes only 1.0 ms of 9.1 ms — there the
double-render fix is the whole win.

**Redundant `surfaceChanged`**, session level: master 11.0 ms (cache discarded), branch 0.38 ms
(served from cache) — **29x**, about 10.7 ms per repeat callback.

Also measured: 6 TOC jumps 20.63 -> 7.90 ms (2.6x); 32 cache-thrash touches across 4 chapters
104.86 -> 18.54 ms (5.7x); backward reading shows no pathology.

### What this does not do

**It removes no total work.** `open + render p0 + render p1` is 32.6 ms versus master's 33.0 ms on
the 229-page book. The chapter's full layout still happens — it moves after first paint, and because
`prefetch_page` warms page N+1 it runs in the background rather than waiting for the reader.

Two regressions found by measuring, both fixed in `09dbc90`:

- **Deep resume.** Resuming at page 225 of 229, the prefix cost nearly as much as the whole chapter
  and the extending pass was pure overhead — +66% total work, with the open win already gone at that
  depth. Past the halfway mark the chapter is now laid out complete in one pass.
- **Memory.** The partial entry was released after the extending pass rather than before, so prefix
  and full layout were both live: +11 MB on a 229-page chapter, +21 MB on a 405-page one. Fixed by
  releasing first.

Residual cost, accepted: one extra 1-page pass per chapter on a sequential read (+1.3%, at the edge
of noise) and on a whole-book search (+3.2%).

### Where the open cost is now

229-page book on this branch, 14.34 ms total: **raster 8.3 ms (58%)**, chapter XHTML parse 3.8 ms
(27%), container open 1.7 ms (12%), **layout 0.07 ms (0.5%)**. Layout is at the floor; no further
work is warranted there.

**Device measurement still wanted.** #186's numbers are from a Nomad and host cannot reproduce their
magnitude: 1282 ms for page 0 of that book does not fit the host model at any plausible ARM factor.
That book is 5.6 MB in a single chapter, so the bulk of it is most likely the **XHTML parse**, not
layout — which this PR does not touch. Worth re-running the device trace before assuming the ~4-5s
open is fully solved.

## Scope / follow-ups

- The first-ever open of a book still paginates the whole thing to build its page-count index; that
  is inherent to counting pages and unchanged here. Every later open is served from SQLite.
- A resumable `Pager` would cut the two passes to one. Deliberately not done: it buys a
  background-only win in exchange for storing an in-progress page in the chapter cache and making
  the cached pages incremental — a materially more error-prone invariant.
- `paginate` / `paginate_with` have one production caller between them; the rest of their uses are
  tests. Collapsing the four pagination entry points behind a bundled `metrics + hyph + images`
  parameter is worth a separate pass.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `cargo llvm-cov --workspace` — coverage holds
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core still builds host-only; no vendor names (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers

