### PR TITLE
fix(reader): keep the bottom bar open for zoom (#164)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -202,13 +202,20 @@ class BottomBarController(private val host: Host) {
             setPadding(dp(2), dp(6), dp(2), dp(12))
         }
         // One control = a line icon over a small label (Boox/NeoReader bottom-bar style, frame 069).
-        fun control(iconRes: Int, label: String, onClick: () -> Unit) {
+        //
+        // [staysOpen] keeps the bar up for a control that acts on the page in place and that a
+        // reader repeats — zoom, in practice (#164). Everything else navigates away or opens
+        // another sheet, where leaving the bar behind would just cover what you asked for.
+        fun control(iconRes: Int, label: String, staysOpen: Boolean = false, onClick: () -> Unit) {
             val cell = LinearLayout(activity).apply {
                 orientation = LinearLayout.VERTICAL
                 gravity = Gravity.CENTER
                 setPadding(dp(2), dp(8), dp(2), dp(8))
                 isClickable = true
-                setOnClickListener { dialog.dismiss(); onClick() }
+                setOnClickListener {
+                    if (!staysOpen) dialog.dismiss()
+                    onClick()
+                }
             }
             cell.addView(
                 ImageView(activity).apply {
@@ -238,8 +245,10 @@ class BottomBarController(private val host: Host) {
         control(R.drawable.ic_menu_contents, "Contents") { showContentsLazy() }
         control(R.drawable.ic_menu_search, "Search") { host.openSearch() }
         // Quick zoom (circle −/+ icons — not magnifiers, which are reserved for Search). Also in Adjust → Zoom.
-        control(R.drawable.ic_menu_zoom_out, "Zoom −") { host.zoomOut() }
-        control(R.drawable.ic_menu_zoom_in, "Zoom +") { host.zoomIn() }
+        // Zoom is stepwise: reaching a comfortable size takes several taps, and dismissing after
+        // each one made every step cost reopening the bar (#164).
+        control(R.drawable.ic_menu_zoom_out, "Zoom −", staysOpen = true) { host.zoomOut() }
+        control(R.drawable.ic_menu_zoom_in, "Zoom +", staysOpen = true) { host.zoomIn() }
         control(R.drawable.ic_menu_export, "Export") { host.openExport() }
         control(R.drawable.ic_menu_dict, "Dicts") { host.openDicts() }
         // Document controls consolidated into one KOReader-style tabbed sheet (Rotate/Fit/Font/Display).


### PR DESCRIPTION
## What & why

#164 reported that taps often had to be repeated before an action registered. Instrumented builds on
a Nomad found the cause, and it was not what the issue guessed.

Addresses part of #164.

## What the measurements showed

**Taps are not being dropped.** 23 deliberate taps on the tool palette, logging `actionMasked` and
whether the click fired:

| surface | `ACTION_DOWN` | `ACTION_UP` | `ACTION_CANCEL` | click fired |
|---|---|---|---|---|
| Pen | 7 | 7 | 0 | 7 |
| Highlight | 11 | 11 | 0 | 11 |
| Eraser | 5 | 5 | 0 | 5 |

Every down had a matching up and fired its click. Feedback is prompt too: median **102 ms** from
click to the following render completing (min 94, max 154). So the `ACTION_UP`-swallowing theory in
the issue is wrong, and the `setOnClickListener` call sites do **not** need converting to
`ACTION_DOWN` dispatch — which would have cost press-then-slide-off cancellation for nothing.

**The bottom bar was one action per open.** Every control dismissed the bar as its first act. A
second instrumented run, logging each open, action and dismiss:

```
OPEN → ACTION → DISMISS
OPEN → ACTION → DISMISS
OPEN → DISMISS
OPEN → ACTION → DISMISS
OPEN → ACTION → DISMISS
OPEN → ACTION → DISMISS
```

6 opens, 5 actions, **never more than one action in a single open**. Zoom is stepwise, so five zoom
steps cost about ten taps — half of them spent reopening a bar that had closed itself. That is what
"had to tap several times" was.

## How it works

`control` takes `staysOpen`. Zoom − and Zoom + set it; everything else keeps dismissing, because it
navigates away or opens another sheet, where leaving the bar behind would cover the thing that was
asked for.

## How it was tested

- [x] `./gradlew :app:testDebugUnitTest` green
- [x] `cargo test --workspace` green (Rust untouched)
- [x] **Verified on device (Supernote Nomad)**

Device verification against a PDF: one open, several zoom taps, eight consecutive renders at
85–135 ms spaced by tapping cadence with no open/close between them, and the page repaints
underneath the bar while it is up.

That last point was the risk in this approach and the reason it needed a device: the bar is a
separate window over the page, and if the firmware had not repainted underneath it, zoom would have
appeared to do nothing until the bar closed — worse than the problem being fixed.

No host test: the change is one boolean per call site, and what needed proving (does the page repaint
under a focused dialog window on this firmware) is not expressible on the host.

## Scope / follow-ups

- **#164 should stay open.** This fixes the bar's one-shot behaviour, which is one contributor. The
  original report is subjective and may have had more than one cause.
- A separate defect found along the way: `Zoom +/−` are shown on **reflowable** documents where they
  do nothing at all (`zoomBy` returns early when the document is not magnifiable, #61), while pinch
  on those documents silently changes the *font size* instead. Tapping a visible control and getting
  nothing is its own "the app is not responding" experience. Filed separately.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core is untouched; no vendor names added (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
