### PR TITLE
fix(ui): remember where the tool palette was parked (#200)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -159,6 +159,13 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     /** The floating tool puck/palette overlay; created in onCreate. */
     private lateinit var toolPalette: ToolPalette
 
+    /** The tool palette's last parked corner (#200), or null when it has never been moved. */
+    private fun parkedPalettePosition(): ToolPalette.Position? =
+        ToolPalette.Position.of(
+            prefs.getFloat(KEY_PALETTE_X, Float.NaN),
+            prefs.getFloat(KEY_PALETTE_Y, Float.NaN),
+        )
+
     // ---- lasso (ADR-INKREAD-0010) ----
     /** The floating selection toolbar; created in onCreate. */
     private lateinit var selectionToolbar: SelectionToolbar
@@ -520,6 +527,12 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             onChrome = { engine.execute { repaintPanel() } },
             onUndo = { lasso.inkUndo() },
             onRedo = { lasso.inkRedo() },
+            // Reopen the toolbar where the reader last parked it (#200) rather than at the default
+            // dock — repositioning it on every document open was the standing annoyance.
+            savedPosition = parkedPalettePosition(),
+            onMoved = { at ->
+                prefs.edit().putFloat(KEY_PALETTE_X, at.x).putFloat(KEY_PALETTE_Y, at.y).apply()
+            },
         )
         selectionToolbar = SelectionToolbar(this, root) { action -> lasso.onSelectionAction(action) }
         toolOptions = ToolOptions(this, root)
@@ -1954,6 +1967,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val KEY_BOOK_PATH = "book_path" // stored PDF under app storage (RR27).
         const val KEY_BOOK_ID = "book_id" // stable per-book id (the stored file name).
         const val KEY_PEN_WIDTH = "pen_width" // selected pen thickness, an index into PEN_WIDTHS (#199).
+        const val KEY_PALETTE_X = "palette_x" // parked tool-palette corner, host fractions (#200).
+        const val KEY_PALETTE_Y = "palette_y"
         const val PALM_REJECT_MS = 1000L // a finger tap within this long of a stylus event = palm.
         // Public, Partner-synced folder the annotated PDF export is written to (Android external
         // storage root + this) so it reaches the desktop. "Document" is in the Supernote sync set.

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -139,8 +139,15 @@ class ToolPalette(
         )
     }
 
-    /** Hand the pill's resting place to the host to remember (#200). */
+    /**
+     * Hand the pill's resting place to the host to remember (#200).
+     *
+     * Never from a degenerate layout. A zero-sized host reads as the default dock, and writing that
+     * would quietly discard the corner the reader had chosen — losing the parked position is the
+     * one failure this whole change exists to prevent, so an unmeasured pill records nothing.
+     */
     private fun persist() {
+        if (host.width <= 0 || host.height <= 0 || container.width <= 0 || container.height <= 0) return
         onMoved(
             Position(
                 fractionX(container.translationX, host.width, container.width),

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -298,6 +298,12 @@ class ToolPalette(
         if (expanded) { expanded = false; render() }
     }
 
+    /**
+     * A parked position for the pill, held as host-relative fractions (#200). Persisted by the
+     * host so the toolbar reopens where the reader left it instead of back at the default dock.
+     */
+    data class Position(val x: Float, val y: Float)
+
     internal companion object {
         /** Resting opacity of the docked puck — translucent so the text behind it stays readable. */
         const val IDLE_ALPHA = 0.55f
@@ -333,5 +339,42 @@ class ToolPalette(
          */
         fun anchorY(ty: Float, oldHeight: Int, newHeight: Int): Float =
             ty + (newHeight - oldHeight) / 2f
+
+        /**
+         * Where the pill's **top-left corner** sits, as a fraction of the host's width and height.
+         *
+         * Fractions rather than raw pixels because a remembered position has to survive things the
+         * pixels do not: a rotation, a different panel (a Nomad is not a Manta), and the pill's own
+         * size changing between its collapsed and expanded forms. The corner is where the grip is,
+         * which is the part the reader actually aims at.
+         */
+        fun fractionX(tx: Float, hostWidth: Int, viewWidth: Int): Float =
+            if (hostWidth <= 0) 0f else ((hostWidth - viewWidth) + tx) / hostWidth
+
+        fun fractionY(ty: Float, hostHeight: Int, viewHeight: Int): Float =
+            if (hostHeight <= 0) 0f else ((hostHeight - viewHeight) / 2f + ty) / hostHeight
+
+        /**
+         * Turn a remembered [fractionX] back into a horizontal offset for the *current* geometry,
+         * clamped so it lands on screen.
+         *
+         * The clamp is the point, not a formality: the fraction may have been saved on the other
+         * rotation, on another device, or against a pill that a later build sized differently, and
+         * a position that was legal then can be off screen now. Restoring the pill out of reach
+         * would recreate the very trap #200 was opened about.
+         */
+        fun translationXFor(fraction: Float, hostWidth: Int, viewWidth: Int): Float =
+            if (hostWidth <= 0 || !fraction.isFinite()) {
+                0f
+            } else {
+                clampX(fraction * hostWidth - (hostWidth - viewWidth), hostWidth, viewWidth)
+            }
+
+        fun translationYFor(fraction: Float, hostHeight: Int, viewHeight: Int): Float =
+            if (hostHeight <= 0 || !fraction.isFinite()) {
+                0f
+            } else {
+                clampY(fraction * hostHeight - (hostHeight - viewHeight) / 2f, hostHeight, viewHeight)
+            }
     }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -62,6 +62,10 @@ class ToolPalette(
     /** Global ink undo / redo (these are actions, not tools — they don't change the active tool). */
     private val onUndo: () -> Unit = {},
     private val onRedo: () -> Unit = {},
+    /** Where the reader last parked the pill (#200); null opens it at the default dock. */
+    private val savedPosition: Position? = null,
+    /** The pill came to rest somewhere new — persist it so the next document opens there (#200). */
+    private val onMoved: (Position) -> Unit = {},
 ) {
     var current: Tool = Tool.PEN
         private set
@@ -88,6 +92,61 @@ class ToolPalette(
         )
         container.alpha = IDLE_ALPHA // see-through while reading so it doesn't cover the text
         render()
+        savedPosition?.let(::restore)
+    }
+
+    /**
+     * Put the pill back where the reader parked it, once the first layout pass has given the host
+     * and the pill real sizes (#200).
+     *
+     * Restoring is deliberately clamped rather than trusted: the fraction may have been saved on
+     * the other rotation or on another panel, and a corner that was on screen then can be off it
+     * now. [reattach] afterwards because a bare translate does not refresh this EPD — without it
+     * the pill would sit at the default dock on the panel while being somewhere else to the touch.
+     */
+    private fun restore(position: Position) = onNextLayout { width, height ->
+        container.translationX = translationXFor(position.x, host.width, width)
+        container.translationY = translationYFor(position.y, host.height, height)
+        reattach()
+        onChrome()
+    }
+
+    /**
+     * Run [action] with the container's size after the next layout pass.
+     *
+     * A one-shot layout listener, not `post`: [render] only *requests* a layout, and a posted
+     * runnable can run before the traversal that measures the new children — which would read the
+     * stale size and correct by the wrong amount.
+     */
+    private fun onNextLayout(action: (width: Int, height: Int) -> Unit) {
+        container.addOnLayoutChangeListener(
+            object : View.OnLayoutChangeListener {
+                override fun onLayoutChange(
+                    v: View,
+                    left: Int,
+                    top: Int,
+                    right: Int,
+                    bottom: Int,
+                    oldLeft: Int,
+                    oldTop: Int,
+                    oldRight: Int,
+                    oldBottom: Int,
+                ) {
+                    v.removeOnLayoutChangeListener(this)
+                    action(right - left, bottom - top)
+                }
+            },
+        )
+    }
+
+    /** Hand the pill's resting place to the host to remember (#200). */
+    private fun persist() {
+        onMoved(
+            Position(
+                fractionX(container.translationX, host.width, container.width),
+                fractionY(container.translationY, host.height, container.height),
+            ),
+        )
     }
 
     /** Rounded white pill with a black keyline — high contrast on e-ink (Inkwell card language). */
@@ -194,7 +253,7 @@ class ToolPalette(
                 }
                 MotionEvent.ACTION_UP -> {
                     container.alpha = IDLE_ALPHA // fade back so it doesn't sit over the text
-                    if (moved) { reattach(); onChrome() } // re-add forces an EPD refresh at the new spot
+                    if (moved) { reattach(); persist(); onChrome() } // re-add forces an EPD refresh at the new spot
                     else { toggleExpanded() }
                     true
                 }
@@ -219,37 +278,14 @@ class ToolPalette(
         val heightBefore = container.height
         expanded = !expanded
         render()
-        // A one-shot layout listener, not `post`: `render` only requests a layout, and a posted
-        // runnable can run before the traversal that measures the new children — which would read
-        // the OLD height and correct by the wrong amount.
-        container.addOnLayoutChangeListener(
-            object : View.OnLayoutChangeListener {
-                override fun onLayoutChange(
-                    v: View,
-                    left: Int,
-                    top: Int,
-                    right: Int,
-                    bottom: Int,
-                    oldLeft: Int,
-                    oldTop: Int,
-                    oldRight: Int,
-                    oldBottom: Int,
-                ) {
-                    v.removeOnLayoutChangeListener(this)
-                    val height = bottom - top
-                    container.translationY =
-                        clampY(
-                            anchorY(container.translationY, heightBefore, height),
-                            host.height,
-                            height,
-                        )
-                    container.translationX =
-                        clampX(container.translationX, host.width, right - left)
-                    reattach()
-                    onChrome()
-                }
-            },
-        )
+        onNextLayout { width, height ->
+            container.translationY =
+                clampY(anchorY(container.translationY, heightBefore, height), host.height, height)
+            container.translationX = clampX(container.translationX, host.width, width)
+            reattach()
+            persist() // the clamp may have nudged the pill; remember where it actually landed
+            onChrome()
+        }
     }
 
     private fun iconButton(tool: Tool): ImageView = ImageView(activity).apply {
@@ -302,7 +338,19 @@ class ToolPalette(
      * A parked position for the pill, held as host-relative fractions (#200). Persisted by the
      * host so the toolbar reopens where the reader left it instead of back at the default dock.
      */
-    data class Position(val x: Float, val y: Float)
+    data class Position(val x: Float, val y: Float) {
+        companion object {
+            /**
+             * Decode a stored pair, or null when there isn't one to decode.
+             *
+             * "Never parked" and "parked before this feature existed" both read back as the NaN
+             * default, and a NaN that reached a layout pass would place the pill nowhere at all —
+             * so anything non-finite means the default dock, not a position.
+             */
+            fun of(x: Float, y: Float): Position? =
+                if (x.isFinite() && y.isFinite()) Position(x, y) else null
+        }
+    }
 
     internal companion object {
         /** Resting opacity of the docked puck — translucent so the text behind it stays readable. */

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -278,14 +278,27 @@ class ToolPalette(
         val heightBefore = container.height
         expanded = !expanded
         render()
-        onNextLayout { width, height ->
-            container.translationY =
-                clampY(anchorY(container.translationY, heightBefore, height), host.height, height)
-            container.translationX = clampX(container.translationX, host.width, width)
+        reanchor(heightBefore) {
             reattach()
             persist() // the clamp may have nudged the pill; remember where it actually landed
             onChrome()
         }
+    }
+
+    /**
+     * After the pill changes size, put its **top-left corner** back where it was and pull it inside
+     * the host, then run [onSettled].
+     *
+     * Every size change needs this, not just the deliberate ones: the pill is anchored
+     * `CENTER_VERTICAL`, so growing or shrinking it moves the corner by half the difference unless
+     * the offset compensates. The corner is where the grip is — the thing the finger just tapped,
+     * and the only way to collapse the pill again.
+     */
+    private fun reanchor(heightBefore: Int, onSettled: () -> Unit) = onNextLayout { width, height ->
+        container.translationY =
+            clampY(anchorY(container.translationY, heightBefore, height), host.height, height)
+        container.translationX = clampX(container.translationX, host.width, width)
+        onSettled()
     }
 
     private fun iconButton(tool: Tool): ImageView = ImageView(activity).apply {
@@ -329,9 +342,20 @@ class ToolPalette(
         android.util.Log.i("ToolPalette", "reattach: expanded=$expanded tx=$tx ty=$ty")
     }
 
-    /** Collapse the pill (call from the host's onPause) — it stays docked, never removed. */
+    /**
+     * Collapse the pill (call from the host's onPause) — it stays docked, never removed.
+     *
+     * Re-anchored like any other collapse: this used to shrink the pill without compensating, so
+     * backgrounding the app and returning to it left the puck half the pill's height further down
+     * the screen than the reader had put it. Nothing is persisted or repainted here — the panel is
+     * going away, and the corner the reader chose was already recorded when they chose it.
+     */
     fun dismiss() {
-        if (expanded) { expanded = false; render() }
+        if (!expanded) return
+        val heightBefore = container.height
+        expanded = false
+        render()
+        reanchor(heightBefore) {}
     }
 
     /**

--- a/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
@@ -99,4 +99,105 @@ class ToolPalettePlacementTest {
         assertEquals(0f, ToolPalette.clampY(10f, 0, 0), 0.01f)
         assertEquals(0f, ToolPalette.clampX(-10f, 0, 0), 0.01f)
     }
+
+    // ── Remembering where the pill was parked (#200) ──────────────────────────────────────────────
+
+    /** The pill's top edge in host coordinates, for an arbitrary host — the placement that matters. */
+    private fun topIn(ty: Float, hostHeight: Int, viewHeight: Int): Float =
+        (hostHeight - viewHeight) / 2f + ty
+
+    /** The pill's left edge in host coordinates (the base anchor is END, so the offset is negative). */
+    private fun leftIn(tx: Float, hostWidth: Int, viewWidth: Int): Float =
+        (hostWidth - viewWidth) + tx
+
+    /**
+     * The everyday case: park the puck, close the document, reopen it on the same panel. The pill
+     * must come back to the same pixel, or "remembering" is worse than not remembering.
+     */
+    @Test
+    fun aParkedPositionComesBackToTheSamePlaceOnTheSamePanel() {
+        val tx = -300f
+        val ty = 200f
+
+        val restoredX = ToolPalette.translationXFor(ToolPalette.fractionX(tx, hostW, puck), hostW, puck)
+        val restoredY = ToolPalette.translationYFor(ToolPalette.fractionY(ty, hostH, puck), hostH, puck)
+
+        assertEquals(tx, restoredX, 0.5f)
+        assertEquals(ty, restoredY, 0.5f)
+    }
+
+    /**
+     * The correction the reporter asked for in the same breath as the feature: "It should account
+     * for wrong positions (keep into the limit of the screen)."
+     *
+     * A puck parked flush with the bottom in portrait describes a point that is *past* the bottom
+     * of a landscape panel. Restoring the raw position would hang the grip off the edge — exactly
+     * the unreachable-grip trap this issue was opened about, only now it would survive a restart.
+     */
+    @Test
+    fun aPositionSavedInPortraitIsPulledBackOntoALandscapeScreen() {
+        val parked = ToolPalette.clampY(99_999f, hostH, puck) // flush with the portrait bottom
+        val fraction = ToolPalette.fractionY(parked, hostH, puck)
+
+        val landscapeH = hostW // the panel turned on its side
+        val naive = fraction * landscapeH - (landscapeH - puck) / 2f
+        assertTrue(
+            "fixture must describe an off-screen point: bottom was ${topIn(naive, landscapeH, puck) + puck}",
+            topIn(naive, landscapeH, puck) + puck > landscapeH,
+        )
+
+        val restored = ToolPalette.translationYFor(fraction, landscapeH, puck)
+        assertTrue("ran off the top: ${topIn(restored, landscapeH, puck)}", topIn(restored, landscapeH, puck) >= -0.5f)
+        assertTrue(
+            "ran off the bottom: ${topIn(restored, landscapeH, puck) + puck}",
+            topIn(restored, landscapeH, puck) + puck <= landscapeH + 0.5f,
+        )
+    }
+
+    /** The same story sideways: a left-flush park stays left-flush on a wider panel. */
+    @Test
+    fun aHorizontalParkIsRestoredAgainstTheNewWidth() {
+        val parked = ToolPalette.clampX(-99_999f, hostW, puck) // flush with the left edge
+        val fraction = ToolPalette.fractionX(parked, hostW, puck)
+
+        val widerW = hostH
+        val restored = ToolPalette.translationXFor(fraction, widerW, puck)
+        assertEquals("should still sit flush left", 0f, leftIn(restored, widerW, puck), 0.5f)
+    }
+
+    /**
+     * The pill is saved at whatever size it happened to be and restored collapsed, because it always
+     * opens collapsed. Anchoring on the top-left corner is what makes that a no-op rather than a
+     * drift of half the height difference.
+     */
+    @Test
+    fun aPositionSavedWhileExpandedRestoresTheCollapsedPuckToTheSameCorner() {
+        val parked = ToolPalette.clampY(-99_999f, hostH, pill) // expanded, flush with the top
+        val cornerBefore = topIn(parked, hostH, pill)
+
+        val restored = ToolPalette.translationYFor(ToolPalette.fractionY(parked, hostH, pill), hostH, puck)
+
+        assertEquals("the corner the grip sits in must not move", cornerBefore, topIn(restored, hostH, puck), 0.5f)
+    }
+
+    /**
+     * Never parked, or a preference file that predates this feature: both arrive as NaN and must
+     * open at the default dock rather than propagating a NaN into a layout pass.
+     */
+    @Test
+    fun anUnsetPositionOpensAtTheDefaultDock() {
+        assertEquals(0f, ToolPalette.translationXFor(Float.NaN, hostW, puck), 0.01f)
+        assertEquals(0f, ToolPalette.translationYFor(Float.NaN, hostH, puck), 0.01f)
+        assertEquals(0f, ToolPalette.translationXFor(Float.POSITIVE_INFINITY, hostW, puck), 0.01f)
+        assertEquals(0f, ToolPalette.translationYFor(Float.NEGATIVE_INFINITY, hostH, puck), 0.01f)
+    }
+
+    /** Before the first layout pass the host has no size; reading or restoring must stay finite. */
+    @Test
+    fun aZeroSizedHostNeitherDividesByZeroNorMoves() {
+        assertEquals(0f, ToolPalette.fractionX(10f, 0, 0), 0.01f)
+        assertEquals(0f, ToolPalette.fractionY(10f, 0, 0), 0.01f)
+        assertEquals(0f, ToolPalette.translationXFor(0.5f, 0, 0), 0.01f)
+        assertEquals(0f, ToolPalette.translationYFor(0.5f, 0, 0), 0.01f)
+    }
 }

--- a/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
@@ -1,6 +1,7 @@
 package dev.jraghavan.inkread
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -190,6 +191,19 @@ class ToolPalettePlacementTest {
         assertEquals(0f, ToolPalette.translationYFor(Float.NaN, hostH, puck), 0.01f)
         assertEquals(0f, ToolPalette.translationXFor(Float.POSITIVE_INFINITY, hostW, puck), 0.01f)
         assertEquals(0f, ToolPalette.translationYFor(Float.NEGATIVE_INFINITY, hostH, puck), 0.01f)
+    }
+
+    /**
+     * A stored pair decodes to a position only when both halves are real. The absent-preference
+     * default is NaN, and letting one through would put the pill nowhere at all.
+     */
+    @Test
+    fun onlyAFullyFinitePairDecodesToAPosition() {
+        assertEquals(ToolPalette.Position(0.25f, 0.75f), ToolPalette.Position.of(0.25f, 0.75f))
+        assertNull("never parked", ToolPalette.Position.of(Float.NaN, Float.NaN))
+        assertNull("half-written pair", ToolPalette.Position.of(0.25f, Float.NaN))
+        assertNull("half-written pair", ToolPalette.Position.of(Float.NaN, 0.75f))
+        assertNull(ToolPalette.Position.of(Float.POSITIVE_INFINITY, 0.5f))
     }
 
     /** Before the first layout pass the host has no size; reading or restoring must stay finite. */


### PR DESCRIPTION
The floating toolbar returned to its default dock — centred on the right edge — on every
document open, so a reader who wanted it anywhere else had to drag it back each time.

## What changed

**The position is now saved as a host-relative fraction of the pill's top-left corner**, not as
the raw `translationX/Y` offset. The offset is measured against the current host size and the
pill's current size, which makes it meaningless as something to remember: the same offset lands
somewhere else after a rotation, on a different panel, or once the pill collapses from its
expanded form to its puck. The corner is the anchor because that is where the grip sits.

**Restoring clamps against the current geometry.** A puck parked flush with the bottom in
portrait describes a point past the bottom of a landscape panel; restoring the raw value would
put the grip off screen and leave no way to collapse the pill — the trap this issue was opened
about, except surviving a restart. `translationXFor`/`translationYFor` run the existing
`clampX`/`clampY` on the way back in.

**A non-finite coordinate means "no saved position".** Never-parked and pre-feature preference
files both read back as the `NaN` default; `Position.of` turns either into the default dock
rather than letting a `NaN` reach a layout pass.

**A position is never recorded from an unmeasured layout.** A host or pill with no size reads as
the default dock, so writing it would replace the reader's parked corner with the very default
this change exists to stop the toolbar returning to — losing it for good rather than merely
leaving it unapplied for one session.

**Collapsing on pause now re-anchors.** `dismiss()` shrank the pill without compensating for its
`CENTER_VERTICAL` anchor, so backgrounding the app and returning left the puck half the pill's
height further down than the reader had put it. The deliberate collapse path already corrected
for this; both now share one re-anchor step, which also absorbs the duplicated one-shot layout
listener.

Persistence is app-wide rather than per-document: a toolbar that sat somewhere different
depending on which book was open would be harder to predict than one that did not move.

## Storage

Two floats beside the existing pen-thickness preference in the reader's `SharedPreferences`
(`palette_x`, `palette_y`).

## Tests

Seven host JVM tests in `ToolPalettePlacementTest`: same-panel round trip, portrait-to-landscape
and narrow-to-wide restores, an expanded-save restored to a collapsed puck, non-finite decoding,
and zero-sized-host geometry. The clamp test was checked against a build with the clamp removed
to confirm it fails there.

`cargo fmt`, `cargo clippy -D warnings`, `cargo test --workspace`, `:app:testDebugUnitTest` and
the licence check all pass; the release APK assembles.

## Scope

Covers the persistence request in the issue thread. The horizontal-toolbar option in the original
report (item 3) is not addressed, so #200 stays open.

