### PR TITLE
fix(reader): give reflowable documents a working size control (#212) — re-targeted at master

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -68,6 +68,14 @@ class BottomBarController(private val host: Host) {
         fun palmGuard(content: View): View
 
         /** Quick zoom from the bar (the shell owns the zoom model + step constant). */
+        /** True when the document magnifies (fixed-layout). A reflowed view resizes text instead. */
+        val magnifiable: Boolean
+
+        /** Step the reflow text size — what a pinch already does on a reflowable document. */
+        fun textLarger()
+
+        fun textSmaller()
+
         fun zoomIn()
 
         fun zoomOut()
@@ -245,10 +253,20 @@ class BottomBarController(private val host: Host) {
         control(R.drawable.ic_menu_contents, "Contents") { showContentsLazy() }
         control(R.drawable.ic_menu_search, "Search") { host.openSearch() }
         // Quick zoom (circle −/+ icons — not magnifiers, which are reserved for Search). Also in Adjust → Zoom.
-        // Zoom is stepwise: reaching a comfortable size takes several taps, and dismissing after
+        // Stepwise either way: reaching a comfortable size takes several taps, and dismissing after
         // each one made every step cost reopening the bar (#164).
-        control(R.drawable.ic_menu_zoom_out, "Zoom −", staysOpen = true) { host.zoomOut() }
-        control(R.drawable.ic_menu_zoom_in, "Zoom +", staysOpen = true) { host.zoomIn() }
+        //
+        // A reflowed view cannot magnify — `zoomBy` returns early for it (#61) — so offering Zoom
+        // there was a control that did nothing at all, while a pinch on the same page quietly
+        // changed the text size instead (#212). Same buttons, same intent, wired to whichever of
+        // the two the document actually supports, and labelled for it.
+        if (host.magnifiable) {
+            control(R.drawable.ic_menu_zoom_out, "Zoom −", staysOpen = true) { host.zoomOut() }
+            control(R.drawable.ic_menu_zoom_in, "Zoom +", staysOpen = true) { host.zoomIn() }
+        } else {
+            control(R.drawable.ic_menu_zoom_out, "Text −", staysOpen = true) { host.textSmaller() }
+            control(R.drawable.ic_menu_zoom_in, "Text +", staysOpen = true) { host.textLarger() }
+        }
         control(R.drawable.ic_menu_export, "Export") { host.openExport() }
         control(R.drawable.ic_menu_dict, "Dicts") { host.openDicts() }
         // Document controls consolidated into one KOReader-style tabbed sheet (Rotate/Fit/Font/Display).

--- a/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
@@ -135,6 +135,16 @@ class DisplayPrefs(private val context: Context) {
         /** Index of the [TEXT_SCALES] entry nearest to [scale]. */
         fun nearestScaleIndex(scale: Float): Int = nearestIndex(TEXT_SCALES, scale)
 
+        /**
+         * The [TEXT_SCALES] index [by] steps from the one nearest [scale], clamped to the ends.
+         *
+         * Returns the *current* index at either end rather than wrapping or overshooting, so a
+         * caller can tell "already as large as it goes" from "moved" and skip a repagination that
+         * would change nothing.
+         */
+        fun steppedScaleIndex(scale: Float, by: Int): Int =
+            (nearestScaleIndex(scale) + by).coerceIn(0, TEXT_SCALES.size - 1)
+
         /** Index of the [UI_SCALES] entry nearest to [scale]. */
         fun nearestUiScaleIndex(scale: Float): Int = nearestIndex(UI_SCALES, scale)
     }

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -218,6 +218,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         override fun palmGuard(content: View) = this@ReaderActivity.palmGuard(content)
         override fun zoomIn() = zoomBy(ZOOM_STEP)
         override fun zoomOut() = zoomBy(1f / ZOOM_STEP)
+        override val magnifiable get() = this@ReaderActivity.magnifiable
+        override fun textLarger() = stepTextScale(+1)
+        override fun textSmaller() = stepTextScale(-1)
         override fun openSearch() = search.showSearchDialog()
         override fun openExport() = export.showExportDialog()
         override fun openDicts() = dict.showDictionariesDialog()
@@ -1666,13 +1669,45 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         }
     }
 
+    /**
+     * Step the reflow text size one preset (#212) — the reflowable counterpart of [zoomBy].
+     *
+     * Routed through the same `applyReflowScale` a pinch uses, so the button and the gesture cannot
+     * drift apart. At either end this is a no-op rather than a repagination that changes nothing;
+     * the toast still fires so a tap is never silent, which is the whole complaint behind #212.
+     */
+    private fun stepTextScale(by: Int) {
+        val cur = DisplayPrefs.nearestScaleIndex(displayPrefs.textScale)
+        val next = DisplayPrefs.steppedScaleIndex(displayPrefs.textScale, by)
+        if (next == cur) {
+            val pct = (DisplayPrefs.TEXT_SCALES[cur] * 100).toInt()
+            val end = if (by > 0) "largest" else "smallest"
+            Log.i(TAG, "text scale: at the $end preset ($pct%), no change")
+            Toast.makeText(this, "Text $pct% — already the $end", Toast.LENGTH_SHORT).show()
+            return
+        }
+        Log.i(
+            TAG,
+            "text scale: ${DisplayPrefs.TEXT_SCALES[cur]} → ${DisplayPrefs.TEXT_SCALES[next]}" +
+                " (index $cur → $next)",
+        )
+        adjust.applyReflowScale(next, announce = true)
+    }
+
     /** Multiply the zoom (clamped); snap back to fit at ~1. Used by the +/- buttons and pinch-end. */
     private fun zoomBy(factor: Float) {
-        if (!magnifiable) return // a reflowed view ignores zoom; don't strand the shell factor (#61)
+        if (!magnifiable) {
+            // The silent case behind #212: a fixed-layout control on a reflowed view. Logged rather
+            // than dropped, so "the button does nothing" is answerable from a logcat.
+            Log.i(TAG, "zoom ignored: this document is not magnifiable (reflowed view)")
+            return
+        }
         val next = (zoom * factor).coerceIn(1f, MAX_ZOOM_UI)
         if (zoom <= 1f && next > 1f) captureFitThumb() // grab the fit thumb before leaving fit
+        val from = zoom
         zoom = next
         if (zoom <= 1.01f) { zoom = 1f; panX = 0f; panY = 0f }
+        Log.i(TAG, "zoom: $from → $zoom" + if (from == zoom) " (at the limit)" else "")
         applyZoom()
     }
 

--- a/app/src/test/java/dev/jraghavan/inkread/TextScaleStepTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/TextScaleStepTest.kt
@@ -1,0 +1,57 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for stepping the reflow text size (#212).
+ *
+ * The bottom bar's Text +/− and a pinch both go through this, so a disagreement here would show up
+ * as the button and the gesture doing different things — which is the defect #212 is about.
+ */
+class TextScaleStepTest {
+
+    private val scales = DisplayPrefs.TEXT_SCALES
+
+    @Test
+    fun steppingMovesOnePresetAtATime() {
+        val mid = scales[4] // 1.0x
+        assertEquals(5, DisplayPrefs.steppedScaleIndex(mid, +1))
+        assertEquals(3, DisplayPrefs.steppedScaleIndex(mid, -1))
+        assertEquals(4, DisplayPrefs.steppedScaleIndex(mid, 0))
+    }
+
+    /**
+     * At the ends the index must not move. The caller compares it against the current index to
+     * decide whether to repaginate at all — wrapping, or overshooting into a clamp that still
+     * differs, would trigger a full repagination that changes nothing on every tap.
+     */
+    @Test
+    fun steppingPastEitherEndHoldsStill() {
+        val largest = scales.last()
+        val smallest = scales.first()
+        assertEquals(scales.size - 1, DisplayPrefs.steppedScaleIndex(largest, +1))
+        assertEquals(scales.size - 1, DisplayPrefs.steppedScaleIndex(largest, +99))
+        assertEquals(0, DisplayPrefs.steppedScaleIndex(smallest, -1))
+        assertEquals(0, DisplayPrefs.steppedScaleIndex(smallest, -99))
+    }
+
+    /** Stepping is defined for any stored scale, including one no longer in the preset list. */
+    @Test
+    fun anOffPresetScaleStepsFromItsNearestNeighbour() {
+        val between = (scales[4] + scales[5]) / 2f
+        val near = DisplayPrefs.nearestScaleIndex(between)
+        assertEquals(near + 1, DisplayPrefs.steppedScaleIndex(between, +1))
+        // A wildly out-of-range stored value still lands inside the table.
+        assertTrue(DisplayPrefs.steppedScaleIndex(99f, +1) in scales.indices)
+        assertTrue(DisplayPrefs.steppedScaleIndex(0.001f, -1) in scales.indices)
+    }
+
+    @Test
+    fun theScaleTableIsAscendingSoAStepIsAlwaysInThatDirection() {
+        for (i in 1 until scales.size) {
+            assertTrue("TEXT_SCALES must ascend at $i", scales[i] > scales[i - 1])
+        }
+    }
+}


### PR DESCRIPTION
Re-targets **#212** at `master`.

#213 was stacked on `fix/bottom-bar-stays-open` and merged into that branch — but that branch had
already been squash-merged to `master` as #211, so this work landed somewhere that was no longer
going anywhere and `master` never received it.

Same commit, cherry-picked onto `master`. No conflicts, and the full gate was re-run on the new
base: `cargo fmt --check`, `clippy -D warnings`, 628 tests, and `:app:testDebugUnitTest`, all green.

The description below is unchanged from #213.

---

## What & why

The bottom bar offered `Zoom −` / `Zoom +` on every document. On a **reflowable** one they did
nothing at all — `zoomBy` returns early when the document is not magnifiable (#61) — with no
movement, no message and no disabled styling. Meanwhile a pinch on the same page quietly changed the
**font size** instead. Two controls that look equivalent: one inert, one doing something else.

Closes #212

## How it works

The buttons are wired to **whichever of the two the document actually supports**, and labelled for
it:

| document state | controls | action |
|---|---|---|
| PDF / CBZ (fixed-layout) | `Zoom −` `Zoom +` | magnify, unchanged |
| EPUB (reflowable) | `Text −` `Text +` | step the text size |
| PDF **in reflow mode** | `Text −` `Text +` | step the text size |

The text path routes through the same `applyReflowScale` a pinch already uses, so the button and the
gesture cannot drift apart — which was the actual defect.

**The condition is the core's `is_magnifiable`, not the file type**, and that third row is why: one
PDF shows `Zoom` normally and `Text` once reflowed.

At either end the step is a no-op rather than a repagination that changes nothing, and it says so
rather than staying silent.

## Logging

Both size paths now log, one line per deliberate action:

```
text scale: 1.0 → 1.15 (index 4 → 5)
zoom: 5.0 → 5.0 (at the limit)
zoom ignored: this document is not magnifiable (reflowed view)
```

That last line is the point: the unmagnifiable early return produced **nothing** in a logcat, which
is why diagnosing #212 took two instrumented builds.

## How it was tested

- [x] `./gradlew :app:testDebugUnitTest` green, including `TextScaleStepTest`
- [x] `cargo test --workspace` green
- [x] **Verified on device (Supernote Nomad)** — `Text −/+` steps an EPUB, `Zoom −/+` still
      magnifies a PDF, log lines confirmed for both paths and both zoom limits

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core is untouched; no vendor names added (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
