### PR TITLE
feat(daily): per-feed article limits (#193)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
@@ -503,6 +503,7 @@ class DailyActivity : Activity() {
         }
         val enabled = sources.map { it.enabled }.toBooleanArray()
         val removed = BooleanArray(sources.size)
+        val limits = sources.map { it.limit }.toIntArray()
 
         val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
         sources.forEachIndexed { i, s ->
@@ -526,6 +527,7 @@ class DailyActivity : Activity() {
             row.addView(cb)
             row.addView(info, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
                 .apply { marginStart = dim(8) })
+            row.addView(limitStepper(limits, i))
             row.addView(remove)
             list.addView(row)
             if (i < sources.size - 1) list.addView(blackRule(Ink.hair()))
@@ -535,11 +537,11 @@ class DailyActivity : Activity() {
             addView(list)
         }
         AlertDialog.Builder(this, R.style.InkDialog)
-            .setTitle("Sources — uncheck to mute")
+            .setTitle("Sources — uncheck to mute, ± sets articles per issue")
             .setView(scroll)
             .setPositiveButton("Save") { _, _ ->
                 val updated = sources.mapIndexedNotNull { i, s ->
-                    if (removed[i]) null else s.copy(enabled = enabled[i])
+                    if (removed[i]) null else s.copy(enabled = enabled[i], limit = limits[i])
                 }
                 daily.setSources(updated)
                 setContentView(buildView())
@@ -547,6 +549,42 @@ class DailyActivity : Activity() {
             .setNeutralButton("Add") { _, _ -> suggestedSourcesDialog() }
             .setNegativeButton("Cancel", null)
             .show()
+    }
+
+    /**
+     * The per-source article count (#193): a `- n +` stepper. A stepper rather than a text field
+     * because the range is small and this dialog is driven by finger on an e-ink panel, where a
+     * keyboard is slow to summon and each keystroke costs a refresh.
+     *
+     * Writes straight into [limits] so Save picks it up with the mutes and removals in one pass.
+     */
+    private fun limitStepper(limits: IntArray, i: Int): View {
+        lateinit var count: TextView
+        fun step(by: Int) {
+            limits[i] = DailyController.clampLimit(limits[i] + by)
+            count.text = limits[i].toString()
+        }
+        val box = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        fun button(label: String, by: Int) = TextView(this).apply {
+            text = label; setTextColor(ink); textSize = fs(17f); typeface = mono
+            setPadding(dim(10), dim(4), dim(10), dim(4))
+            isClickable = true
+            contentDescription = if (by > 0) "More articles" else "Fewer articles"
+            setOnClickListener { step(by) }
+        }
+        count = TextView(this).apply {
+            text = limits[i].toString()
+            setTextColor(ink); textSize = fs(13f); typeface = mono
+            gravity = Gravity.CENTER
+            minWidth = dim(26)
+        }
+        box.addView(button("−", -1))
+        box.addView(count)
+        box.addView(button("+", +1))
+        return box
     }
 
     private fun archiveDialog() {

--- a/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
@@ -24,7 +24,17 @@ class DailyController(private val context: Context) {
 
     /** A followed source: a display name (byline) + its feed URL. [enabled] sources are the ones a
      *  compile fetches; muting one (unchecking it) keeps it in the list without pulling it. */
-    data class Source(val name: String, val url: String, val enabled: Boolean = true)
+    /**
+     * A followed feed. [limit] is how many of its articles an issue takes (#193) — sources differ a
+     * lot in volume, and one cap for all of them either starves a good feed or floods the issue with
+     * a noisy one.
+     */
+    data class Source(
+        val name: String,
+        val url: String,
+        val enabled: Boolean = true,
+        val limit: Int = PER_SOURCE,
+    )
 
     /** A compiled issue's headline. [index] is the article's position in the issue (0-based), so a
      *  tap can open the issue at that article. */
@@ -44,8 +54,14 @@ class DailyController(private val context: Context) {
             val arr = JSONArray(prefs().getString("sources", "[]"))
             (0 until arr.length()).map {
                 val o = arr.getJSONObject(it)
-                // Pre-existing stored sources have no "enabled" key → default to on.
-                Source(o.optString("name"), o.optString("url"), o.optBoolean("enabled", true))
+                // Pre-existing stored sources have neither "enabled" nor "limit" → on, and the
+                // cap every source used before this was configurable.
+                Source(
+                    o.optString("name"),
+                    o.optString("url"),
+                    o.optBoolean("enabled", true),
+                    clampLimit(o.optInt("limit", PER_SOURCE)),
+                )
             }
         }.getOrDefault(emptyList())
 
@@ -92,7 +108,13 @@ class DailyController(private val context: Context) {
     private fun save(list: List<Source>) {
         val arr = JSONArray()
         list.forEach {
-            arr.put(JSONObject().put("name", it.name).put("url", it.url).put("enabled", it.enabled))
+            arr.put(
+                JSONObject()
+                    .put("name", it.name)
+                    .put("url", it.url)
+                    .put("enabled", it.enabled)
+                    .put("limit", clampLimit(it.limit)),
+            )
         }
         prefs().edit().putString("sources", arr.toString()).apply()
     }
@@ -144,7 +166,7 @@ class DailyController(private val context: Context) {
                 val items = fetchFeedItems(src.url, reached)
                 if (reached[0]) feedsReached++
                 itemsFound += items.length()
-                val take = minOf(items.length(), PER_SOURCE)
+                val take = minOf(items.length(), clampLimit(src.limit))
                 Log.i(TAG, "feed ${src.url}: ${items.length()} items, fetching $take")
                 // Fetch this source's article pages in parallel.
                 val tasks = (0 until take).map { i ->
@@ -168,11 +190,7 @@ class DailyController(private val context: Context) {
         }
         // Interleave: every source's 1st article, then every source's 2nd, … Source order still
         // decides ties, so the issue keeps a stable, predictable reading order.
-        for (rank in 0 until PER_SOURCE) {
-            for (list in perSource) {
-                list.getOrNull(rank)?.let { articles.put(it) }
-            }
-        }
+        interleaveByRank(perSource).forEach { articles.put(it) }
         Log.i(TAG, "compile: feedsReached=$feedsReached itemsFound=$itemsFound articles=${articles.length()}")
         // Specific failure messages so the cause is obvious without a logcat.
         if (feedsReached == 0) {
@@ -339,7 +357,8 @@ class DailyController(private val context: Context) {
     private fun dateLabelFromName(name: String): String =
         name.removePrefix("inkread-daily-").removeSuffix(".epub")
 
-    private companion object {
+    /** Internal rather than private so the pure limit/ordering logic is host-testable (#193). */
+    internal companion object {
         const val TAG = "DailyController"
 
         /** Curated popular feeds for the suggested-sources picker (stable, well-known RSS/Atom). */
@@ -355,7 +374,40 @@ class DailyController(private val context: Context) {
             Source("Daring Fireball", "https://daringfireball.net/feeds/main"),
             Source("Smashing Magazine", "https://www.smashingmagazine.com/feed/"),
         )
-        const val PER_SOURCE = 5 // articles taken per source
+        const val PER_SOURCE = 5 // default articles taken per source; per-source override in #193
+        const val MIN_PER_SOURCE = 1 // a source taking nothing should be muted, not set to zero
+        const val MAX_PER_SOURCE = 20 // a ceiling, so one busy feed cannot swamp an issue
+
+        /**
+         * Hold a per-source article limit inside [MIN_PER_SOURCE]..[MAX_PER_SOURCE].
+         *
+         * Applied on read as well as write: a limit that arrives out of range — hand-edited prefs,
+         * or a value stored by a build with a different ceiling — would otherwise decide how many
+         * articles get fetched, and zero or negative would silently drop a source the reader still
+         * sees listed as active.
+         */
+        fun clampLimit(n: Int): Int = n.coerceIn(MIN_PER_SOURCE, MAX_PER_SOURCE)
+
+        /**
+         * Round-robin the sources: every source's 1st article, then every source's 2nd, and so on.
+         * Source order decides ties, so the reading order stays stable and predictable.
+         *
+         * This runs to the longest list rather than to a fixed count (#193). With per-source limits
+         * the lists are different lengths, and a fixed bound would silently drop everything a
+         * source contributed past it — a feed set to 10 would deliver 5. Sources that run out drop
+         * away and the rest keep interleaving, so a high-limit feed tails the issue rather than
+         * being truncated.
+         */
+        fun <T> interleaveByRank(perSource: List<List<T>>): List<T> {
+            val deepest = perSource.maxOfOrNull { it.size } ?: 0
+            val out = ArrayList<T>(perSource.sumOf { it.size })
+            for (rank in 0 until deepest) {
+                for (list in perSource) {
+                    list.getOrNull(rank)?.let { out.add(it) }
+                }
+            }
+            return out
+        }
         const val MAX_PARALLEL = 6 // concurrent article fetches
         const val HEADLINES_SHOWN = 60 // headlines stored for the front page (grouped by source)
         const val TIMEOUT_MS = 10_000

--- a/app/src/test/java/dev/jraghavan/inkread/PerFeedLimitTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/PerFeedLimitTest.kt
@@ -1,0 +1,76 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for per-feed article limits (#193): the clamp that decides how many articles a
+ * source contributes, and the round-robin that orders them into the issue.
+ */
+class PerFeedLimitTest {
+
+    @Test
+    fun theDefaultLimitIsUnchangedFromBeforeItWasConfigurable() {
+        assertEquals(5, DailyController.PER_SOURCE)
+        assertEquals(
+            "an existing feed must keep the behaviour it had",
+            DailyController.PER_SOURCE,
+            DailyController.Source("x", "u").limit,
+        )
+    }
+
+    /**
+     * Out-of-range values are clamped on read as well as write. Zero is the dangerous one: it would
+     * silently contribute nothing while the source still shows as active, which reads as a broken
+     * feed rather than a setting.
+     */
+    @Test
+    fun aLimitIsHeldInsideItsRange() {
+        assertEquals(DailyController.MIN_PER_SOURCE, DailyController.clampLimit(0))
+        assertEquals(DailyController.MIN_PER_SOURCE, DailyController.clampLimit(-7))
+        assertEquals(DailyController.MIN_PER_SOURCE, DailyController.clampLimit(Int.MIN_VALUE))
+        assertEquals(DailyController.MAX_PER_SOURCE, DailyController.clampLimit(999))
+        assertEquals(DailyController.MAX_PER_SOURCE, DailyController.clampLimit(Int.MAX_VALUE))
+        assertEquals(3, DailyController.clampLimit(3))
+        assertTrue(DailyController.MIN_PER_SOURCE >= 1)
+        assertTrue(DailyController.MAX_PER_SOURCE > DailyController.PER_SOURCE)
+    }
+
+    @Test
+    fun everySourceGetsFrontOfIssuePresenceBeforeAnySecondArticle() {
+        val a = listOf("a1", "a2", "a3")
+        val b = listOf("b1", "b2")
+        val c = listOf("c1")
+        assertEquals(
+            listOf("a1", "b1", "c1", "a2", "b2", "a3"),
+            DailyController.interleaveByRank(listOf(a, b, c)),
+        )
+    }
+
+    /**
+     * The bug this shape prevents: interleaving to a fixed count would stop at the default and
+     * silently discard everything a higher-limit source contributed past it — a feed set to 10
+     * would deliver 5, with no error anywhere.
+     */
+    @Test
+    fun aSourceAboveTheDefaultLimitKeepsAllOfItsArticles() {
+        val big = (1..10).map { "big$it" }
+        val small = listOf("small1", "small2")
+        val out = DailyController.interleaveByRank(listOf(big, small))
+        assertEquals("no article may be dropped", big.size + small.size, out.size)
+        assertTrue("the tail of the long source survived", out.contains("big10"))
+        assertEquals("front of issue is still round-robin", listOf("big1", "small1", "big2"), out.take(3))
+    }
+
+    @Test
+    fun emptyAndRaggedInputsAreHandled() {
+        assertTrue(DailyController.interleaveByRank(emptyList<List<String>>()).isEmpty())
+        assertTrue(DailyController.interleaveByRank(listOf(emptyList<String>(), emptyList())).isEmpty())
+        // A source that fetched nothing must not punch a hole in the ordering.
+        assertEquals(
+            listOf("a1", "b1", "a2"),
+            DailyController.interleaveByRank(listOf(listOf("a1", "a2"), emptyList(), listOf("b1"))),
+        )
+    }
+}


### PR DESCRIPTION
## What & why

Every source contributed the same 5 articles to a Daily Read issue. Feeds differ a lot in volume and
signal, so one cap either starves a feed worth reading widely or floods the issue from a noisy one.

Closes #193

## How it works

**A `Source` carries its own limit**, persisted next to its enabled flag. A stored source without the
key defaults to **5** — the number every feed used before this — so an existing reader's issues are
unchanged until they say otherwise.

**Limits are clamped on read as well as write**, to 1–20. Zero is the case that matters: a source set
to zero would contribute nothing while still listed as active, which reads as a broken feed rather
than a setting. Muting stays the way to switch a source off. The ceiling is the "reasonable maximum"
the issue asks for, so one busy feed cannot swamp an issue.

**The round-robin that orders the issue now runs to the longest source** rather than to a fixed
count. This is the load-bearing part, not tidying: with per-source limits the lists are different
lengths, and the old fixed bound would have silently dropped everything a source contributed past the
default — a feed set to 10 delivering 5, with no error anywhere. Sources that run out drop away and
the rest keep interleaving, so a high-limit feed tails the issue instead of being truncated. Every
source still gets front-of-issue presence before any source's second article (#107).

**The control is a per-row `− n +` stepper** in the Sources dialog, saved with mutes and removals in
one pass. A stepper rather than a numeric field because the range is small and the dialog is driven
by finger on e-ink, where summoning a keyboard is slow and costs a refresh per keystroke. The buttons
go through the same clamp as storage, so the control cannot express a value the compile would reject.

## How it was tested

- [x] `./gradlew :app:testDebugUnitTest` is green, including a new `PerFeedLimitTest`
- [x] `cargo test --workspace` green (the Rust core is untouched — the cap lives in the shell)
- [x] Added tests that fail without this change — verified by restoring the old fixed bound
- [ ] Verified on a device (Supernote)

Covered: the default is still 5 and an existing feed keeps it; out-of-range limits clamp (0, negative,
`Int.MIN_VALUE`, `Int.MAX_VALUE`); round-robin ordering; a source above the default keeps **all** its
articles; and ragged/empty inputs, so a source that fetched nothing does not punch a hole in the
ordering.

The limit and ordering logic is in the companion object so it is testable on the host JVM without an
Android runtime — the module has no JSON stub in unit tests, so persistence itself stays untested,
as it already was.

**Device check wanted:** set one feed to 10 and another to 2, compile an issue, and confirm the
counts and that the front page still shows every source.

## Scope / follow-ups

- The issue's suggested UI showed a numeric field as an alternative; the stepper covers the same
  range with fewer refreshes. Easy to swap if it reads badly on device.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core is untouched; no vendor names added (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
