### PR TITLE
feat(daily): In This Issue contents section (#198)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
@@ -179,6 +179,9 @@ class DailyController(private val context: Context) {
                             .put("source", src.name)
                             .put("url", item.optString("url"))
                             .put("published", item.optString("published"))
+                            // The feed's own description, for the contents page (#198). Absent on
+                            // feeds that give none; the core falls back to a body excerpt.
+                            .put("summary", item.optString("summary"))
                             .put("html", html)
                     }
                 }

--- a/inkread-daily/src/epub.rs
+++ b/inkread-daily/src/epub.rs
@@ -120,25 +120,45 @@ fn nav(issue: &Issue) -> String {
     )
 }
 
-/// The cover/title page: issue title, date, and a contents list.
+/// The cover: issue title, date, and the **In This Issue** contents (#198).
+///
+/// A newspaper opens with a contents page so you can decide what is worth reading before committing
+/// to a page turn — which matters more on e-ink, where browsing costs a refresh each way. Every
+/// entry is a link into the article, carries its source, and shows a short excerpt where one can be
+/// had.
 fn title_page(issue: &Issue) -> String {
     let mut toc = String::new();
-    for art in &issue.articles {
+    for (i, art) in issue.articles.iter().enumerate() {
+        // `article_path` is the packaged path; inside the OPF everything is relative to OEBPS/.
+        let href = article_path(i).trim_start_matches("OEBPS/").to_string();
         toc.push_str(&format!(
-            "    <li>{}<br/><span class=\"src\">{}</span></li>\n",
+            "    <li><a href=\"{href}\">{}</a><br/><span class=\"src\">{}</span>",
             esc(&art.title),
             esc(&art.source)
         ));
+        // Title-only when there is nothing worth showing — an empty or near-empty line under every
+        // headline reads worse than no line at all.
+        if let Some(text) = art.excerpt(EXCERPT_CHARS) {
+            toc.push_str(&format!(
+                "<br/><span class=\"excerpt\">{}</span>",
+                esc(&text)
+            ));
+        }
+        toc.push_str("</li>\n");
     }
     xhtml(
         &issue.title,
         &format!(
-            "<h1>{}</h1>\n<p class=\"date\">{}</p>\n<ul>\n{toc}</ul>",
+            "<h1>{}</h1>\n<p class=\"date\">{}</p>\n<h2>In This Issue</h2>\n<ul>\n{toc}</ul>",
             esc(&issue.title),
             esc(&issue.date)
         ),
     )
 }
+
+/// How much of an article to show under its headline. Long enough to say what the piece is about,
+/// short enough that a dozen of them still fit a contents page.
+const EXCERPT_CHARS: usize = 160;
 
 /// One article document: headline, a source · date byline, then the clean article body.
 fn article_xhtml(issue: &Issue, i: usize) -> String {

--- a/inkread-daily/src/epub_tests.rs
+++ b/inkread-daily/src/epub_tests.rs
@@ -13,6 +13,7 @@ fn article(title: &str, source: &str, body: &str, published: Option<&str>) -> Ar
         url: format!("https://example.test/{title}"),
         published: published.map(str::to_string),
         body_html: body.to_string(),
+        summary: None,
     }
 }
 
@@ -116,4 +117,135 @@ fn xml_metacharacters_in_titles_do_not_break_the_container() {
         "title decodes back: {:?}",
         pkg.title
     );
+}
+
+// ---------------------------------------------------------------------------------------------
+// #198 — the "In This Issue" contents section.
+// ---------------------------------------------------------------------------------------------
+
+fn with_summary(mut a: Article, summary: &str) -> Article {
+    a.summary = Some(summary.to_string());
+    a
+}
+
+/// The publisher's own description beats an excerpt of the opening words: it is what they chose to
+/// say the piece is about.
+#[test]
+fn the_feeds_summary_is_preferred_over_the_body() {
+    let art = with_summary(
+        article("T", "S", "<p>Opening words of the body.</p>", None),
+        "What the piece is actually about.",
+    );
+    assert_eq!(
+        art.excerpt(160).as_deref(),
+        Some("What the piece is actually about.")
+    );
+}
+
+/// Without a feed summary an entry still gets a line, from the body — so the contents page is
+/// useful on feeds that give no description, and with no AI in the loop.
+#[test]
+fn the_body_supplies_an_excerpt_when_the_feed_gives_none() {
+    let art = article("T", "S", "<p>Opening words.</p><p>And more.</p>", None);
+    assert_eq!(
+        art.excerpt(160).as_deref(),
+        Some("Opening words. And more.")
+    );
+}
+
+/// A tag boundary is a word boundary — otherwise paragraphs run together into "words.And".
+#[test]
+fn markup_is_stripped_without_gluing_words_together() {
+    let art = article("T", "S", "<p>alpha</p><p>bravo</p>", None);
+    assert_eq!(art.excerpt(160).as_deref(), Some("alpha bravo"));
+    // Entities the assembly stage emits are decoded for display.
+    let ent = article("T", "S", "<p>Tom &amp; Jerry &quot;x&quot;</p>", None);
+    assert_eq!(ent.excerpt(160).as_deref(), Some("Tom & Jerry \"x\""));
+}
+
+/// Nothing worth printing yields no line at all: an empty line under every headline reads worse
+/// than the title alone, which is what #198 asks for as the fallback.
+#[test]
+fn an_article_with_no_usable_text_has_no_excerpt() {
+    assert_eq!(article("T", "S", "", None).excerpt(160), None);
+    assert_eq!(
+        article("T", "S", "<p></p>  <div>\n</div>", None).excerpt(160),
+        None
+    );
+    // A blank feed summary falls through to the body rather than printing emptiness.
+    let blank = with_summary(article("T", "S", "<p>Real body.</p>", None), "   ");
+    assert_eq!(blank.excerpt(160).as_deref(), Some("Real body."));
+}
+
+#[test]
+fn a_long_excerpt_is_cut_at_a_word_boundary() {
+    let body = format!("<p>{}</p>", "alpha bravo ".repeat(60));
+    let art = article("T", "S", &body, None);
+    let got = art.excerpt(40).expect("has an excerpt");
+    assert!(
+        got.chars().count() <= 41,
+        "got {} chars: {got:?}",
+        got.chars().count()
+    );
+    assert!(got.ends_with('…'), "should mark the cut: {got:?}");
+    assert!(!got.contains("alp…"), "must not cut mid-word: {got:?}");
+}
+
+/// A feed summary is arbitrary text. Cutting by bytes would split a multi-byte character and render
+/// as a replacement box.
+#[test]
+fn cutting_never_splits_a_multibyte_character() {
+    for text in [
+        "日本語のテキストがここにあります。".repeat(20),
+        "é".repeat(400),
+    ] {
+        let art = with_summary(article("T", "S", "<p>x</p>", None), &text);
+        let got = art.excerpt(40).expect("has an excerpt");
+        assert!(got.chars().count() <= 41, "{} chars", got.chars().count());
+        // Round-tripping proves every char is whole.
+        assert_eq!(got, String::from_utf8(got.clone().into_bytes()).unwrap());
+    }
+}
+
+/// A single word longer than the budget must still leave something readable rather than an ellipsis
+/// on its own.
+#[test]
+fn one_very_long_word_still_yields_text() {
+    let art = with_summary(article("T", "S", "<p>x</p>", None), &"z".repeat(200));
+    let got = art.excerpt(40).expect("has an excerpt");
+    assert!(got.chars().count() > 10, "collapsed to nothing: {got:?}");
+}
+
+/// End to end: the contents page lists every article, links to it, and the whole issue still parses
+/// with the real reader backend.
+#[test]
+fn the_contents_page_links_every_article_and_the_issue_still_opens() {
+    let issue = Issue {
+        title: "inkread daily".into(),
+        date: "21 Aug 2026".into(),
+        articles: vec![
+            with_summary(
+                article("First", "Ars", "<p>Body one.</p>", None),
+                "Summary one.",
+            ),
+            article("Second", "BBC", "<p>Body two.</p>", None),
+        ],
+    };
+    let cover = title_page(&issue);
+    assert!(cover.contains("In This Issue"), "missing the heading");
+    for (i, art) in issue.articles.iter().enumerate() {
+        assert!(
+            cover.contains(&format!("a{i:04}.xhtml")),
+            "entry {i} is not a link"
+        );
+        assert!(cover.contains(&art.title), "entry {i} missing its title");
+        assert!(cover.contains(&art.source), "entry {i} missing its source");
+    }
+    assert!(cover.contains("Summary one."), "feed summary not shown");
+    assert!(cover.contains("Body two."), "body excerpt not shown");
+
+    // The headline guarantee of this module: it still parses with the real EPUB backend.
+    let bytes = assemble_epub(&issue);
+    let pkg = EpubPackage::open(bytes).expect("assembled issue opens");
+    assert!(pkg.chapter_count() >= issue.articles.len());
 }

--- a/inkread-daily/src/feed.rs
+++ b/inkread-daily/src/feed.rs
@@ -18,6 +18,9 @@ pub struct FeedItem {
     pub url: String,
     /// Published (or, failing that, updated) date, formatted "DD Mon YYYY"; `None` if the feed omits it.
     pub published: Option<String>,
+    /// The entry's own `description`/`summary`, when the feed carries one (#198) — the publisher's
+    /// line about the piece, used for the contents page in preference to an excerpt of its opening.
+    pub summary: Option<String>,
 }
 
 /// Parse an RSS / Atom / JSON feed into its entries, in document order. Tolerant of malformed input.
@@ -42,6 +45,13 @@ pub fn parse_feed(xml: &str) -> Vec<FeedItem> {
                 .published
                 .or(e.updated)
                 .map(|d| d.format("%d %b %Y").to_string()),
+            // Same double-decode as the title: a summary goes on the contents page, so a stray
+            // "&#8217;" would be read by a person. Markup is left alone here and stripped where the
+            // excerpt is built — many feeds put a whole HTML paragraph in `description`.
+            summary: e
+                .summary
+                .map(|t| crate::extract::decode_entities(t.content.trim()))
+                .filter(|t| !t.is_empty()),
         })
         .collect()
 }

--- a/inkread-daily/src/lib.rs
+++ b/inkread-daily/src/lib.rs
@@ -45,6 +45,10 @@ struct RawArticle {
     published: Option<String>,
     /// Raw fetched article HTML — the core runs readability extraction over it.
     html: String,
+    /// The feed's own description/summary for this entry, when it had one (#198). Optional so an
+    /// issue compiled by an older shell still parses.
+    #[serde(default)]
+    summary: Option<String>,
 }
 
 /// Assemble an issue EPUB from the shell's fetched JSON: each article's raw `html` is run through
@@ -65,6 +69,7 @@ pub fn assemble_issue_from_json(json: &str) -> Result<Vec<u8>, String> {
                 url: a.url,
                 published: a.published,
                 body_html,
+                summary: a.summary,
             }
         })
         .collect();

--- a/inkread-daily/src/model.rs
+++ b/inkread-daily/src/model.rs
@@ -34,6 +34,78 @@ pub struct Article {
     pub published: Option<String>,
     /// Clean article body as XHTML-compatible markup (well-formed; readability output).
     pub body_html: String,
+    /// The feed's own `description`/`summary` for this entry, when it gave one (#198). Preferred
+    /// over a body excerpt: it is what the publisher chose to say the piece is about, where an
+    /// excerpt is just its opening words.
+    pub summary: Option<String>,
+}
+
+impl Article {
+    /// A short line describing the article for the contents page (#198), at most `max_chars`.
+    ///
+    /// Prefers the feed's own summary and falls back to the opening of the body, so an entry
+    /// usually has one without a feed providing it and without any AI in the loop. `None` when
+    /// neither yields anything worth printing — the caller then shows the title alone, which reads
+    /// better than an empty line under every headline.
+    #[must_use]
+    pub fn excerpt(&self, max_chars: usize) -> Option<String> {
+        let source = self
+            .summary
+            .as_deref()
+            .map(strip_markup)
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| strip_markup(&self.body_html));
+        let text = source.split_whitespace().collect::<Vec<_>>().join(" ");
+        if text.is_empty() {
+            return None;
+        }
+        Some(truncate_on_word(&text, max_chars))
+    }
+}
+
+/// Drop tags and decode the handful of entities the assembly stage emits, leaving plain text.
+///
+/// Deliberately not a parser: this runs over already-clean output from the readability stage, and a
+/// contents line does not justify building a DOM per article. Anything between `<` and `>` goes,
+/// which is exactly right for well-formed input and fails safe on anything else — worst case a
+/// stray fragment is dropped from a preview line.
+fn strip_markup(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for ch in html.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => {
+                in_tag = false;
+                out.push(' '); // a tag boundary is a word boundary: "<p>a</p><p>b</p>" is "a b"
+            }
+            c if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&nbsp;", " ")
+}
+
+/// Cut `text` to at most `max_chars` **characters**, breaking at a word boundary and marking the
+/// cut with an ellipsis. Counting characters rather than bytes is what keeps this from splitting a
+/// multi-byte character — a feed summary is arbitrary text, and half a character renders as a box.
+fn truncate_on_word(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let cut: String = text.chars().take(max_chars).collect();
+    let trimmed = match cut.rsplit_once(char::is_whitespace) {
+        // Keep the word boundary only if it leaves most of the budget; a very long first word would
+        // otherwise cut the line to almost nothing.
+        Some((head, _)) if head.chars().count() >= max_chars / 2 => head,
+        _ => cut.trim_end(),
+    };
+    format!("{}…", trimmed.trim_end_matches([',', ';', ':', '.', ' ']))
 }
 
 /// A compiled daily issue: a dated, titled set of articles in reading order.


### PR DESCRIPTION
## What & why

A Daily Read issue opened with a bare list of titles and sources. You could not tell what a piece
was about without paging into it, and the list was not tappable, so getting there and back cost two
e-ink refreshes for every article you rejected.

Closes #198

## How it works

The cover now carries an **In This Issue** section. Every entry links into its article and shows a
short excerpt beneath the headline and source.

**The excerpt prefers the feed's own `description`/`summary`** — what the publisher chose to say the
piece is about — and falls back to the opening of the extracted body. That fallback is what makes
the page useful on feeds carrying no description, and it means **no AI anywhere in the path**, which
the issue asks for explicitly. An article yielding neither shows its title alone, which is the
graceful fallback #198 asks for: an empty line under every headline reads worse than no line.

Feed summaries get the same double entity-decode as titles, since a `&#8217;` on the contents page
is read by a person.

## Details worth flagging

**Cutting counts characters, not bytes.** A feed summary is arbitrary text, and splitting a
multi-byte character renders as a replacement box — tests cover CJK and accented input. The cut
lands on a word boundary unless that would leave almost nothing, so a single very long word still
yields something readable rather than a lone ellipsis.

**Markup is stripped with a scanner, not a parser.** This runs over already-clean readability output,
and a contents line does not justify building a DOM per article. A tag boundary counts as a word
boundary, or `<p>a</p><p>b</p>` collapses to `a.And`.

**`summary` is optional throughout**, so an issue compiled by an older shell still parses.

## How it was tested

- [x] `cargo test --workspace` — 636 passing
- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] Added tests that fail without this change
- [ ] Verified on a device (Supernote) — host-only change to issue assembly; see below

Covered: feed summary preferred over body; body excerpt when the feed gives none; markup stripped
without gluing words; entities decoded; no excerpt at all when there is nothing worth printing
(including a blank feed summary falling through to the body); word-boundary cutting; multi-byte
safety; a single over-long word; and an end-to-end check that the contents page links every article
and the assembled issue **still opens with the real reader EPUB backend** — the headline guarantee
of that test module.

**Device check wanted:** compile an issue and confirm the contents entries are tappable and land on
the right article, and that the excerpts read well at your text size.

## Scope / follow-ups

- Optional AI-generated summaries remain a possible later layer, as the issue notes. Nothing here
  depends on one.
- The excerpt budget is a constant (160 characters). If it reads long or short on device that is a
  one-line change.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core still builds host-only; no vendor names (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
