### PR TITLE
feat: two-column newspaper layout (#194) — re-targeted at master

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -329,13 +329,28 @@ class AdjustSheetController(private val host: Host) {
             host.diag { "DIAG alignment=$which" }
             applyReflow { NativeBridge.nativeSetAlignment(host.docHandle, which) }
         }))
-        // #194. The core declines two columns on a page too narrow for a readable measure, so this
-        // can read as "nothing happened" — the stored setting still stands and takes effect if the
-        // text is made smaller or the page turned landscape.
+        // #194. The core declines two columns on a page too narrow for a readable measure. Say so:
+        // silently doing nothing is indistinguishable from a broken control, and the setting is
+        // still stored — it takes effect once the text is smaller or the page wider.
         container.addView(settingRow("Columns", segmented(listOf("Single", "Two"), prefs.columns - 1) { which ->
             prefs.columns = which + 1
-            host.diag { "DIAG columns=${prefs.columns}" }
-            applyReflow { NativeBridge.nativeSetColumns(host.docHandle, prefs.columns) }
+            applyReflow {
+                val page = NativeBridge.nativeSetColumns(host.docHandle, prefs.columns)
+                val effective =
+                    runCatching { NativeBridge.nativeEffectiveColumns(host.docHandle) }.getOrDefault(1)
+                android.util.Log.i(
+                    "AdjustSheet",
+                    "columns: asked ${prefs.columns}, layout using $effective, page=$page",
+                )
+                if (prefs.columns > effective) activity.runOnUiThread {
+                    Toast.makeText(
+                        activity,
+                        "Two columns need a wider page or smaller text",
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                }
+                page
+            }
         }))
         return container
     }

--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -329,6 +329,14 @@ class AdjustSheetController(private val host: Host) {
             host.diag { "DIAG alignment=$which" }
             applyReflow { NativeBridge.nativeSetAlignment(host.docHandle, which) }
         }))
+        // #194. The core declines two columns on a page too narrow for a readable measure, so this
+        // can read as "nothing happened" — the stored setting still stands and takes effect if the
+        // text is made smaller or the page turned landscape.
+        container.addView(settingRow("Columns", segmented(listOf("Single", "Two"), prefs.columns - 1) { which ->
+            prefs.columns = which + 1
+            host.diag { "DIAG columns=${prefs.columns}" }
+            applyReflow { NativeBridge.nativeSetColumns(host.docHandle, prefs.columns) }
+        }))
         return container
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
@@ -89,6 +89,11 @@ class DisplayPrefs(private val context: Context) {
         get() = typography.getInt("alignment", 0).coerceIn(0, 3)
         set(i) = typography.edit().putInt("alignment", i).apply()
 
+    /** Text columns per page (#194): 1 or 2. Stored per reader, applied where the page can take it. */
+    var columns: Int
+        get() = typography.getInt("columns", 1).coerceIn(1, 2)
+        set(i) = typography.edit().putInt("columns", i.coerceIn(1, 2)).apply()
+
     /** The segmented index for the saved multiplier (nearest [LINE_SPACINGS] entry; default Medium). */
     fun lineSpacingIndex(): Int {
         val m = lineSpacingMult

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -252,6 +252,10 @@ object NativeBridge {
      *  regardless — the request is still stored. Re-render after. */
     external fun nativeSetColumns(handle: Long, columns: Int): Int
 
+    /** Columns the layout is ACTUALLY using — a narrow page reduces two to one whatever was asked
+     *  for (#194). Lets the shell say a request was declined rather than leave it looking ignored. */
+    external fun nativeEffectiveColumns(handle: Long): Int
+
     /** Apply ALL reflow typography at once, repaginating ONCE (RR4). Use this on the open path to
      *  restore persisted settings — the individual setters each repaginate, so applying four of
      *  them in a row costs four full passes over the book (#161/#162). Returns the new page, or -1

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -56,6 +56,7 @@ object NativeBridge {
         fontId: Int,
         lineSpacing: Float,
         alignCode: Int,
+        columns: Int,
     ): Long
 
     /** Persist the current reading position (RR12-FR3); store-less session = no-op. */
@@ -246,6 +247,11 @@ object NativeBridge {
      *  new page, or -1 for a fixed-layout PDF. Re-render after. */
     external fun nativeSetAlignment(handle: Long, code: Int): Int
 
+    /** Reflow columns (1 or 2; #194); repaginates EPUB. Returns the new page, or -1 for a
+     *  fixed-layout PDF. A page too narrow for a readable two-column measure lays out single-column
+     *  regardless — the request is still stored. Re-render after. */
+    external fun nativeSetColumns(handle: Long, columns: Int): Int
+
     /** Apply ALL reflow typography at once, repaginating ONCE (RR4). Use this on the open path to
      *  restore persisted settings — the individual setters each repaginate, so applying four of
      *  them in a row costs four full passes over the book (#161/#162). Returns the new page, or -1
@@ -256,6 +262,7 @@ object NativeBridge {
         fontId: Int,
         lineSpacing: Float,
         alignCode: Int,
+        columns: Int,
     ): Int
 
     /** Chapters laid out so far, packed as `(done shl 32) or total` (#161). `total == 0` means no

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -802,7 +802,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             NativeBridge.nativeOpenDocumentWithStore(
                 path, capsBytes, viewW, viewH, DPI, dbPath, bookId,
                 displayPrefs.textScale, displayPrefs.font,
-                displayPrefs.lineSpacingMult, displayPrefs.alignment,
+                displayPrefs.lineSpacingMult, displayPrefs.alignment, displayPrefs.columns,
             )
         } catch (e: RuntimeException) {
             Log.e(TAG, "open failed: ${e.message}")
@@ -1852,6 +1852,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                             displayPrefs.font,
                             displayPrefs.lineSpacingMult,
                             displayPrefs.alignment,
+                            displayPrefs.columns,
                         )
                     } catch (e: RuntimeException) {}
                 }

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -47,6 +47,14 @@ impl Hyphenator for NoHyphen {
 }
 
 /// Viewport + typography for a layout pass (all pixels). Repagination on a font-size or margin
+/// Narrowest column worth setting, in ems of the body size (#194).
+///
+/// Typography puts a comfortable measure at 45-75 characters; below roughly 20 the line breaks
+/// every few words and justified text opens rivers. 18 em is about 30-35 characters at a normal
+/// face — tight, but still readable — so it is the point at which a two-column request is declined
+/// rather than honoured badly.
+const MIN_COLUMN_EM: f32 = 18.0;
+
 /// Horizontal text alignment for reflowed lines (RR4 — KOReader's "Alignment").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Align {
@@ -108,6 +116,9 @@ pub struct LayoutOpts {
     pub para_gap: f32,
     /// Horizontal alignment of reflowed lines (RR4).
     pub align: Align,
+    /// Text columns per page — 1 (default) or 2 (#194). A page too narrow to give two columns a
+    /// readable measure falls back to one; see [`LayoutOpts::effective_columns`].
+    pub columns: u8,
 }
 
 impl LayoutOpts {
@@ -122,11 +133,56 @@ impl LayoutOpts {
             line_spacing: 1.4,
             para_gap: font_px * 0.7,
             align: Align::Left,
+            columns: 1,
         }
     }
 
-    fn content_w(&self) -> f32 {
+    /// The gap between columns. Reuses the page margin rather than adding a knob: it is already
+    /// tuned to the panel, and a gutter narrower than the outer margin reads as a mistake.
+    fn gutter(&self) -> f32 {
+        self.margin
+    }
+
+    /// The full text measure, ignoring columns.
+    fn text_w(&self) -> f32 {
         (self.page_w - 2.0 * self.margin).max(1.0)
+    }
+
+    /// Columns actually used, which is not always what was asked for (#194).
+    ///
+    /// Two columns on a narrow page produce a measure too short to read — words break every few
+    /// characters and justification opens rivers. Below [`MIN_COLUMN_EM`] ems the request is
+    /// declined and the page stays single-column, which is what the reader wants even though it is
+    /// not what they asked for.
+    #[must_use]
+    pub fn effective_columns(&self) -> u8 {
+        if self.columns <= 1 {
+            return 1;
+        }
+        let each = (self.text_w() - self.gutter()) / f32::from(self.columns);
+        if each < MIN_COLUMN_EM * self.font_px {
+            1
+        } else {
+            self.columns
+        }
+    }
+
+    /// One column's width — what a rule spans, and what a caller drawing column-wide furniture
+    /// needs. Same as [`Self::content_w`], exposed because the renderer is outside this module.
+    #[must_use]
+    pub fn column_width(&self) -> f32 {
+        self.content_w()
+    }
+
+    /// The measure lines are broken to — one column's width, which for a single-column page is the
+    /// whole text width. Line breaking, justification and image fitting all read this, so columns
+    /// need no special handling anywhere below this point.
+    fn content_w(&self) -> f32 {
+        let cols = self.effective_columns();
+        if cols <= 1 {
+            return self.text_w();
+        }
+        ((self.text_w() - self.gutter()) / f32::from(cols)).max(1.0)
     }
 
     fn content_h(&self) -> f32 {
@@ -165,6 +221,13 @@ impl LayoutOpts {
             }
         }
         eat(self.align as u8);
+        // Folded in only when it changes the layout. A single-column page lays out exactly as it
+        // did before columns existed, so leaving its digest alone keeps every pagination already
+        // cached — rebuilding one is the cost #186 is about, and there is nothing to gain by
+        // discarding them all for a field most books never set.
+        if self.columns > 1 {
+            eat(self.columns);
+        }
         h
     }
 }
@@ -210,6 +273,11 @@ pub struct LayoutLine {
     /// An illustration occupying this line's box (#187). Mutually exclusive with `runs` in
     /// practice: an image block emits one line that is nothing but the picture.
     pub image: Option<PlacedImage>,
+    /// Left edge of the column this line sits in, relative to the content origin (#194). Zero for a
+    /// single-column page and for the first column. Runs already carry their own absolute-in-content
+    /// `x`; this exists for the things that span a whole column rather than sitting at an `x` — the
+    /// horizontal rule, which would otherwise run across both columns.
+    pub column_x: f32,
 }
 
 /// An illustration placed in the content box: where it sits and how big it is drawn, not its
@@ -354,10 +422,13 @@ pub fn paginate_upto(
     // the before-margin collapses at the top of a page.
     let indent = opts.font_px * 1.2;
     let mut complete = true;
+    // `max_pages` counts pages, but the pager is producing *columns* — a two-column page needs two
+    // of them before it is whole.
+    let column_budget = max_pages.saturating_mul(usize::from(opts.effective_columns()));
     for (block_index, block) in blocks.iter().enumerate() {
         // Checked before the block, not after: once enough whole pages exist, laying out one more
         // block is work the caller has said it does not need.
-        if pager.finished_page_count() >= max_pages {
+        if pager.finished_page_count() >= column_budget {
             complete = false;
             break;
         }
@@ -483,11 +554,51 @@ pub fn paginate_upto(
             Block::Rule => pager.add_rule(opts.para_gap),
         }
     }
-    if complete {
-        (pager.finish(), true)
+    let columns = opts.effective_columns();
+    let laid = if complete {
+        pager.finish()
     } else {
-        (pager.into_finished_pages(), false)
+        pager.into_finished_pages()
+    };
+    (combine_columns(laid, opts, columns), complete)
+}
+
+/// Fold a run of single-column pages into multi-column ones (#194).
+///
+/// The pagination above lays out to the *column* measure, so what it produced is a sequence of
+/// columns in reading order. A two-column page is simply the next two of them side by side: the
+/// second column's content is shifted right by one column plus the gutter, and its vertical
+/// positions are already correct, because every column starts at the top of the page.
+///
+/// That is why columns need no special handling in line breaking, justification, image fitting or
+/// page breaking — by the time this runs, all of it has already happened against the right measure.
+fn combine_columns(pages: Vec<Page>, opts: &LayoutOpts, columns: u8) -> Vec<Page> {
+    if columns <= 1 {
+        return pages;
     }
+    let dx = opts.content_w() + opts.gutter();
+    pages
+        .chunks(usize::from(columns))
+        .map(|chunk| {
+            let mut lines = Vec::new();
+            for (index, column) in chunk.iter().enumerate() {
+                let shift = dx * index as f32;
+                lines.extend(column.lines.iter().cloned().map(|mut line| {
+                    if shift != 0.0 {
+                        for run in &mut line.runs {
+                            run.x += shift;
+                        }
+                        if let Some(image) = &mut line.image {
+                            image.x += shift.round() as i32;
+                        }
+                        line.column_x += shift;
+                    }
+                    line
+                }));
+            }
+            Page { lines }
+        })
+        .collect()
 }
 
 /// Accumulates lines into pages, breaking when the content box is full.
@@ -523,6 +634,7 @@ impl<'o> Pager<'o> {
             runs,
             rule,
             image: None,
+            column_x: 0.0,
         });
         self.cursor_y += height;
     }
@@ -679,6 +791,7 @@ impl<'o> Pager<'o> {
             runs: Vec::new(),
             rule: false,
             image: Some(image),
+            column_x: 0.0,
         });
         self.cursor_y += height;
     }

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -49,11 +49,17 @@ impl Hyphenator for NoHyphen {
 /// Viewport + typography for a layout pass (all pixels). Repagination on a font-size or margin
 /// Narrowest column worth setting, in ems of the body size (#194).
 ///
-/// Typography puts a comfortable measure at 45-75 characters; below roughly 20 the line breaks
-/// every few words and justified text opens rivers. 18 em is about 30-35 characters at a normal
-/// face — tight, but still readable — so it is the point at which a two-column request is declined
-/// rather than honoured badly.
-const MIN_COLUMN_EM: f32 = 18.0;
+/// A comfortable single-column measure is 45-75 characters, but newspaper columns are deliberately
+/// far tighter — 30-35 is normal, which is the look this feature exists to produce. At roughly half
+/// an em per character, 14 em is about **28 characters**: tight, and squarely in newspaper
+/// territory.
+///
+/// The floor is in ems, not pixels, because what matters is characters per line: raising the text
+/// size narrows the measure even though the page has not changed. Set from measurement rather than
+/// taste — at a comfortable reading size on a 1920px panel (56px text) a column comes out at 14 em,
+/// so a floor above that declines the feature exactly where it was asked for. Below this the line
+/// breaks every few words and justified text opens rivers, which is worse than one column.
+const MIN_COLUMN_EM: f32 = 14.0;
 
 /// Horizontal text alignment for reflowed lines (RR4 — KOReader's "Alignment").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/inkread-epub/src/layout_tests.rs
+++ b/inkread-epub/src/layout_tests.rs
@@ -92,6 +92,7 @@ fn layout_digest_is_pinned_against_algorithm_drift() {
         line_spacing: 1.4,
         para_gap: 11.2,
         align: Align::Left,
+        columns: 1,
     };
     assert_eq!(opts.layout_digest(), 17_685_407_801_978_826_572);
 }
@@ -134,6 +135,7 @@ fn style_opts() -> LayoutOpts {
         line_spacing: 1.0,
         para_gap: 0.0,
         align: Align::Left,
+        columns: 1,
     }
 }
 
@@ -311,6 +313,7 @@ fn long_paragraph_wraps_to_multiple_lines() {
         line_spacing: 1.0,
         para_gap: 0.0,
         align: Align::Left,
+        columns: 1,
     };
     let words = "aaaa ".repeat(12); // 12 words of 4 chars → ~ wraps
     let pages = paginate(&[para(words.trim())], &opts, &Mono);
@@ -341,6 +344,7 @@ fn cjk_opts() -> LayoutOpts {
         line_spacing: 1.0,
         para_gap: 0.0,
         align: Align::Left,
+        columns: 1,
     }
 }
 
@@ -477,6 +481,7 @@ fn content_overflow_breaks_into_pages() {
         line_spacing: 1.0,
         para_gap: 0.0,
         align: Align::Left,
+        columns: 1,
     };
     let blocks: Vec<Block> = (0..7).map(|_| para("x")).collect();
     let pages = paginate(&blocks, &opts, &Mono);
@@ -495,6 +500,7 @@ fn heading_uses_a_larger_line_height() {
         line_spacing: 1.0,
         para_gap: 0.0,
         align: Align::Left,
+        columns: 1,
     };
     let pages = paginate(
         &[Block::Heading {
@@ -569,6 +575,7 @@ fn wide(font_px: f32) -> LayoutOpts {
         line_spacing: 1.0,
         para_gap: 0.0,
         align: Align::Left,
+        columns: 1,
     }
 }
 
@@ -645,6 +652,7 @@ fn narrow_para() -> LayoutOpts {
         line_spacing: 1.0,
         para_gap: 0.0,
         align: Align::Left,
+        columns: 1,
     }
 }
 
@@ -728,6 +736,7 @@ fn image_opts() -> LayoutOpts {
         line_spacing: 1.0,
         para_gap: 0.0,
         align: Align::Left,
+        columns: 1,
     }
 }
 
@@ -989,4 +998,182 @@ fn a_zero_bound_lays_nothing_out_and_an_empty_book_is_complete() {
     let (pages, complete) = paginate_upto(&[], &opts, &Mono, &NoHyphen, &NoImages, 5);
     assert!(pages.is_empty());
     assert!(complete, "there was nothing left unlaid");
+}
+
+// ---------------------------------------------------------------------------------------------
+// #194 — two-column layout.
+// ---------------------------------------------------------------------------------------------
+
+/// A page wide enough for two real columns at the test metrics: 400px wide, 50px tall, margin 0,
+/// 10px font. Two columns = (400 - 0 gutter) / 2 = 200px each — well over the 18em floor.
+fn two_col_opts() -> LayoutOpts {
+    LayoutOpts {
+        page_w: 400.0,
+        page_h: 50.0,
+        margin: 0.0,
+        font_px: 10.0,
+        line_spacing: 1.0,
+        para_gap: 0.0,
+        align: Align::Left,
+        columns: 2,
+    }
+}
+
+fn words_of(page: &Page) -> Vec<String> {
+    page.lines
+        .iter()
+        .flat_map(|l| &l.runs)
+        .map(|r| r.text.clone())
+        .collect()
+}
+
+/// The heart of it: text must fill the left column, then the right, then move to the next page.
+/// Getting this wrong reads as scrambled prose, not as a layout bug.
+#[test]
+fn text_fills_the_first_column_then_the_second() {
+    let opts = two_col_opts();
+    let blocks: Vec<Block> = (0..40).map(|i| para(&format!("w{i}"))).collect();
+    let single = paginate(&blocks, &LayoutOpts { columns: 1, ..opts }, &Mono);
+    let double = paginate(&blocks, &opts, &Mono);
+
+    // Same words, same order — only their positions differ.
+    let flat = |pages: &[Page]| -> Vec<String> { pages.iter().flat_map(words_of).collect() };
+    assert_eq!(flat(&single), flat(&double), "reading order changed");
+
+    // Two columns hold twice the text, so the page count roughly halves.
+    assert!(
+        double.len() < single.len(),
+        "two columns produced {} pages vs {} single",
+        double.len(),
+        single.len()
+    );
+
+    // On page 1 the left column's words all precede the right column's, and the right column starts
+    // at the second column's origin.
+    let first = &double[0];
+    let dx = opts.column_width() + opts.margin.max(0.0);
+    let left: Vec<&PlacedRun> = first
+        .lines
+        .iter()
+        .flat_map(|l| &l.runs)
+        .filter(|r| r.x < dx.max(1.0))
+        .collect();
+    let right: Vec<&PlacedRun> = first
+        .lines
+        .iter()
+        .flat_map(|l| &l.runs)
+        .filter(|r| r.x >= dx.max(1.0))
+        .collect();
+    assert!(
+        !left.is_empty() && !right.is_empty(),
+        "expected both columns filled"
+    );
+    let last_left = left.last().unwrap().anchor.char_offset;
+    let first_right = right.first().unwrap().anchor.char_offset;
+    assert!(
+        first_right > last_left,
+        "the right column must continue from the left, not precede it ({first_right} vs {last_left})"
+    );
+}
+
+/// Both columns start at the top of the page — that is what makes them columns rather than a
+/// continuation down the page.
+#[test]
+fn both_columns_start_at_the_top_of_the_page() {
+    let opts = two_col_opts();
+    let blocks: Vec<Block> = (0..40).map(|i| para(&format!("w{i}"))).collect();
+    let pages = paginate(&blocks, &opts, &Mono);
+    let dx = opts.column_width();
+    let top_of = |right: bool| -> f32 {
+        pages[0]
+            .lines
+            .iter()
+            .filter(|l| l.runs.iter().any(|r| (r.x >= dx) == right))
+            .map(|l| l.top)
+            .fold(f32::INFINITY, f32::min)
+    };
+    assert_eq!(top_of(false), top_of(true), "columns must share a top edge");
+}
+
+/// A page too narrow for a readable measure declines the request rather than honouring it badly.
+#[test]
+fn a_page_too_narrow_for_two_columns_stays_single() {
+    // 200px wide at a 10px font: each column would be 100px = 10em, under the 18em floor.
+    let narrow = LayoutOpts {
+        page_w: 200.0,
+        ..two_col_opts()
+    };
+    assert_eq!(narrow.effective_columns(), 1, "should have declined");
+    assert_eq!(
+        narrow.column_width(),
+        LayoutOpts {
+            columns: 1,
+            ..narrow
+        }
+        .column_width(),
+        "a declined request must lay out exactly as single-column"
+    );
+
+    // …and a page that IS wide enough honours it.
+    assert_eq!(two_col_opts().effective_columns(), 2);
+}
+
+/// A larger font makes a column narrower in ems, so the same page can stop supporting two columns.
+#[test]
+fn the_fallback_follows_the_font_size_not_just_the_page_width() {
+    let base = two_col_opts();
+    assert_eq!(base.effective_columns(), 2);
+    let huge = LayoutOpts {
+        font_px: 20.0,
+        ..base
+    };
+    assert_eq!(
+        huge.effective_columns(),
+        1,
+        "200px column is 10em at a 20px font"
+    );
+}
+
+/// The digest keys persisted paginations. Two columns must not be served a single-column index.
+#[test]
+fn the_column_count_changes_the_layout_digest() {
+    let one = two_col_opts_with(1);
+    let two = two_col_opts_with(2);
+    assert_ne!(one.layout_digest(), two.layout_digest());
+    // …but a single-column page digests exactly as it did before columns existed, so paginations
+    // already cached are not thrown away.
+    assert_eq!(
+        one.layout_digest(),
+        LayoutOpts { columns: 0, ..one }.layout_digest()
+    );
+}
+
+fn two_col_opts_with(columns: u8) -> LayoutOpts {
+    LayoutOpts {
+        columns,
+        ..two_col_opts()
+    }
+}
+
+/// A rule must not run across the gutter — that reads as a divider between columns.
+#[test]
+fn a_rule_spans_only_its_own_column() {
+    let opts = two_col_opts();
+    let mut blocks: Vec<Block> = (0..20).map(|i| para(&format!("w{i}"))).collect();
+    blocks.push(Block::Rule);
+    blocks.extend((20..40).map(|i| para(&format!("w{i}"))));
+    let pages = paginate(&blocks, &opts, &Mono);
+    let rules: Vec<f32> = pages
+        .iter()
+        .flat_map(|p| &p.lines)
+        .filter(|l| l.rule)
+        .map(|l| l.column_x)
+        .collect();
+    assert!(!rules.is_empty(), "the fixture should produce a rule");
+    for x in &rules {
+        assert!(
+            *x == 0.0 || (*x - (opts.column_width() + opts.margin)).abs() < 0.5,
+            "a rule sits at a column origin, got {x}"
+        );
+    }
 }

--- a/inkread-epub/src/layout_tests.rs
+++ b/inkread-epub/src/layout_tests.rs
@@ -1177,3 +1177,38 @@ fn a_rule_spans_only_its_own_column() {
         );
     }
 }
+
+/// The case #194 was actually reported for, and the one the first attempt got wrong: a Nomad at a
+/// comfortable reading size. 1920px wide, 56px text (a 1.5x scale on the 38px base) — the column
+/// comes out at 14 em, so a floor set any higher declines the feature precisely where it was asked
+/// for. Pinned with real numbers rather than taste.
+#[test]
+fn a_nomad_at_a_comfortable_reading_size_gets_two_columns() {
+    let opts = LayoutOpts {
+        columns: 2,
+        ..LayoutOpts::new(1920.0, 2560.0, 56.0)
+    };
+    assert_eq!(
+        opts.effective_columns(),
+        2,
+        "column was {:.1} em",
+        opts.column_width() / opts.font_px
+    );
+    // Comfortably inside newspaper territory: about 28 characters at half an em each.
+    let ems = opts.column_width() / opts.font_px;
+    assert!(
+        (13.0..=16.0).contains(&ems),
+        "expected ~14 em, got {ems:.1}"
+    );
+
+    // Raise the text far enough and it is declined again — the floor still protects the measure.
+    let huge = LayoutOpts {
+        columns: 2,
+        ..LayoutOpts::new(1920.0, 2560.0, 90.0)
+    };
+    assert_eq!(
+        huge.effective_columns(),
+        1,
+        "90px text leaves under 9 em a column"
+    );
+}

--- a/inkread-epub/src/render.rs
+++ b/inkread-epub/src/render.rs
@@ -330,10 +330,12 @@ pub fn render_page_with_images(
             continue;
         }
         if line.rule {
-            // A hairline rule across the content width, vertically centred in the line slot.
+            // A hairline rule across the content width, vertically centred in the line slot. On a
+            // two-column page it spans only its own column (#194) — a rule running across the
+            // gutter would read as a divider between the columns rather than within one.
             let y = (margin + line.top + line.height * 0.5).round() as i32;
-            let x0 = margin.round() as i32;
-            let x1 = (opts.page_w - margin).round() as i32;
+            let x0 = (margin + line.column_x).round() as i32;
+            let x1 = (margin + line.column_x + opts.column_width()).round() as i32;
             for x in x0..x1 {
                 canvas.blend(x, y, 0.6);
             }

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -469,6 +469,16 @@ pub trait Document {
         None
     }
 
+    /// Set the reflow **column count** (1 or 2) and repaginate, preserving the chapter (#194).
+    /// Returns the new page, or `None` for a fixed-layout format (PDF). Default: unsupported.
+    ///
+    /// A page too narrow for a readable two-column measure lays out single-column regardless; the
+    /// request is stored either way, so widening the page or shrinking the text takes effect
+    /// without the reader having to ask again.
+    fn set_columns(&self, _columns: i32, _current_page: usize) -> Option<usize> {
+        None
+    }
+
     /// Set the reflow **font family** (`font_id` = index into the bundled reading faces) and
     /// repaginate, preserving the chapter (RR4). Returns the new page, or `None` for a fixed-layout
     /// format (PDF). Default: unsupported.

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -103,6 +103,8 @@ pub struct Typography {
     pub line_spacing: f32,
     /// `0=Left, 1=Justify, 2=Center, 3=Right`.
     pub align_code: i32,
+    /// Text columns per page — 1 or 2 (#194).
+    pub columns: i32,
 }
 
 impl Default for Typography {
@@ -114,6 +116,7 @@ impl Default for Typography {
             font_id: 0,
             line_spacing: 1.4,
             align_code: 0,
+            columns: 1,
         }
     }
 }
@@ -504,6 +507,7 @@ pub trait Document {
             t.font_id,
             t.line_spacing,
             t.align_code,
+            t.columns,
             current_page,
         )
     }
@@ -515,12 +519,14 @@ pub trait Document {
     /// in seconds and opening in minutes (#161/#162). Returns the new page, or `None` for a format
     /// with no reflow at all. The default composes the individual setters — correct for any backend,
     /// and a backend that can fold them into a single pass overrides this.
+    #[allow(clippy::too_many_arguments)]
     fn set_typography(
         &self,
         scale: f32,
         font_id: i32,
         line_spacing: f32,
         align_code: i32,
+        columns: i32,
         current_page: usize,
     ) -> Option<usize> {
         // Threaded, not batched: each step repaginates, so the next must resolve its chapter
@@ -541,6 +547,10 @@ pub trait Document {
             at = p;
         }
         if let Some(p) = self.set_alignment(align_code, at) {
+            page = Some(p);
+            at = p;
+        }
+        if let Some(p) = self.set_columns(columns, at) {
             page = Some(p);
         }
         page

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -482,6 +482,13 @@ pub trait Document {
         None
     }
 
+    /// Columns the layout is **actually** using, which is not always what was asked for: a page too
+    /// narrow for a readable measure lays out single-column regardless (#194). The shell needs this
+    /// to tell the reader their request was declined rather than ignored. Default: 1.
+    fn effective_columns(&self) -> i32 {
+        1
+    }
+
     /// Set the reflow **font family** (`font_id` = index into the bundled reading faces) and
     /// repaginate, preserving the chapter (RR4). Returns the new page, or `None` for a fixed-layout
     /// format (PDF). Default: unsupported.

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -757,12 +757,14 @@ impl Document for EpubBackend {
         font_id: i32,
         line_spacing: f32,
         align_code: i32,
+        columns: i32,
         current_page: usize,
     ) -> Option<usize> {
         self.scale.set(clamp_scale(scale));
         self.apply_font(font_id);
         self.line_spacing.set(clamp_line_spacing(line_spacing));
         self.align.set(Align::from_code(align_code));
+        self.columns.set(columns.clamp(1, 2) as u8);
         self.repaginate_keeping_chapter(current_page)
     }
 

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -383,9 +383,15 @@ impl EpubBackend {
                     return entry.pages.get(offset).map(|p| f(p, &opts));
                 }
                 // Defence in depth: an in-range page always falls inside its chapter's counted
-                // length, so this is unreachable unless the pagination index and the layout have
-                // diverged. Cheap to keep, and it fails closed rather than re-paginating.
-                Some(entry) if entry.complete => return None,
+                // length, so this is reached only when the pagination index and the layout have
+                // diverged. Fails closed rather than re-paginating, and says so — the caller
+                // otherwise reports it as a plain out-of-range page, which is misleading: the index
+                // believes the page exists, and that disagreement is the actual fault.
+                Some(entry) if entry.complete => {
+                    #[cfg(test)]
+                    DIVERGED.with(|d| d.set(d.get() + 1));
+                    return None;
+                }
                 Some(_) => true, // materialized, but not this far yet
                 None => false,
             }
@@ -737,6 +743,10 @@ impl Document for EpubBackend {
         self.repaginate_keeping_chapter(current_page)
     }
 
+    fn effective_columns(&self) -> i32 {
+        i32::from(Self::opts_for(&self.current_request()).effective_columns())
+    }
+
     fn set_font(&self, font_id: i32, current_page: usize) -> Option<usize> {
         // Swap the reading face, then repaginate (new metrics → new line breaks), keeping the chapter.
         self.apply_font(font_id);
@@ -811,10 +821,18 @@ thread_local! {
     static LAYOUT_PASSES: Cell<usize> = const { Cell::new(0) };
     /// Chapters parsed on this thread — the counter behind the laziness test (#186).
     static CHAPTER_PARSES: Cell<usize> = const { Cell::new(0) };
+    /// Times the index/layout divergence guard fired (#194 surfaced one in the wild).
+    static DIVERGED: Cell<usize> = const { Cell::new(0) };
     /// Chapter layout passes on this thread, and the pages each produced (#186). Materializing a
     /// chapter is cost a correctness test cannot see, so laziness has to be asserted directly.
     static CHAPTER_LAYOUTS: Cell<usize> = const { Cell::new(0) };
     static CHAPTER_PAGES_LAID: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Times the divergence guard fired on this thread.
+#[cfg(test)]
+pub(crate) fn diverged() -> usize {
+    DIVERGED.with(Cell::get)
 }
 
 /// Chapter layout passes on this thread since [`reset_chapter_layouts`].

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -63,6 +63,8 @@ struct LayoutRequest {
     scale: f32,
     line_spacing: f32,
     align: Align,
+    /// Text columns per page (#194).
+    columns: u8,
     /// The bundled reading face. Not part of [`LayoutOpts`], but a different face means different
     /// metrics, so it belongs in the staleness key.
     font_id: usize,
@@ -163,6 +165,8 @@ pub struct EpubBackend {
     line_spacing: Cell<f32>,
     /// Text alignment (RR4 — default Left, matching every other reflow default). Drives repagination.
     align: Cell<Align>,
+    /// Text columns per page (#194 — default 1). Drives repagination.
+    columns: Cell<u8>,
     /// The page size to lay out for; updated by the render path when the buffer changes.
     viewport: Cell<(u32, u32)>,
     /// The current pagination index, or `None` before the first one is needed. Laying out lazily
@@ -234,6 +238,7 @@ impl EpubBackend {
             scale: Cell::new(1.0),
             line_spacing: Cell::new(DEFAULT_LINE_SPACING),
             align: Cell::new(Align::default()),
+            columns: Cell::new(1),
             viewport: Cell::new((viewport.width, viewport.height)),
             // Deferred: the first read paginates, so the saved typography applied right after open
             // is folded into that single pass rather than triggering one pass per setting.
@@ -270,6 +275,7 @@ impl EpubBackend {
             scale: Cell::new(1.0),
             line_spacing: Cell::new(DEFAULT_LINE_SPACING),
             align: Cell::new(Align::default()),
+            columns: Cell::new(1),
             viewport: Cell::new((viewport.width, viewport.height)),
             laid: RefCell::new(None),
             chapter_pages: RefCell::new(Vec::new()),
@@ -427,6 +433,7 @@ impl EpubBackend {
             scale: self.scale.get(),
             line_spacing: self.line_spacing.get(),
             align: self.align.get(),
+            columns: self.columns.get(),
             font_id: self.font_id.get(),
         }
     }
@@ -437,6 +444,7 @@ impl EpubBackend {
         let mut opts = LayoutOpts::new(w as f32, h as f32, BASE_FONT_PX * request.scale);
         opts.line_spacing = request.line_spacing;
         opts.align = request.align;
+        opts.columns = request.columns;
         opts
     }
 
@@ -718,6 +726,14 @@ impl Document for EpubBackend {
 
     fn set_alignment(&self, align_code: i32, current_page: usize) -> Option<usize> {
         self.align.set(Align::from_code(align_code));
+        self.repaginate_keeping_chapter(current_page)
+    }
+
+    fn set_columns(&self, columns: i32, current_page: usize) -> Option<usize> {
+        // Stored as asked, clamped to what the engine models. Whether two columns are actually used
+        // is the layout's call — a page too narrow for a readable measure declines them — so the
+        // request survives a font-size change that later makes them viable.
+        self.columns.set(columns.clamp(1, 2) as u8);
         self.repaginate_keeping_chapter(current_page)
     }
 

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -1332,3 +1332,85 @@ fn extending_a_chapter_does_not_hold_the_prefix_and_the_full_layout_at_once() {
     );
     assert!(entries[0].complete);
 }
+
+/// #194: selecting two columns must repaginate and keep the reader where they were — the same
+/// contract every other reflow setting honours (RR12-FR4).
+#[test]
+fn selecting_two_columns_repaginates_and_keeps_the_chapter() {
+    let doc = EpubBackend::open(SAMPLE.to_vec(), vp(1200, 1600)).expect("sample opens");
+    let before = doc.page_count();
+    assert!(before > 0);
+
+    let moved = doc
+        .set_columns(2, 0)
+        .expect("a reflowable document supports columns");
+    assert!(
+        moved < doc.page_count(),
+        "position must land inside the new pagination"
+    );
+
+    // Two columns hold more text per page, so a book cannot get longer by asking for them.
+    assert!(
+        doc.page_count() <= before,
+        "{} pages in two columns vs {before} in one",
+        doc.page_count()
+    );
+
+    // Back to one column returns the original pagination exactly.
+    doc.set_columns(1, 0);
+    assert_eq!(
+        doc.page_count(),
+        before,
+        "single column should be as it was"
+    );
+}
+
+/// The request is stored even when the page is too narrow to honour it, so a later font-size
+/// change can bring it into effect without the reader asking again.
+#[test]
+fn a_column_request_survives_being_declined() {
+    // A narrow viewport at the default text size cannot give two readable columns.
+    let doc = EpubBackend::open(SAMPLE.to_vec(), vp(300, 900)).expect("sample opens");
+    let single = doc.page_count();
+    doc.set_columns(2, 0);
+    assert_eq!(
+        doc.page_count(),
+        single,
+        "a declined request must lay out exactly as single-column"
+    );
+
+    // Widen the page — the backend takes its viewport from the render buffer — and the stored
+    // request takes effect with no further call.
+    let mut bytes = vec![0u8; 1600 * 1200 * 4];
+    {
+        let mut buf = PixelBuffer::from_rgba(&mut bytes, 1600, 1200).unwrap();
+        doc.render_page(0, &mut buf)
+            .expect("renders at the new size");
+    }
+    assert!(
+        doc.page_count() <= single,
+        "the stored two-column request should apply once the page can take it"
+    );
+}
+
+/// Out-of-range column counts are clamped rather than trusted — the value crosses JNI.
+#[test]
+fn an_out_of_range_column_count_is_clamped() {
+    let doc = EpubBackend::open(SAMPLE.to_vec(), vp(1200, 1600)).expect("sample opens");
+    let one = doc.page_count();
+    doc.set_columns(2, 0);
+    let two = doc.page_count();
+
+    for absurd in [99, i32::MAX] {
+        doc.set_columns(absurd, 0);
+        assert_eq!(
+            doc.page_count(),
+            two,
+            "clamped to the widest supported ({absurd})"
+        );
+    }
+    for absurd in [0, -1, i32::MIN] {
+        doc.set_columns(absurd, 0);
+        assert_eq!(doc.page_count(), one, "clamped to single column ({absurd})");
+    }
+}

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -315,7 +315,7 @@ fn restoring_saved_typography_over_a_cold_open_costs_one_pagination() {
     reset_layout_passes();
     let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
     // Exactly what the shell does on open: restore four persisted settings, then read the count.
-    let page = b.set_typography(1.25, 1, 1.7, 2, 0);
+    let page = b.set_typography(1.25, 1, 1.7, 2, 1, 0);
     let count = b.page_count();
     assert_eq!(
         layout_passes(),
@@ -361,7 +361,7 @@ fn set_typography_lays_out_the_same_book_as_the_four_setters_do() {
     // The batched path is an optimization, so it must be indistinguishable from the individual
     // setters it replaces — same page count, same page content.
     let batched = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
-    assert_eq!(batched.set_typography(1.5, 2, 1.2, 3, 0), Some(0));
+    assert_eq!(batched.set_typography(1.5, 2, 1.2, 3, 1, 0), Some(0));
 
     let stepwise = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
     let _ = stepwise.set_font(2, 0);
@@ -749,7 +749,7 @@ fn a_cancel_restores_the_request_exactly_across_the_whole_settings_range() {
             for align_code in 0..4 {
                 let (w, _) = watcher(Some(1));
                 b.set_pagination_progress(w);
-                let _ = b.set_typography(scale, 1, spacing, align_code, 0);
+                let _ = b.set_typography(scale, 1, spacing, align_code, 1, 0);
 
                 assert_eq!(
                     b.current_request(),

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -1247,12 +1247,17 @@ fn a_page_the_index_claims_but_the_layout_lacks_is_refused_without_relaying_out(
     // The phantom page: in range per the index, absent from the layout.
     let phantom = real_total;
     assert!(doc.with_page(phantom, |_, _| ()).is_none(), "phantom page");
+    let diverged_before = diverged();
     reset_chapter_layouts();
     assert!(doc.with_page(phantom, |_, _| ()).is_none(), "still refused");
     assert_eq!(
         chapter_layouts(),
         0,
         "a known-complete chapter must not be laid out again for a page it does not have"
+    );
+    assert!(
+        diverged() > diverged_before,
+        "the refusal should come from the divergence guard, not an out-of-range page"
     );
 }
 

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -917,6 +917,21 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetLineSpac
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeEffectiveColumns(handle) : int — columns the layout is ACTUALLY using, which a narrow page
+// can reduce to 1 whatever was asked for (#194). Lets the shell say the request was declined.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeEffectiveColumns<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+) -> jint {
+    env.with_env(|env| -> jni::errors::Result<jint> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        Ok(session.effective_columns())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetColumns(handle, columns) : int — reflow columns (1 or 2; #194); repaginates EPUB.
 // Returns the new page index, or -1 for a fixed-layout PDF. Re-render after.
 #[unsafe(no_mangle)]

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -212,6 +212,7 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeOpenDocumen
     font_id: jint,
     line_spacing: jfloat,
     align_code: jint,
+    columns: jint,
 ) -> jlong {
     env.with_env(|env| -> jni::errors::Result<jlong> {
         let path: String = path.try_to_string(env)?;
@@ -226,6 +227,7 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeOpenDocumen
             font_id,
             line_spacing,
             align_code,
+            columns,
         };
 
         let bytes = read_document_file(&path).map_err(|e| throw(env, &e))?;
@@ -1034,10 +1036,11 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetTypograp
     font_id: jint,
     line_spacing: jfloat,
     align_code: jint,
+    columns: jint,
 ) -> jint {
     env.with_env(|env| -> jni::errors::Result<jint> {
         let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
-        if session.set_typography(scale, font_id, line_spacing, align_code) {
+        if session.set_typography(scale, font_id, line_spacing, align_code, columns) {
             Ok(session.current_page() as jint)
         } else {
             Ok(-1)

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -915,6 +915,26 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetLineSpac
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }
 
+// nativeSetColumns(handle, columns) : int — reflow columns (1 or 2; #194); repaginates EPUB.
+// Returns the new page index, or -1 for a fixed-layout PDF. Re-render after.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetColumns<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    columns: jint,
+) -> jint {
+    env.with_env(|env| -> jni::errors::Result<jint> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        if session.set_columns(columns) {
+            Ok(session.current_page() as jint)
+        } else {
+            Ok(-1)
+        }
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
 // nativeSetAlignment(handle, code) : int — reflow alignment (0=Left,1=Justify,2=Center,3=Right; RR4);
 // repaginates EPUB. Returns the new page index, or -1 for a fixed-layout PDF. Re-render after.
 #[unsafe(no_mangle)]

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -847,6 +847,12 @@ impl ReaderSession {
         }
     }
 
+    /// Columns the layout is actually using — see [`Document::effective_columns`] (#194).
+    #[must_use]
+    pub fn effective_columns(&self) -> i32 {
+        self.document.effective_columns()
+    }
+
     /// Set the reflow column count (1 or 2; #194); repaginates EPUB preserving the chapter.
     /// `false` for a fixed-layout PDF. Re-render after.
     pub fn set_columns(&mut self, columns: i32) -> bool {

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -885,17 +885,23 @@ impl ReaderSession {
     /// operation, repaginating once (RR4). The open path uses this instead of four separate setters
     /// so restoring a reader's saved settings costs a single layout pass (#161/#162). `false` for a
     /// fixed-layout document. Re-render after.
+    #[allow(clippy::too_many_arguments)]
     pub fn set_typography(
         &mut self,
         scale: f32,
         font_id: i32,
         line_spacing: f32,
         align_code: i32,
+        columns: i32,
     ) -> bool {
-        match self
-            .document
-            .set_typography(scale, font_id, line_spacing, align_code, self.page)
-        {
+        match self.document.set_typography(
+            scale,
+            font_id,
+            line_spacing,
+            align_code,
+            columns,
+            self.page,
+        ) {
             Some(new_page) => {
                 self.page = new_page.min(self.page_count().saturating_sub(1));
                 self.invalidate_render_cache(); // repagination changes what each page index renders

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -847,6 +847,20 @@ impl ReaderSession {
         }
     }
 
+    /// Set the reflow column count (1 or 2; #194); repaginates EPUB preserving the chapter.
+    /// `false` for a fixed-layout PDF. Re-render after.
+    pub fn set_columns(&mut self, columns: i32) -> bool {
+        match self.document.set_columns(columns, self.page) {
+            Some(new_page) => {
+                self.page = new_page.min(self.page_count().saturating_sub(1));
+                self.invalidate_render_cache(); // repagination changes what each page index renders
+                self.load_ink_for_current_page();
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Set the reflow alignment (`0=Left,1=Justify,2=Center,3=Right`; RR4); repaginates EPUB
     /// preserving the chapter. `false` for a fixed-layout PDF. Re-render after.
     pub fn set_alignment(&mut self, align_code: i32) -> bool {

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -1437,6 +1437,7 @@ fn reading_typography() -> Typography {
         font_id: 0,
         line_spacing: 1.7,
         align_code: 1,
+        columns: 1,
     }
 }
 


### PR DESCRIPTION
Re-targets **#194** at `master`.

#214 was stacked on `perf/epub-open-cost` and merged into that branch — but `perf/epub-open-cost`
had already been squash-merged to `master` as #207, so the two-column work landed on a branch that
was no longer going anywhere. `master` never received it, and v1.2.4 shipped without it: the
installed APK's `libreader.so` contains no column symbols at all.

Same four commits, cherry-picked onto `master`. No conflicts — the base's own changes were already
present via the #207 squash — and the full gate was re-run on the new base: `cargo fmt --check`,
`clippy -D warnings`, **628 tests**, and `:app:testDebugUnitTest`, all green.

The description below is unchanged from #214.

---

## What & why

A two-column newspaper measure: on a large e-ink panel, shorter lines read better than one
full-width column.

Closes #194

## How it works

**A column is just a narrower page.** Pagination already lays out to whatever measure `content_w`
reports, so pointing that at the column width makes line breaking, hyphenation, justification, image
fitting and page breaking all work unchanged. What comes out is a sequence of columns in reading
order, and a two-column page is the next two of them side by side — the second shifted right by a
column plus the gutter, its vertical positions already correct because every column starts at the
top of the page.

**No column-aware code exists below the composition step**, which is why headings, paragraph spacing
and images survive it without special handling.

The gutter reuses the page margin rather than adding a knob: it is already tuned to the panel, and a
gutter narrower than the outer margin reads as a mistake.

**The narrow-column floor is 14 em, set from measurement.** At roughly half an em per character that
is about 28 characters — squarely in the newspaper territory this feature exists to produce. The
first attempt used 18 em, derived from the 38px *base* font, and that declined the feature on a real
device: at a comfortable 56px reading size a column comes out at 14 em. A test pins that exact case
(1920px, 56px) and another confirms a 90px font is still declined.

**A declined request is reported, not silent.** `effective_columns` exposes what the layout actually
did, so choosing Two on a page that cannot take it says *"Two columns need a wider page or smaller
text"*.

**Columns join the batched typography** rather than being applied after open, so a large book does
not repaginate once per setting on every open (#161/#162/#178).

**The digest folds in the column count only when greater than one**, so single-column pages keep
their cached paginations. No cache version bump needed.

## How it was tested

- [x] `cargo test --workspace` — 628 passing
- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] Added tests that fail without this change — reading order verified by reversing the columns
- [x] **Verified on device (Supernote Nomad)** — two columns active on an EPUB
      (`columns: asked 2, layout using 2`), page count 6 → 5

## Known issue, not reproduced

Tracked as #215: one device session logged `page 3 out of range (have 6)` while paging forward in
two-column mode — self-contradictory, and traced to the index/layout divergence guard. Not
reproducible on host across every page in both modes; stale page counts, stale chapter caches and
cache-key collisions are all ruled out in the issue. The guard now records when it fires.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core still builds host-only; no vendor names (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
