### PR TITLE
feat(eink): choose the display adapter by capability (#220)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/DeviceCapabilities.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DeviceCapabilities.kt
@@ -35,6 +35,30 @@ data class DeviceCapabilities(
          * (RR2-FR2 / RR3-AC3). M0 advertises this until the RR19-FR4b spike proves the
          * fast path, at which point the adapter can advertise the fuller profile.
          */
+        /**
+         * An ordinary backlit display — no e-ink anywhere (#220).
+         *
+         * `eink = false` is the whole point: the core's refresh policy exists to hide EPD ghosting
+         * and flash cost, and applying it to an LCD produces full-screen refreshes and a
+         * refresh-after-resume that a panel redrawing at 60Hz has no use for. `colorScreen` is the
+         * other honest difference; the rest of the flags describe e-ink hardware features and are
+         * meaningless without a panel to apply them to.
+         */
+        fun genericDisplay(): DeviceCapabilities = DeviceCapabilities(
+            eink = false,
+            einkFull = false,
+            regal = false,
+            fastMode = false,
+            regionalUpdate = false,
+            hwInvert = false,
+            hwDither = false,
+            kaleidoWfm = false,
+            colorScreen = true,
+            swipeAnimation = true,
+            penLowLatency = false,
+            needsRefreshAfterResume = false,
+        )
+
         fun supernoteBaseline(): DeviceCapabilities = DeviceCapabilities(
             eink = true,
             einkFull = false,

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -33,7 +33,7 @@ import dev.jraghavan.inkread.eink.EinkAdapter
 import java.net.HttpURLConnection
 import java.net.URL
 import org.json.JSONObject
-import dev.jraghavan.inkread.eink.SupernoteEinkAdapter
+import dev.jraghavan.inkread.eink.DisplayAdapters
 import dev.jraghavan.inkread.eink.SupernoteInk
 import java.io.File
 import java.nio.ByteBuffer
@@ -59,7 +59,9 @@ import java.util.concurrent.Executors
 class ReaderActivity : Activity(), SurfaceHolder.Callback {
 
     private lateinit var surfaceView: SurfaceView
-    private val adapter: EinkAdapter = SupernoteEinkAdapter()
+    // Chosen by capability probe, not hardcoded (#220): a device with no e-ink service is told it
+    // has no e-ink panel, rather than being given the Supernote's refresh policy by default.
+    private val adapter: EinkAdapter by lazy { DisplayAdapters.forDevice(this) }
 
     /** Periodic full-refresh cadence (#99): fires a full EPD flash every Nth page-turn to clear
      *  ghosting. Interval comes from [DisplayPrefs.fullRefreshEvery] (set in onCreate + on change);

--- a/app/src/main/java/dev/jraghavan/inkread/eink/DisplayAdapter.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/eink/DisplayAdapter.kt
@@ -1,0 +1,50 @@
+package dev.jraghavan.inkread.eink
+
+import android.content.Context
+import dev.jraghavan.inkread.DeviceCapabilities
+import dev.jraghavan.inkread.RefreshCommand
+
+/**
+ * The adapter for a device with an ordinary backlit display (#220).
+ *
+ * Every method is a no-op because there is nothing to do: an LCD redraws itself. The value is not in
+ * what it does but in what it *advertises* — `eink = false`, so the core stops applying a refresh
+ * policy written for a panel that ghosts.
+ */
+class LcdAdapter : EinkAdapter {
+    override fun capabilities(): DeviceCapabilities = DeviceCapabilities.genericDisplay()
+
+    override fun execute(command: RefreshCommand) {
+        // Nothing to execute: with `eink = false` the core emits no refresh commands, and a stray
+        // one would still describe work an LCD does not need.
+    }
+}
+
+/**
+ * Picks the display adapter for the device this build is running on (#220).
+ *
+ * The reader previously constructed [SupernoteEinkAdapter] unconditionally, so any other device was
+ * told it had an e-ink panel and got the ghosting cadence, full-screen flashes and
+ * refresh-after-resume meant for one. Nothing crashed — every vendor call already fails closed —
+ * but the behaviour was wrong.
+ *
+ * The probe stays in the shell. The core must name no vendor (IR-7); it only ever sees the
+ * resulting [DeviceCapabilities].
+ */
+object DisplayAdapters {
+
+    /**
+     * True when this device exposes the Supernote's `eink` system service.
+     *
+     * The same signal [SupernoteEinkAdapter] already uses for every refresh, so selection cannot
+     * disagree with execution: if this is false, every call that adapter makes would have no-opped
+     * anyway. Deliberately **not** a `Build.MANUFACTURER` check — a model string is a guess about
+     * hardware, whereas the service either answers or it does not.
+     */
+    fun hasEinkService(context: Context): Boolean =
+        runCatching { context.getSystemService("eink") != null }.getOrDefault(false)
+
+    /** The adapter for `context`'s device. */
+    fun forDevice(context: Context): EinkAdapter =
+        if (hasEinkService(context)) SupernoteEinkAdapter() else LcdAdapter()
+}

--- a/app/src/test/java/dev/jraghavan/inkread/DisplayCapabilitiesTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/DisplayCapabilitiesTest.kt
@@ -1,0 +1,68 @@
+package dev.jraghavan.inkread
+
+import dev.jraghavan.inkread.eink.LcdAdapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host JVM tests for what each adapter advertises to the core (#220).
+ *
+ * The capabilities are the whole point of picking an adapter: they decide whether the core applies
+ * an e-ink refresh policy — ghosting cadence, full-screen flashes, refresh-after-resume — to the
+ * display in front of the reader. Getting them wrong is not a crash, which is exactly why it needs
+ * asserting rather than eyeballing.
+ */
+class DisplayCapabilitiesTest {
+
+    /** The shipping device's profile must not shift while making room for another one. */
+    @Test
+    fun theSupernoteBaselineIsUnchanged() {
+        val caps = DeviceCapabilities.supernoteBaseline()
+        assertTrue("Supernote is e-ink", caps.eink)
+        assertTrue("and needs a refresh after resume", caps.needsRefreshAfterResume)
+        assertFalse("M0 has no full-refresh control", caps.einkFull)
+        assertFalse("monochrome panel", caps.colorScreen)
+    }
+
+    /**
+     * The bug this fixes: a non-Supernote was told `eink = true` and got a refresh policy written
+     * for a panel that ghosts.
+     */
+    @Test
+    fun anOrdinaryDisplayIsNotAdvertisedAsEink() {
+        val caps = DeviceCapabilities.genericDisplay()
+        assertFalse("an LCD is not e-ink", caps.eink)
+        assertFalse("and needs no refresh after resume", caps.needsRefreshAfterResume)
+        assertTrue("it is a colour screen", caps.colorScreen)
+    }
+
+    /** Every e-ink hardware feature is meaningless without an e-ink panel to apply it to. */
+    @Test
+    fun anOrdinaryDisplayClaimsNoEinkHardwareFeatures() {
+        val caps = DeviceCapabilities.genericDisplay()
+        for ((name, claimed) in listOf(
+            "einkFull" to caps.einkFull,
+            "regal" to caps.regal,
+            "fastMode" to caps.fastMode,
+            "regionalUpdate" to caps.regionalUpdate,
+            "hwInvert" to caps.hwInvert,
+            "hwDither" to caps.hwDither,
+            "kaleidoWfm" to caps.kaleidoWfm,
+        )) {
+            assertFalse("an LCD must not claim $name", claimed)
+        }
+    }
+
+    @Test
+    fun theLcdAdapterAdvertisesTheOrdinaryDisplayProfile() {
+        assertEquals(DeviceCapabilities.genericDisplay(), LcdAdapter().capabilities())
+    }
+
+    /** The two profiles must actually differ, or selecting between them changes nothing. */
+    @Test
+    fun theTwoProfilesDiffer() {
+        assertTrue(DeviceCapabilities.supernoteBaseline() != DeviceCapabilities.genericDisplay())
+    }
+}


### PR DESCRIPTION
## What & why

`ReaderActivity` constructed `SupernoteEinkAdapter()` unconditionally, so any device that is not a
Supernote was still told `DeviceCapabilities.supernoteBaseline()` — `eink = true`,
`needsRefreshAfterResume = true`. The core then applied a refresh policy written for a panel that
ghosts: full-screen flashes, refresh-after-resume, the periodic ghosting clear from #99.

Nothing crashed — every vendor call in that adapter already fails closed — but the behaviour was
wrong, and it was the one thing stopping the shell being genuinely portable.

Closes #220. Found by the audit on #196.

## How it works

Pick the adapter from a probe, and add an `LcdAdapter` advertising `eink = false`. Its methods are
no-ops because an LCD redraws itself — **the value is in what it advertises, not what it does.**

**The probe asks whether the device exposes the `eink` system service.** That is the same signal
`SupernoteEinkAdapter` already uses for every refresh, so selection cannot disagree with execution:
where the probe says no, that adapter's calls would have no-opped anyway. Deliberately **not** a
`Build.MANUFACTURER` check — a model string is a guess about hardware, while the service either
answers or it does not.

The probe stays in the shell. The core names no vendor (IR-7) and only ever sees the resulting
`DeviceCapabilities`.

## Risk, and what guards it

The risk here is not the new path — it is **shifting the shipping device's behaviour** while making
room for another one. So the Supernote profile is byte-identical, and a test pins it: still e-ink,
still needs a refresh after resume, still no full-refresh control, still monochrome.

## How it was tested

- [x] `./gradlew :app:testDebugUnitTest` green, including a new `DisplayCapabilitiesTest`
- [x] `cargo test --workspace` green (the Rust core is untouched)
- [x] Added tests that fail without this change — verified by making `genericDisplay()` claim
      `eink = true`, which fails the assertion
- [ ] Verified on a device — the Supernote path is unchanged by construction; the LCD path cannot be
      exercised without a non-Supernote device (that is #221)

Covered: the Supernote baseline is unchanged; an ordinary display is not advertised as e-ink and
needs no refresh after resume; it claims none of the seven e-ink hardware features; `LcdAdapter`
advertises exactly that profile; and the two profiles actually differ, so selecting between them
changes something.

## Scope / follow-ups

- #221 — `x86_64` in debug builds, which is what would let anyone actually boot the LCD path.
- #222 — first-run storage flow for stock Android.
- #223 — whether handwriting is in scope on non-Supernote tablets at all.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core is untouched; the probe is in the shell, so no vendor name reaches the core (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
