### PR TITLE
fix(ink): bake pen strokes at the firmware nib width (#126)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/StylusInkController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/StylusInkController.kt
@@ -259,6 +259,11 @@ class StylusInkController(private val host: Host) {
             NativeBridge.nativeInkBeginStroke(host.docHandle, coreTool, color, widthNorm, System.currentTimeMillis())
             NativeBridge.nativeInkAddPoints(host.docHandle, toNormPoints(raw))
             NativeBridge.nativeInkEndStroke(host.docHandle)
+            Log.i(
+                TAG,
+                "stroke: tool=${host.activeTool} width=${if (isHl) HIGHLIGHT_WIDTH_PX else penWidthPx}px" +
+                    " points=${raw.size / 2}",
+            )
             scheduleInkFlush() // deferred autosave: persist on a trailing debounce, not this fsync
             host.diag { "DIAG commitStroke OK ${raw.size / 2} pts tool=${host.activeTool} → core page ${host.currentPage}" }
         } catch (e: RuntimeException) {
@@ -362,12 +367,25 @@ class StylusInkController(private val host: Host) {
          * core, so changing the setting restyles nothing already written — old notes keep the width
          * they were drawn at.
          *
-         * The default (index 2, 6px) is the width every stroke used before this was selectable, and
-         * was tuned to match the firmware needle. The thinner options exist because that needle is
-         * heavy on a Nomad's smaller panel, which is what #199 asks for.
+         * **The default matches the firmware nib** (#126). While you write, the stroke on screen is
+         * painted by the firmware's EMR overlay at its own fixed width; what inkread stores is baked
+         * over the top at the next full render. If the two differ, the stroke visibly changes
+         * thickness the moment it bakes — which is what #126 reports as "renders fat, then refreshes
+         * thinner".
+         *
+         * Measured on a Nomad at a 1920px viewport: strokes baked at 9px are indistinguishable from
+         * the live nib, while the previous 6px default was visibly thinner. So 9px is the default,
+         * and the ladder is built around it rather than under it.
+         *
+         * The other widths are a deliberate trade the reader makes: a stroke narrower or wider than
+         * the nib *will* change thickness when it bakes, because the firmware's live width is not
+         * ours to set. Only suppressing the firmware overlay and drawing the stroke ourselves could
+         * avoid that, and the highlighter — which does exactly that — is the reason not to (#126).
          */
-        val PEN_WIDTHS = floatArrayOf(2f, 4f, 6f, 9f)
-        val PEN_WIDTH_NAMES = arrayOf("Fine", "Thin", "Medium", "Bold")
+        val PEN_WIDTHS = floatArrayOf(4f, 6f, 9f, 12f, 16f)
+        val PEN_WIDTH_NAMES = arrayOf("Fine", "Thin", "Medium", "Bold", "Heavy")
+
+        /** Index of the width that matches the firmware nib; see [PEN_WIDTHS]. */
         const val DEFAULT_PEN_WIDTH_INDEX = 2
 
         const val HIGHLIGHT_WIDTH_PX = 30f // wide marker band (vs the pen's PEN_WIDTHS).

--- a/app/src/test/java/dev/jraghavan/inkread/PenWidthTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/PenWidthTest.kt
@@ -29,12 +29,17 @@ class PenWidthTest {
      * The reporter's actual ask: something thinner than what the pen wrote before. If the default
      * were the thinnest option there would be nothing finer to choose.
      */
+    /**
+     * The default must match the firmware nib, measured on a Nomad at a 1920px viewport (#126):
+     * a stroke baked at 9px is indistinguishable from the live stroke, while the previous 6px
+     * default was visibly thinner and produced the "renders fat, then refreshes thinner" report.
+     */
     @Test
-    fun theDefaultIsUnchangedFromBeforeAndHasThinnerOptionsBelowIt() {
+    fun theDefaultMatchesTheFirmwareNibAndHasChoicesEitherSide() {
         val i = StylusInkController.DEFAULT_PEN_WIDTH_INDEX
         val widths = StylusInkController.PEN_WIDTHS
         assertTrue("default index out of range", i in widths.indices)
-        assertEquals("the default must stay the width strokes already used", 6f, widths[i], 0.001f)
+        assertEquals("the default must match the measured firmware nib", 9f, widths[i], 0.001f)
         assertTrue("nothing thinner to choose", i > 0)
         assertTrue("nothing thicker to choose", i < widths.size - 1)
     }
@@ -66,5 +71,23 @@ class PenWidthTest {
                 w < StylusInkController.HIGHLIGHT_WIDTH_PX,
             )
         }
+    }
+
+    /**
+     * The reason the default matters: a stroke is painted live by the firmware at its own nib width
+     * and re-drawn by inkread when it bakes. Any width other than the nib visibly changes thickness
+     * at that moment — an inherent trade, but the *default* must not make it.
+     */
+    @Test
+    fun exactlyOneWidthMatchesTheNibAndItIsTheDefault() {
+        val widths = StylusInkController.PEN_WIDTHS
+        val nib = widths[StylusInkController.DEFAULT_PEN_WIDTH_INDEX]
+        assertEquals(
+            "the nib width must appear exactly once, or the default is ambiguous",
+            1,
+            widths.count { it == nib },
+        )
+        assertTrue("a thinner choice must exist (#199 asked for one)", widths.any { it < nib })
+        assertTrue("a thicker choice must exist", widths.any { it > nib })
     }
 }


### PR DESCRIPTION
## What & why

A pen stroke is painted live by the firmware's EMR overlay at its own fixed width, then re-drawn by
inkread from the core at the next full render. **The two did not agree.** The default baked at 6px
against a nib measured at 9px, so every stroke visibly slimmed the moment it baked — what #126
reports as *"strokes render at a fat thickness, then refresh thinner"*.

The code half-knew: `inkPaint` carried `// match the firmware needle (baked was thinner than live)`.
The width had been raised toward the nib without reaching it.

Addresses **#126 (a) — bake-width calibration**. The issue's other three sub-tasks are untouched.

## The measurement

Not host-verifiable — the firmware overlay cannot be captured (`adb screencap` returns black on this
panel), so the comparison has to be made by eye on device.

Instrumented builds on a **Nomad at a 1920px viewport** logged every committed width and every baked
width in pixels, while writing at each setting and comparing the live stroke against the baked one:

| baked width | against the live nib |
|---|---|
| 6px (old default) | visibly thinner |
| **9px** | **indistinguishable** |

So the nib is ≈9px, and the old default undershot it.

## The change

| | before | after |
|---|---|---|
| widths | 2, 4, 6, **9** | 4, 6, **9**, 12, 16 |
| default | 6px — thinner than the nib | **9px — matches the nib** |

The ladder is built *around* the nib rather than under it. Out of the box a stroke no longer changes
thickness when it bakes. Thinner options remain — that was #199's ask — and thicker ones are new.

Width is stored per stroke, so **nothing already written changes**; only new strokes use the new
default.

## What this does not fix

A width other than the nib still changes thickness at the bake. That is inherent: the firmware's live
width is not ours to set. The only way to make every setting match would be to suppress the firmware
overlay and draw strokes ourselves — which is exactly what the highlighter does, and exactly why the
highlighter lags behind the pen (#126 (b)). That trade deserves its own change, not a bundle with
this one.

It is documented at the constant rather than left for the next reader to rediscover.

## How it was tested

- [x] `./gradlew :app:testDebugUnitTest` green
- [x] `cargo test --workspace` green (the Rust core is untouched)
- [x] **Verified on device (Supernote Nomad)**

Host tests pin the relationship rather than the number alone: the default must equal the measured
nib, the nib width must appear exactly once so the default is unambiguous, and a thinner and a
thicker choice must both exist.

Device: writing at each setting, with every committed and baked width logged. The nib comparison
above, then a clean run at the two new thicker widths (12 strokes, no errors).

## Note for review

This changes the **default** stroke width, so a returning reader's new strokes will be slightly
thicker than before. I believe that is right — 9px is the width the firmware was showing them while
writing all along, and the old default was the anomaly — but it is a visible change and worth a
second opinion.

## Pre-merge checklist

- [x] `cargo fmt --all` — no format diff
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo test --workspace` — passes
- [x] `./scripts/check-licenses.sh` — no new dependencies
- [x] The Rust core is untouched; no vendor names added (IR-7)
- [x] Commits follow Conventional Commits with no AI/Co-Authored-By trailers
