### PR TITLE
fix(toolbar): keep the expanded pill on screen and the grip reachable (#200)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -185,23 +185,71 @@ class ToolPalette(
                     val dx = e.rawX - downX; val dy = e.rawY - downY
                     if (!moved && kotlin.math.hypot(dx, dy) > touchSlop) moved = true
                     if (moved) {
-                        // Base anchor = END | CENTER_VERTICAL: X only moves left (≤0), Y from centre.
-                        val xMin = -(host.width - container.width).toFloat().coerceAtLeast(0f)
-                        val yHalf = ((host.height - container.height) / 2f).coerceAtLeast(0f)
-                        container.translationX = (startTx + dx).coerceIn(xMin, 0f)
-                        container.translationY = (startTy + dy).coerceIn(-yHalf, yHalf)
+                        container.translationX =
+                            clampX(startTx + dx, host.width, container.width)
+                        container.translationY =
+                            clampY(startTy + dy, host.height, container.height)
                     }
                     true
                 }
                 MotionEvent.ACTION_UP -> {
                     container.alpha = IDLE_ALPHA // fade back so it doesn't sit over the text
                     if (moved) { reattach(); onChrome() } // re-add forces an EPD refresh at the new spot
-                    else { expanded = !expanded; render(); reattach(); onChrome() }
+                    else { toggleExpanded() }
                     true
                 }
                 else -> false
             }
         }
+    }
+
+    /**
+     * Collapse or expand, keeping the grip under the finger and the pill on screen (#200).
+     *
+     * The pill is anchored `CENTER_VERTICAL`, so changing its height moves it *both* ways from the
+     * centre. Two things went wrong because of that. The grip jumped away from the finger that had
+     * just tapped it; and — the reported bug — a puck dragged to the top or bottom edge expanded
+     * past the edge, taking the grip with it. With the grip off screen there was no way to collapse
+     * the pill again, so the only escape was to reopen the document.
+     *
+     * The height is not known until the new children are laid out, so the correction runs on the
+     * next layout pass rather than here.
+     */
+    private fun toggleExpanded() {
+        val heightBefore = container.height
+        expanded = !expanded
+        render()
+        // A one-shot layout listener, not `post`: `render` only requests a layout, and a posted
+        // runnable can run before the traversal that measures the new children — which would read
+        // the OLD height and correct by the wrong amount.
+        container.addOnLayoutChangeListener(
+            object : View.OnLayoutChangeListener {
+                override fun onLayoutChange(
+                    v: View,
+                    left: Int,
+                    top: Int,
+                    right: Int,
+                    bottom: Int,
+                    oldLeft: Int,
+                    oldTop: Int,
+                    oldRight: Int,
+                    oldBottom: Int,
+                ) {
+                    v.removeOnLayoutChangeListener(this)
+                    val height = bottom - top
+                    container.translationY =
+                        clampY(
+                            anchorY(container.translationY, heightBefore, height),
+                            host.height,
+                            height,
+                        )
+                    container.translationX =
+                        clampX(container.translationX, host.width, right - left)
+                    reattach()
+                    onChrome()
+                }
+            },
+        )
     }
 
     private fun iconButton(tool: Tool): ImageView = ImageView(activity).apply {
@@ -250,8 +298,40 @@ class ToolPalette(
         if (expanded) { expanded = false; render() }
     }
 
-    private companion object {
+    internal companion object {
         /** Resting opacity of the docked puck — translucent so the text behind it stays readable. */
         const val IDLE_ALPHA = 0.55f
+
+        /**
+         * Clamp the horizontal offset so the pill stays inside the host. The base anchor is
+         * `END`, so the pill only ever moves left: the offset is negative, bounded by how much
+         * wider the host is than the pill.
+         */
+        fun clampX(tx: Float, hostWidth: Int, viewWidth: Int): Float {
+            val min = -(hostWidth - viewWidth).toFloat().coerceAtLeast(0f)
+            return tx.coerceIn(min, 0f)
+        }
+
+        /**
+         * Clamp the vertical offset so the pill stays inside the host. The base anchor is
+         * `CENTER_VERTICAL`, so the offset runs symmetrically about the centre and is bounded by
+         * half the slack. A pill taller than the host has no slack at all and stays centred, which
+         * is the least-bad answer: some of it is off screen whatever we do.
+         */
+        fun clampY(ty: Float, hostHeight: Int, viewHeight: Int): Float {
+            val half = ((hostHeight - viewHeight) / 2f).coerceAtLeast(0f)
+            return ty.coerceIn(-half, half)
+        }
+
+        /**
+         * The vertical offset that keeps the pill's **top** where it was when its height changes
+         * from `oldHeight` to `newHeight`.
+         *
+         * Under `CENTER_VERTICAL` the top sits at `(host - height) / 2 + ty`, so growing by `d`
+         * moves the top up by `d / 2` unless the offset compensates. The top is where the grip is,
+         * which is what the finger just tapped and what has to stay reachable.
+         */
+        fun anchorY(ty: Float, oldHeight: Int, newHeight: Int): Float =
+            ty + (newHeight - oldHeight) / 2f
     }
 }

--- a/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
@@ -1,0 +1,102 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for the floating toolbar's placement maths (#200).
+ *
+ * The reported bug: a collapsed puck dragged to the top edge expanded past the edge, taking the grip
+ * with it — and with the grip off screen there was no way to collapse the pill again, so the only
+ * escape was to reopen the document. The drag clamped against the *collapsed* size, and nothing
+ * re-clamped once the pill grew.
+ *
+ * A 1920x2560 panel with a 96px puck and a 660px expanded pill stands in for a Nomad below.
+ */
+class ToolPalettePlacementTest {
+
+    private val hostW = 1920
+    private val hostH = 2560
+    private val puck = 96
+    private val pill = 660
+
+    /** The escape hatch this whole issue is about: the top of the pill must stay on screen. */
+    private fun topOf(ty: Float, viewHeight: Int): Float = (hostH - viewHeight) / 2f + ty
+
+    private fun bottomOf(ty: Float, viewHeight: Int): Float = topOf(ty, viewHeight) + viewHeight
+
+    @Test
+    fun aPuckDraggedToTheTopEdgeStaysOnScreenWhenItExpands() {
+        // Dragged as far up as the collapsed puck is allowed to go.
+        val parked = ToolPalette.clampY(-99_999f, hostH, puck)
+        assertEquals("puck should sit flush with the top", 0f, topOf(parked, puck), 0.5f)
+
+        // Expanding from there: without the fix the pill's top goes negative — off screen.
+        val naive = topOf(parked, pill)
+        assertTrue("fixture must reproduce the bug: top was $naive", naive < 0f)
+
+        val fixed = ToolPalette.clampY(ToolPalette.anchorY(parked, puck, pill), hostH, pill)
+        assertTrue("expanded pill must not run off the top: ${topOf(fixed, pill)}", topOf(fixed, pill) >= -0.5f)
+        assertTrue(
+            "expanded pill must not run off the bottom: ${bottomOf(fixed, pill)}",
+            bottomOf(fixed, pill) <= hostH + 0.5f,
+        )
+    }
+
+    @Test
+    fun aPuckDraggedToTheBottomEdgeStaysOnScreenWhenItExpands() {
+        val parked = ToolPalette.clampY(99_999f, hostH, puck)
+        assertEquals("puck should sit flush with the bottom", hostH.toFloat(), bottomOf(parked, puck), 0.5f)
+
+        val fixed = ToolPalette.clampY(ToolPalette.anchorY(parked, puck, pill), hostH, pill)
+        assertTrue("ran off the top: ${topOf(fixed, pill)}", topOf(fixed, pill) >= -0.5f)
+        assertTrue("ran off the bottom: ${bottomOf(fixed, pill)}", bottomOf(fixed, pill) <= hostH + 0.5f)
+    }
+
+    /**
+     * Away from the edges the grip must not jump: it is what the finger just tapped, and moving it
+     * out from under the finger is the second complaint in #200.
+     */
+    @Test
+    fun awayFromTheEdgesTheGripKeepsItsPosition() {
+        val parked = 0f // centred
+        val topBefore = topOf(parked, puck)
+        val after = ToolPalette.clampY(ToolPalette.anchorY(parked, puck, pill), hostH, pill)
+        assertEquals("the pill's top should not move", topBefore, topOf(after, pill), 0.5f)
+    }
+
+    /** Collapsing is the same problem in reverse and must also keep the grip still. */
+    @Test
+    fun collapsingAlsoKeepsTheGripPosition() {
+        val expanded = 200f
+        val topBefore = topOf(expanded, pill)
+        val after = ToolPalette.clampY(ToolPalette.anchorY(expanded, pill, puck), hostH, puck)
+        assertEquals(topBefore, topOf(after, puck), 0.5f)
+    }
+
+    @Test
+    fun horizontalOffsetOnlyEverMovesThePillLeftAndStaysInside() {
+        assertEquals("cannot move right of its anchor", 0f, ToolPalette.clampX(500f, hostW, puck), 0.01f)
+        assertEquals(-100f, ToolPalette.clampX(-100f, hostW, puck), 0.01f)
+        assertEquals(
+            "cannot pass the left edge",
+            -(hostW - puck).toFloat(),
+            ToolPalette.clampX(-99_999f, hostW, puck),
+            0.01f,
+        )
+    }
+
+    /**
+     * Degenerate geometry must not produce a NaN or an inverted range — `coerceIn` throws when the
+     * bounds cross, which would take the reader down while merely opening a toolbar.
+     */
+    @Test
+    fun aViewLargerThanItsHostIsClampedRatherThanCrashing() {
+        assertEquals("no slack: stays centred", 0f, ToolPalette.clampY(500f, 100, 4000), 0.01f)
+        assertEquals(0f, ToolPalette.clampX(-500f, 100, 4000), 0.01f)
+        // Zero-sized host (before the first layout pass) is the same story.
+        assertEquals(0f, ToolPalette.clampY(10f, 0, 0), 0.01f)
+        assertEquals(0f, ToolPalette.clampX(-10f, 0, 0), 0.01f)
+    }
+}


### PR DESCRIPTION
## What & why

Drag the collapsed toolbar puck to the top or bottom edge, then tap to expand: the pill grows past
the screen edge, taking the grip with it. Tools are unreachable, and — because the grip is what
collapses the pill — there is no way back. The only escape is to reopen the document.

Addresses items 1 and 2 of #200.

## Requirements / design refs

- ADR-INKREAD-0010 — the modal tool palette; this is a placement fix, not a change to the tool model.

## How it works

**Cause.** The drag clamps `translationY` against the container's size *at drag time*. For a
collapsed puck that is small, so parking it flush with an edge is allowed. The pill is anchored
`CENTER_VERTICAL`, so expanding grows it in *both* directions from the centre while that offset still
stands — and nothing re-clamped once it had grown.

**Fix.** Re-clamp when the size changes, and keep the pill's top where it was while doing it. The
top is where the grip is, so it no longer jumps away from the finger that just tapped it — item 2 of
the issue, which falls out of the same correction.

This runs on a **one-shot layout listener**, not a posted runnable: `render()` only *requests* a
layout, and a posted runnable can run before the traversal that measures the new children, which
would correct by the wrong amount.

The maths moved to the companion object so it is testable on the host JVM without an Android
runtime, and the drag path now shares that clamp rather than keeping its own copy.

## How it was tested

- [x] `./gradlew :app:testDebugUnitTest` is green, including a new `ToolPalettePlacementTest`
- [x] `cargo test --workspace` green (Rust untouched)
- [x] Added tests that fail without this change — **verified by reverting each half separately**
- [ ] Verified on a device (Supernote)

Covered, against a 1920x2560 panel with a 96px puck and a 660px pill:

- a puck parked flush with the **top** edge stays fully on screen when it expands — the test first
  asserts the fixture reproduces the bug (the naive top is negative), so it cannot silently stop
  testing anything
- the same at the **bottom** edge
- away from the edges the pill's top does not move on expand, nor on collapse
- horizontal offset only ever moves the pill left, and never past the left edge
- a view **larger than its host**, where the naive bound inverts and `coerceIn` throws — that would
  take the reader down while merely opening a toolbar

Reverting the clamp fails the two edge tests and the degenerate-geometry test; reverting the
anchoring fails the two no-jump tests.

**Device check wanted:** drag the puck to the very top, expand, and confirm the whole pill is
visible and the grip still collapses it. Same at the bottom. Then confirm the grip stays put when
expanding away from an edge.

## Scope / follow-ups

- Item 3 of #200 — an optional **horizontal** toolbar, which the reporter wants for two-column
  layouts and the smaller Nomad panel — is a separate feature and is not attempted here. #200 should
  stay open for it.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core is untouched; no vendor names added (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
