### PR TITLE
feat(shelf): Shelf and Home UX pass (#227)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -121,6 +121,25 @@ object Books {
     fun sidecarDir(file: File): File =
         File(file.parentFile, "${file.nameWithoutExtension}.inkread")
 
+    /**
+     * Whether this book actually carries handwriting.
+     *
+     * Deliberately **not** "does the sidecar exist". The core stamps a `metadata.json` into the
+     * sidecar the first time a document is opened, to bind it to that document's identity
+     * (RR10-FR6) — so the directory is present for every book that has ever been opened, ink or
+     * no ink, and testing for it marked the whole shelf as annotated (#227).
+     *
+     * Ink lives in `annotations/page-NNNN.inkbin`, written only when a stroke is committed and
+     * *removed* again when a page's last stroke is erased, so one of those files is the question
+     * actually being asked. A quarantined `.inkbin.corrupt` page does not match, and should not:
+     * it is ink the reader can no longer see.
+     */
+    fun hasNotes(file: File): Boolean =
+        File(sidecarDir(file), "annotations").list()?.any(INK_PAGE_FILE::matches) == true
+
+    /** `page-NNNN.inkbin` — the core's committed-ink page files (`SidecarPaths::page_file`). */
+    private val INK_PAGE_FILE = Regex("^page-\\d+\\.inkbin$")
+
     /** Bytes this book occupies, its annotations included — what removing it actually frees. */
     fun sizeOnDisk(file: File): Long =
         file.length() + sidecarDir(file).walkBottomUp().filter { it.isFile }.sumOf { it.length() }

--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -152,6 +152,39 @@ object Books {
     fun disambiguatingFileName(displayTitle: String, fileName: String): String? =
         fileName.takeIf { !it.substringBeforeLast('.').equals(displayTitle.trim(), ignoreCase = true) }
 
+    /** How the shelf is ordered (#227). */
+    enum class ShelfSort(val label: String) {
+        TITLE("Title"),
+        RECENT("Recent"),
+        SIZE("Size"),
+        ;
+
+        companion object {
+            /** Decode a stored name, falling back to [TITLE] for anything unrecognised. */
+            fun of(name: String?): ShelfSort =
+                entries.firstOrNull { it.name == name } ?: TITLE
+        }
+    }
+
+    /** One shelf row's sort keys, resolved once so ordering never re-reads the filesystem. */
+    data class ShelfEntry(val file: File, val title: String, val opened: Long, val size: Long)
+
+    /**
+     * Order the shelf.
+     *
+     * Ties break on title in every mode, so the list is stable and a reader scanning it twice sees
+     * the same order both times — on a panel that repaints in whole frames, a list that reshuffles
+     * between visits is worse than one ordered imperfectly.
+     */
+    fun sortEntries(entries: List<ShelfEntry>, sort: ShelfSort): List<ShelfEntry> {
+        val byTitle = compareBy<ShelfEntry> { it.title.lowercase() }
+        return when (sort) {
+            ShelfSort.TITLE -> entries.sortedWith(byTitle)
+            ShelfSort.RECENT -> entries.sortedWith(compareByDescending<ShelfEntry> { it.opened }.then(byTitle))
+            ShelfSort.SIZE -> entries.sortedWith(compareByDescending<ShelfEntry> { it.size }.then(byTitle))
+        }
+    }
+
     /** Bytes this book occupies, its annotations included — what removing it actually frees. */
     fun sizeOnDisk(file: File): Long =
         file.length() + sidecarDir(file).walkBottomUp().filter { it.isFile }.sumOf { it.length() }
@@ -300,6 +333,21 @@ object Books {
             // a lost recents entry is cosmetic.
         }
     }
+
+    /**
+     * Stamp this book as opened now. Paired with [pushRecent], which records the same event but
+     * keeps only the newest handful — this survives past the recents cut, which is what the shelf
+     * needs to order a library larger than that.
+     */
+    fun setLastOpened(context: Context, id: String, now: Long = System.currentTimeMillis()) =
+        meta(context).edit().putLong("$id.opened", now).apply()
+
+    /**
+     * When this book was last opened, or 0 if never — including every book that was already on the
+     * shelf before the stamp existed. The shelf falls back to the file's own timestamp for those,
+     * so they order by when they arrived rather than collapsing into one undifferentiated block.
+     */
+    fun lastOpened(context: Context, id: String): Long = meta(context).getLong("$id.opened", 0L)
 
     /** Per-book read progress (0–100), written by the reader on save; shown on the home shelf. */
     fun setProgress(context: Context, id: String, percent: Int) {

--- a/app/src/main/java/dev/jraghavan/inkread/Books.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Books.kt
@@ -140,6 +140,18 @@ object Books {
     /** `page-NNNN.inkbin` — the core's committed-ink page files (`SidecarPaths::page_file`). */
     private val INK_PAGE_FILE = Regex("^page-\\d+\\.inkbin$")
 
+    /**
+     * The file name to show beside [displayTitle], or null when it would merely repeat it.
+     *
+     * Books are listed by their metadata title, which is the right name to read by but a poor way
+     * to tell two files apart: a reader holding three copies of the same work sees the same line
+     * three times with no way to reach the file name (#227). Showing it always would be noise on
+     * the common shelf, where the title *is* the file name, so it appears only when it adds
+     * something — which is exactly the ambiguous case.
+     */
+    fun disambiguatingFileName(displayTitle: String, fileName: String): String? =
+        fileName.takeIf { !it.substringBeforeLast('.').equals(displayTitle.trim(), ignoreCase = true) }
+
     /** Bytes this book occupies, its annotations included — what removing it actually frees. */
     fun sizeOnDisk(file: File): Long =
         file.length() + sidecarDir(file).walkBottomUp().filter { it.isFile }.sumOf { it.length() }

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -170,6 +170,7 @@ class BottomBarController(private val host: Host) {
             gravity = Gravity.CENTER; setPadding(dp(8), dp(2), dp(8), dp(2)); isClickable = true
             setOnClickListener { dialog.dismiss(); chapterJump(dir) }
         }
+        fileNameLine()?.let(container::addView)
         container.addView(
             LinearLayout(activity).apply {
                 orientation = LinearLayout.HORIZONTAL
@@ -530,4 +531,29 @@ class BottomBarController(private val host: Host) {
     companion object {
         private const val TAG = "BottomBar"
     }
+
+    /**
+     * The open document's file name, shown only when it differs from the title it is listed under.
+     *
+     * The title is on screen everywhere; the file name was reachable nowhere, which leaves a reader
+     * holding several copies of one work unable to tell which one they have open (#227). It goes
+     * here rather than behind a twelfth control in a row that is already full on a small panel.
+     */
+    private fun fileNameLine(): View? {
+        val d = activity.resources.displayMetrics.density
+        fun dp(v: Int) = (v * d).toInt()
+        val file = java.io.File(host.requestedPath ?: return null)
+        val title = Books.metaTitle(activity, file.name) ?: Books.title(file)
+        val name = Books.disambiguatingFileName(title, file.name) ?: return null
+        return TextView(activity).apply {
+            text = name
+            setTextColor(Ink.muted)
+            textSize = Ink.sp(11f)
+            typeface = Ink.mono
+            maxLines = 1
+            ellipsize = android.text.TextUtils.TruncateAt.MIDDLE
+            setPadding(dp(24), dp(12), dp(24), 0)
+        }
+    }
+
 }

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -544,7 +544,11 @@ class BottomBarController(private val host: Host) {
         fun dp(v: Int) = (v * d).toInt()
         val file = java.io.File(host.requestedPath ?: return null)
         val title = Books.metaTitle(activity, file.name) ?: Books.title(file)
-        val name = Books.disambiguatingFileName(title, file.name) ?: return null
+        val name = Books.disambiguatingFileName(title, file.name)
+        // Say which way it went. "Nothing shown" is the correct answer when the file is named after
+        // its title, and is indistinguishable from a broken line unless the log states the reason.
+        Log.i(TAG, "file name line: file=${file.name} title=$title -> ${name ?: "(same, hidden)"}")
+        if (name == null) return null
         return TextView(activity).apply {
             text = name
             setTextColor(Ink.muted)

--- a/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/HomeActivity.kt
@@ -484,8 +484,14 @@ class HomeActivity : Activity() {
         }
     }
 
-    /** The design's stat chips — outlined pills of REAL reading stats (streak · this week · pages).
-     *  Each chip appears only when it has data, so nothing is faked; null when there's nothing yet. */
+    /**
+     * REAL reading stats (streak · this week · pages), as a plain line.
+     *
+     * These used to be outlined pills, which on this screen is the shape of a button — so the one
+     * thing on Home that *was* tappable looked like a label while three things that do nothing
+     * looked pressable (#227). Each part still appears only when it has data, so nothing is faked;
+     * null when there is nothing to report yet.
+     */
     private fun statChips(): View? {
         val chips = buildList {
             val streak = ReadingStats.streakDays(this@HomeActivity)
@@ -496,21 +502,11 @@ class HomeActivity : Activity() {
             if (pages > 0) add(if (pages == 1) "1 page" else "$pages pages")
         }
         if (chips.isEmpty()) return null
-        return LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL
+        return TextView(this).apply {
+            text = chips.joinToString("   ·   ")
+            setTextColor(inkSoft); textSize = fs(13f); typeface = serif
             gravity = Gravity.CENTER
-            chips.forEachIndexed { i, c ->
-                addView(chip(c), LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-                    .apply { marginStart = if (i == 0) 0 else dim(10) })
-            }
-        }
-    }
-
-    private fun chip(text: String): View = TextView(this).apply {
-        this.text = text; setTextColor(ink); textSize = fs(13f); typeface = serif
-        gravity = Gravity.CENTER; setPadding(dim(16), dim(6), dim(16), dim(6))
-        background = GradientDrawable().apply {
-            setColor(Color.WHITE); setStroke(maxOf(1, dp(1)), ink); cornerRadius = dim(40).toFloat()
+            setPadding(dim(12), dim(6), dim(12), dim(6))
         }
     }
 
@@ -525,15 +521,24 @@ class HomeActivity : Activity() {
         layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
 
-    /** "Your shelf · N books" → [ShelfActivity]; `null` when the device holds nothing yet. */
+    /**
+     * "Your shelf · N books" → [ShelfActivity]; `null` when the device holds nothing yet.
+     *
+     * Carries the same outlined-pill shape as [openButton], because it does the same kind of thing:
+     * both take you somewhere. It used to be set as plain mono text and read as a caption, which is
+     * how the shelf stayed hard to find (#227).
+     */
     private fun allBooksLink(): View? {
         val count = Books.list(this).size
         if (count == 0) return null
         return TextView(this).apply {
             text = "Your shelf · $count ${if (count == 1) "book" else "books"}"
-            setTextColor(inkSoft); textSize = fs(13f); typeface = mono; letterSpacing = 0.08f
+            setTextColor(ink); textSize = fs(16f); typeface = serif
             gravity = Gravity.CENTER
-            setPadding(dim(12), dim(8), dim(12), dim(8))
+            setPadding(dim(30), dim(13), dim(30), dim(13))
+            background = GradientDrawable().apply {
+                setColor(Color.WHITE); setStroke(maxOf(1, dp(1)), ink); cornerRadius = dim(40).toFloat()
+            }
             isClickable = true
             setOnClickListener { startActivity(Intent(this@HomeActivity, ShelfActivity::class.java)) }
         }

--- a/app/src/main/java/dev/jraghavan/inkread/OpdsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/OpdsActivity.kt
@@ -254,7 +254,7 @@ class OpdsActivity : Activity() {
 
     /** A downloaded book is on the shelf either way; this just saves a trip back to Home to open it. */
     private fun offerToRead(title: String, path: String, id: String) {
-        AlertDialog.Builder(this)
+        AlertDialog.Builder(this, R.style.InkDialog)
             .setTitle("Added to your shelf")
             .setMessage("$title is now on your shelf.")
             .setPositiveButton("Read now") { _, _ ->

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -863,6 +863,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             // (line spacing + alignment were restored above, in the same nativeSetTypography call)
             pageCount = NativeBridge.nativePageCount(docHandle)
             Books.pushRecent(this, bookId, path)
+            Books.setLastOpened(this, bookId) // orders the shelf past the recents cut (#227)
             // Capture the real document metadata so the library shows the actual title/author + page
             // position instead of the filename (the home redesign's real-data path).
             try {

--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -229,7 +229,7 @@ class SettingsActivity : Activity() {
                 setPadding(0, dp(12), 0, 0); setLineSpacing(0f, 1.25f)
             })
         }
-        AlertDialog.Builder(this)
+        AlertDialog.Builder(this, R.style.InkDialog)
             .setTitle("Your library")
             .setView(body)
             .setPositiveButton("Save") { _, _ ->

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -67,6 +67,7 @@ class ShelfActivity : Activity() {
 
     private fun header(books: List<File>): View = LinearLayout(this).apply {
         orientation = LinearLayout.VERTICAL
+        addView(backLink())
         addView(Ink.eyebrow(this@ShelfActivity, "Your shelf"))
         addView(TextView(this@ShelfActivity).apply {
             text = if (books.size == 1) "1 book" else "${books.size} books"
@@ -83,6 +84,26 @@ class ShelfActivity : Activity() {
         }
         addView(Ink.rule(this@ShelfActivity))
         addView(spacer(dp(6)))
+    }
+
+    /**
+     * The way back to Home.
+     *
+     * This screen had none. Every other secondary screen finishes itself from somewhere, but the
+     * shelf could only be entered — and the device's own UI offers no system Back, so a reader who
+     * opened it was stranded until they left the app (#227). The label names the destination rather
+     * than showing a bare arrow, and the padding is a finger's worth: this is the only exit.
+     */
+    private fun backLink(): View = TextView(this).apply {
+        text = "‹ Home"
+        setTextColor(Ink.muted)
+        textSize = Ink.sp(12f)
+        typeface = mono
+        letterSpacing = 0.12f
+        setPadding(0, dp(6), dp(24), dp(16))
+        isClickable = true
+        contentDescription = "Back to Home"
+        setOnClickListener { finish() }
     }
 
     /** One book: tap the title to read it, tap Remove to take it off the device. */

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -37,9 +37,13 @@ class ShelfActivity : Activity() {
 
     private lateinit var column: LinearLayout
 
+    private val prefs by lazy { getSharedPreferences(PREFS, MODE_PRIVATE) }
+    private var sort = Books.ShelfSort.TITLE
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Ink.uiScale = DisplayPrefs(this).uiScale
+        sort = Books.ShelfSort.of(prefs.getString(KEY_SORT, null))
         column = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(dp(22), dp(20), dp(22), dp(28))
@@ -50,7 +54,7 @@ class ShelfActivity : Activity() {
 
     private fun render() {
         Books.sweepPartialDownloads(this)
-        val books = Books.list(this)
+        val books = ordered(Books.list(this))
         column.removeAllViews()
         column.addView(header(books))
 
@@ -83,7 +87,59 @@ class ShelfActivity : Activity() {
             })
         }
         addView(Ink.rule(this@ShelfActivity))
+        if (books.isNotEmpty()) addView(sortRow())
         addView(spacer(dp(6)))
+    }
+
+    /**
+     * Resolve each book's sort keys once, then order them (#227).
+     *
+     * The keys are read here rather than inside the comparator because a comparator runs O(n log n)
+     * times: reading a book's size walks its sidecar, so doing it per comparison would turn opening
+     * the shelf into a directory crawl proportional to the sort, not the library.
+     */
+    private fun ordered(books: List<File>): List<File> =
+        Books.sortEntries(
+            books.map {
+                Books.ShelfEntry(
+                    file = it,
+                    title = titleOf(it),
+                    opened = Books.lastOpened(this, it.name).takeIf { t -> t > 0L } ?: it.lastModified(),
+                    size = Books.sizeOnDisk(it),
+                )
+            },
+            sort,
+        ).map { it.file }
+
+    /** Pick an order. Three plain words; the active one is inked, the rest recede. */
+    private fun sortRow(): View = LinearLayout(this).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(0, dp(10), 0, dp(2))
+        addView(TextView(this@ShelfActivity).apply {
+            text = "SORT"
+            setTextColor(Ink.muted); textSize = Ink.sp(10f); typeface = mono; letterSpacing = 0.14f
+            setPadding(0, 0, dp(14), 0)
+        })
+        for (option in Books.ShelfSort.entries) addView(sortOption(option))
+    }
+
+    private fun sortOption(option: Books.ShelfSort): View = TextView(this).apply {
+        val active = option == sort
+        text = option.label
+        setTextColor(if (active) ink else Ink.muted)
+        textSize = Ink.sp(12f)
+        typeface = if (active) Ink.serifBold else serif
+        setPadding(0, dp(4), dp(18), dp(4))
+        isClickable = true
+        contentDescription = "Sort by ${option.label}"
+        setOnClickListener {
+            if (option != sort) {
+                sort = option
+                prefs.edit().putString(KEY_SORT, option.name).apply()
+                render()
+            }
+        }
     }
 
     /**
@@ -220,4 +276,8 @@ class ShelfActivity : Activity() {
         layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, h)
     }
 
+    private companion object {
+        const val PREFS = "shelf"
+        const val KEY_SORT = "sort" // the reader's chosen order, kept between visits (#227).
+    }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -139,7 +139,7 @@ class ShelfActivity : Activity() {
         } else {
             "Remove “$title” from this device? It frees ${Books.humanSize(Books.sizeOnDisk(book))}."
         }
-        val dialog = AlertDialog.Builder(this)
+        val dialog = AlertDialog.Builder(this, R.style.InkDialog)
             .setTitle("Remove from device")
             .setMessage(message)
             .setPositiveButton("Remove") { _, _ -> doRemove(book, alsoNotes = false) }
@@ -150,7 +150,7 @@ class ShelfActivity : Activity() {
 
     /** Discarding handwriting is irreversible, so it gets its own confirmation. */
     private fun confirmNotesToo(book: File, title: String) {
-        AlertDialog.Builder(this)
+        AlertDialog.Builder(this, R.style.InkDialog)
             .setTitle("Delete the notes too?")
             .setMessage("Your handwriting on “$title” will be deleted. This can't be undone.")
             .setPositiveButton("Delete notes") { _, _ -> doRemove(book, alsoNotes = true) }

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -122,7 +122,7 @@ class ShelfActivity : Activity() {
         val bits = mutableListOf(book.extension.uppercase(), Books.humanSize(Books.sizeOnDisk(book)))
         val percent = Books.progress(this, book.name)
         if (percent > 0) bits += "$percent% read"
-        if (Books.sidecarDir(book).exists()) bits += "HAS NOTES"
+        if (Books.hasNotes(book)) bits += "HAS NOTES"
         return bits.joinToString(" · ")
     }
 
@@ -132,7 +132,7 @@ class ShelfActivity : Activity() {
      */
     private fun confirmRemove(book: File) {
         val title = Books.metaTitle(this, book.name) ?: Books.title(book)
-        val hasNotes = Books.sidecarDir(book).exists()
+        val hasNotes = Books.hasNotes(book)
         val message = if (hasNotes) {
             "Remove “$title” from this device? Your handwritten notes stay, and come back if you " +
                 "add the book again."

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -150,18 +150,25 @@ class ShelfActivity : Activity() {
     /**
      * Confirm before deleting, and make the annotations an explicit, separate decision — a reader who
      * is clearing space must not lose handwriting they did not think they were discarding.
+     *
+     * The wording says *inkread's own copy* rather than "from this device", which read as though the
+     * source document were being deleted (#227). Books live in the app's private storage: an import
+     * copies the file in, so removing one never touches the original the reader picked.
      */
     private fun confirmRemove(book: File) {
         val title = Books.metaTitle(this, book.name) ?: Books.title(book)
         val hasNotes = Books.hasNotes(book)
+        val freed = Books.humanSize(Books.sizeOnDisk(book))
         val message = if (hasNotes) {
-            "Remove “$title” from this device? Your handwritten notes stay, and come back if you " +
-                "add the book again."
+            "Remove “$title” from inkread? This deletes inkread’s own copy and frees $freed. " +
+                "A file you imported stays where it is. Your handwritten notes are kept, and come " +
+                "back if you add the book again."
         } else {
-            "Remove “$title” from this device? It frees ${Books.humanSize(Books.sizeOnDisk(book))}."
+            "Remove “$title” from inkread? This deletes inkread’s own copy and frees $freed. " +
+                "A file you imported stays where it is."
         }
         val dialog = AlertDialog.Builder(this, R.style.InkDialog)
-            .setTitle("Remove from device")
+            .setTitle("Remove from inkread")
             .setMessage(message)
             .setPositiveButton("Remove") { _, _ -> doRemove(book, alsoNotes = false) }
             .setNegativeButton("Cancel", null)

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -55,16 +55,9 @@ class ShelfActivity : Activity() {
 
     private fun render() {
         Books.sweepPartialDownloads(this)
-        val books = ordered(Books.list(this))
-        // Report what was decided, not merely that we ran: the shelf's three visible judgements
-        // (order, notes flag, file-name disclosure) are all invisible to a log otherwise, and a
-        // wrong one looks exactly like a right one on a panel that cannot be screenshotted.
-        Log.i(
-            TAG,
-            "shelf: ${books.size} books, sort=$sort, withNotes=${books.count { Books.hasNotes(it) }}, " +
-                "named=${books.count { Books.disambiguatingFileName(titleOf(it), it.name) != null }} — " +
-                books.take(4).joinToString(", ") { it.name },
-        )
+        val entries = ordered(Books.list(this))
+        val books = entries.map { it.file }
+        logShelf(entries)
         column.removeAllViews()
         column.addView(header(books))
 
@@ -108,7 +101,7 @@ class ShelfActivity : Activity() {
      * times: reading a book's size walks its sidecar, so doing it per comparison would turn opening
      * the shelf into a directory crawl proportional to the sort, not the library.
      */
-    private fun ordered(books: List<File>): List<File> =
+    private fun ordered(books: List<File>): List<Books.ShelfEntry> =
         Books.sortEntries(
             books.map {
                 Books.ShelfEntry(
@@ -119,7 +112,22 @@ class ShelfActivity : Activity() {
                 )
             },
             sort,
-        ).map { it.file }
+        )
+
+    /**
+     * Report the order **with the keys it was ordered on**.
+     *
+     * Logging the resulting sequence alone was useless: on a small shelf the three orders can
+     * coincide, so a list that was never sorted is indistinguishable from one that was. The keys
+     * are the evidence — with them, a wrong order is visible from the log alone.
+     */
+    private fun logShelf(entries: List<Books.ShelfEntry>) {
+        val rows = entries.take(5).joinToString(" | ") {
+            "${it.file.name} sz=${Books.humanSize(it.size)} opened=${it.opened} " +
+                "notes=${Books.hasNotes(it.file)} named=${Books.disambiguatingFileName(it.title, it.file.name) != null}"
+        }
+        Log.i(TAG, "shelf: ${entries.size} books, sort=$sort — $rows")
+    }
 
     /** Pick an order. Three plain words; the active one is inked, the rest recede. */
     private fun sortRow(): View = LinearLayout(this).apply {

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -117,7 +117,7 @@ class ShelfActivity : Activity() {
             isClickable = true
             setOnClickListener { open(book) }
             addView(TextView(this@ShelfActivity).apply {
-                text = Books.metaTitle(this@ShelfActivity, book.name) ?: Books.title(book)
+                text = titleOf(book)
                 setTextColor(ink); textSize = Ink.sp(18f); typeface = serif
                 maxLines = 2; setLineSpacing(0f, 1.1f)
             })
@@ -133,10 +133,22 @@ class ShelfActivity : Activity() {
                 setTextColor(Ink.muted); textSize = Ink.sp(11f); typeface = mono; letterSpacing = 0.08f
                 setPadding(0, dp(5), 0, 0)
             })
+            Books.disambiguatingFileName(titleOf(book), book.name)?.let { name ->
+                addView(TextView(this@ShelfActivity).apply {
+                    text = name
+                    setTextColor(Ink.muted); textSize = Ink.sp(10f); typeface = mono
+                    setPadding(0, dp(3), 0, 0); maxLines = 1
+                    ellipsize = android.text.TextUtils.TruncateAt.MIDDLE // keep the tail: v2, (1)…
+                })
+            }
         }, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
 
         addView(Ink.pillButton(this@ShelfActivity, "Remove", primary = false) { confirmRemove(book) })
     }
+
+    /** The name this book is listed under: its metadata title, else the file name. */
+    private fun titleOf(book: File): String =
+        Books.metaTitle(this, book.name) ?: Books.title(book)
 
     /** Format · size · how far in you are — enough to decide whether it can go. */
     private fun subtitleFor(book: File): String {
@@ -156,7 +168,7 @@ class ShelfActivity : Activity() {
      * copies the file in, so removing one never touches the original the reader picked.
      */
     private fun confirmRemove(book: File) {
-        val title = Books.metaTitle(this, book.name) ?: Books.title(book)
+        val title = titleOf(book)
         val hasNotes = Books.hasNotes(book)
         val freed = Books.humanSize(Books.sizeOnDisk(book))
         val message = if (hasNotes) {

--- a/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ShelfActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -55,6 +56,15 @@ class ShelfActivity : Activity() {
     private fun render() {
         Books.sweepPartialDownloads(this)
         val books = ordered(Books.list(this))
+        // Report what was decided, not merely that we ran: the shelf's three visible judgements
+        // (order, notes flag, file-name disclosure) are all invisible to a log otherwise, and a
+        // wrong one looks exactly like a right one on a panel that cannot be screenshotted.
+        Log.i(
+            TAG,
+            "shelf: ${books.size} books, sort=$sort, withNotes=${books.count { Books.hasNotes(it) }}, " +
+                "named=${books.count { Books.disambiguatingFileName(titleOf(it), it.name) != null }} — " +
+                books.take(4).joinToString(", ") { it.name },
+        )
         column.removeAllViews()
         column.addView(header(books))
 
@@ -135,6 +145,7 @@ class ShelfActivity : Activity() {
         contentDescription = "Sort by ${option.label}"
         setOnClickListener {
             if (option != sort) {
+                Log.i(TAG, "sort: $sort -> $option")
                 sort = option
                 prefs.edit().putString(KEY_SORT, option.name).apply()
                 render()
@@ -235,6 +246,7 @@ class ShelfActivity : Activity() {
             "Remove “$title” from inkread? This deletes inkread’s own copy and frees $freed. " +
                 "A file you imported stays where it is."
         }
+        Log.i(TAG, "remove dialog: ${book.name} hasNotes=$hasNotes (offers 'Remove with notes'=$hasNotes)")
         val dialog = AlertDialog.Builder(this, R.style.InkDialog)
             .setTitle("Remove from inkread")
             .setMessage(message)
@@ -277,6 +289,7 @@ class ShelfActivity : Activity() {
     }
 
     private companion object {
+        const val TAG = "ShelfActivity"
         const val PREFS = "shelf"
         const val KEY_SORT = "sort" // the reader's chosen order, kept between visits (#227).
     }

--- a/app/src/test/java/dev/jraghavan/inkread/ShelfFileNameTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ShelfFileNameTest.kt
@@ -1,0 +1,53 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Host JVM tests for [Books.disambiguatingFileName] (#227).
+ *
+ * A reader holding several copies of one work sees the same metadata title on every row, with no
+ * way to tell which file is which. The file name settles it — but only when it says something the
+ * title doesn't, or every row on an ordinary shelf grows a second line repeating itself.
+ */
+class ShelfFileNameTest {
+
+    @Test
+    fun aFileNamedAfterItsTitleAddsNothing() {
+        assertNull(Books.disambiguatingFileName("Moby-Dick", "Moby-Dick.epub"))
+    }
+
+    /** The case that motivated it: same work, different files. */
+    @Test
+    fun aFileNameThatDiffersFromTheTitleIsShown() {
+        assertEquals("moby-dick-v2.epub", Books.disambiguatingFileName("Moby-Dick", "moby-dick-v2.epub"))
+        assertEquals("Moby-Dick (1).epub", Books.disambiguatingFileName("Moby-Dick", "Moby-Dick (1).epub"))
+    }
+
+    /** Metadata titles arrive from EPUB packages with stray whitespace more often than not. */
+    @Test
+    fun surroundingWhitespaceInTheTitleIsNotADifference() {
+        assertNull(Books.disambiguatingFileName("  Moby-Dick ", "Moby-Dick.epub"))
+    }
+
+    /** A re-import can change only the case of a name; that is not worth a second line. */
+    @Test
+    fun caseAloneIsNotADifference() {
+        assertNull(Books.disambiguatingFileName("moby-dick", "Moby-Dick.epub"))
+    }
+
+    /** Only the final extension is stripped — a dotted title must still match its own file. */
+    @Test
+    fun onlyTheExtensionIsStripped() {
+        assertNull(Books.disambiguatingFileName("Vol. 1. Whales", "Vol. 1. Whales.pdf"))
+        assertEquals("vol1.pdf", Books.disambiguatingFileName("Vol. 1. Whales", "vol1.pdf"))
+    }
+
+    /** A file with no extension at all still compares against the whole name. */
+    @Test
+    fun anExtensionlessFileComparesWhole() {
+        assertNull(Books.disambiguatingFileName("notes", "notes"))
+        assertEquals("notes", Books.disambiguatingFileName("Reading list", "notes"))
+    }
+}

--- a/app/src/test/java/dev/jraghavan/inkread/ShelfNotesFlagTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ShelfNotesFlagTest.kt
@@ -1,0 +1,93 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Host JVM tests for [Books.hasNotes] — the `HAS NOTES` flag on the shelf (#227).
+ *
+ * The flag was reported as always-on, and it was: it tested whether the `.inkread` sidecar existed,
+ * but the core stamps a `metadata.json` in there on the first open of *any* document to bind the
+ * sidecar to that document's identity. So every book that had ever been opened claimed handwriting,
+ * which also made the Remove dialog warn about notes that were not there.
+ *
+ * These fixtures build the sidecar the way the core lays it out (`SidecarPaths`), so the shapes
+ * below are the real ones rather than an approximation of them.
+ */
+class ShelfNotesFlagTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun book(name: String = "book.epub"): File = tmp.newFile(name)
+
+    /** `book.epub` → sibling `book.inkread/`, as [Books.sidecarDir] maps it. */
+    private fun sidecar(book: File): File =
+        File(book.parentFile, "${book.nameWithoutExtension}.inkread").apply { mkdirs() }
+
+    private fun annotations(book: File): File =
+        File(sidecar(book), "annotations").apply { mkdirs() }
+
+    @Test
+    fun aBookThatWasNeverOpenedHasNoNotes() {
+        assertFalse(Books.hasNotes(book()))
+    }
+
+    /** The regression: opening a book stamps the sidecar, and that used to read as handwriting. */
+    @Test
+    fun anOpenedButUnannotatedBookHasNoNotes() {
+        val b = book()
+        File(sidecar(b), "metadata.json").writeText("""{"fingerprint":"abc"}""")
+        assertFalse("a stamped sidecar is not handwriting", Books.hasNotes(b))
+    }
+
+    /** An empty `annotations/` is what a page erased back to nothing leaves behind. */
+    @Test
+    fun anEmptyAnnotationsDirectoryHasNoNotes() {
+        val b = book()
+        annotations(b)
+        assertFalse(Books.hasNotes(b))
+    }
+
+    @Test
+    fun aCommittedStrokePageCountsAsNotes() {
+        val b = book()
+        File(annotations(b), "page-0001.inkbin").writeBytes(byteArrayOf(1, 2, 3))
+        assertTrue(Books.hasNotes(b))
+    }
+
+    /**
+     * A quarantined page is ink the reader can no longer see, so it must not claim otherwise — and
+     * the suffix must not be matched loosely, which `endsWith(".inkbin")` would have done.
+     */
+    @Test
+    fun aQuarantinedCorruptPageDoesNotCountAsNotes() {
+        val b = book()
+        File(annotations(b), "page-0001.inkbin.corrupt").writeBytes(byteArrayOf(1))
+        assertFalse(Books.hasNotes(b))
+    }
+
+    /** Exports and thumbnails share the sidecar and are not handwriting either. */
+    @Test
+    fun otherSidecarContentIsNotMistakenForNotes() {
+        val b = book()
+        File(sidecar(b), "exports").apply { mkdirs() }
+        File(File(sidecar(b), "exports"), "book-annotated.pdf").writeBytes(byteArrayOf(1))
+        File(sidecar(b), "thumbnails").apply { mkdirs() }
+        assertFalse(Books.hasNotes(b))
+    }
+
+    /** Two books in one directory must not borrow each other's ink. */
+    @Test
+    fun notesBelongToTheBookTheySitBeside() {
+        val annotated = book("annotated.epub")
+        val plain = book("plain.epub")
+        File(annotations(annotated), "page-0001.inkbin").writeBytes(byteArrayOf(1))
+        assertTrue(Books.hasNotes(annotated))
+        assertFalse(Books.hasNotes(plain))
+    }
+}

--- a/app/src/test/java/dev/jraghavan/inkread/ShelfSortTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ShelfSortTest.kt
@@ -1,0 +1,70 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+/**
+ * Host JVM tests for [Books.sortEntries] — the shelf's ordering (#227).
+ *
+ * A shelf with one order is only usable up to a point: past a few dozen books, "which did I read
+ * last" and "what is taking up the space" are the questions being asked, and alphabetical answers
+ * neither.
+ */
+class ShelfSortTest {
+
+    private fun entry(name: String, opened: Long = 0L, size: Long = 0L) =
+        Books.ShelfEntry(File("/books/$name.epub"), name, opened, size)
+
+    private fun names(entries: List<Books.ShelfEntry>) = entries.map { it.title }
+
+    @Test
+    fun titleOrdersAlphabeticallyIgnoringCase() {
+        val shelf = listOf(entry("zebra"), entry("Apple"), entry("mango"))
+        assertEquals(listOf("Apple", "mango", "zebra"), names(Books.sortEntries(shelf, Books.ShelfSort.TITLE)))
+    }
+
+    @Test
+    fun recentPutsTheMostRecentlyOpenedFirst() {
+        val shelf = listOf(entry("old", opened = 100), entry("newest", opened = 300), entry("mid", opened = 200))
+        assertEquals(listOf("newest", "mid", "old"), names(Books.sortEntries(shelf, Books.ShelfSort.RECENT)))
+    }
+
+    @Test
+    fun sizePutsTheBiggestFirstSoSpaceCanBeReclaimed() {
+        val shelf = listOf(entry("small", size = 10), entry("huge", size = 900), entry("mid", size = 100))
+        assertEquals(listOf("huge", "mid", "small"), names(Books.sortEntries(shelf, Books.ShelfSort.SIZE)))
+    }
+
+    /**
+     * Ties break on title in every mode. Without it the order of equal keys is whatever the
+     * filesystem handed back, so a shelf of never-opened books could reshuffle between visits — on
+     * a panel that repaints in whole frames, that reads as a glitch.
+     */
+    @Test
+    fun equalKeysFallBackToTitleSoTheOrderIsStable() {
+        val shelf = listOf(entry("pear", opened = 5), entry("apple", opened = 5), entry("fig", opened = 5))
+        assertEquals(listOf("apple", "fig", "pear"), names(Books.sortEntries(shelf, Books.ShelfSort.RECENT)))
+        assertEquals(listOf("apple", "fig", "pear"), names(Books.sortEntries(shelf.reversed(), Books.ShelfSort.RECENT)))
+    }
+
+    /** Books predating the last-opened stamp arrive as 0 and must sort last, not first. */
+    @Test
+    fun neverOpenedBooksSortAfterOpenedOnes() {
+        val shelf = listOf(entry("never", opened = 0), entry("read", opened = 50))
+        assertEquals(listOf("read", "never"), names(Books.sortEntries(shelf, Books.ShelfSort.RECENT)))
+    }
+
+    @Test
+    fun anEmptyShelfSortsToNothing() {
+        assertEquals(emptyList<String>(), names(Books.sortEntries(emptyList(), Books.ShelfSort.SIZE)))
+    }
+
+    /** A stored preference from a future build, or a corrupt one, must not strand the shelf. */
+    @Test
+    fun anUnknownStoredSortFallsBackToTitle() {
+        assertEquals(Books.ShelfSort.TITLE, Books.ShelfSort.of(null))
+        assertEquals(Books.ShelfSort.TITLE, Books.ShelfSort.of("SOMETHING_ELSE"))
+        assertEquals(Books.ShelfSort.RECENT, Books.ShelfSort.of("RECENT"))
+    }
+}


### PR DESCRIPTION
Addresses the seven items reported in #227. Two of them were defects rather than polish.

## Defects

**`HAS NOTES` was always on.** It tested whether the `.inkread` sidecar directory existed, but the
core stamps a `metadata.json` in there on the first open of *any* document, to bind the sidecar to
that document's identity — so every book that had ever been read claimed handwriting. The same
expression drove the Remove dialog, which therefore offered "Remove with notes" and warned that ink
was at stake for books that had none. `Books.hasNotes` now tests for a committed ink page, which is
written only when a stroke lands and deleted again when a page's last stroke is erased.

**The shelf could not be left.** It had no `finish()` anywhere, and the device provides no system
Back, so opening the shelf stranded the reader there. It now has a `‹ Home` link.

**Four dialogs were white on black.** They were built without the `InkDialog` theme and inherited
the platform's dark default. Sixteen others already pass it. Two are the reported shelf dialogs; the
same defect was in the OPDS download prompt and the Settings library sheet, and all four are fixed.

## Wording and affordances

**Remove says what it deletes.** "Remove X from this device" read as though the source document were
being deleted. Books live in app-private storage and an import copies the file in, so removal takes
inkread's own copy and never touches the original — the dialog now says so, and names the space
freed in both branches.

**Home's affordances were inverted.** The reading stats were outlined pills — this screen's button
shape — while the shelf link, the only thing on the page that navigates, was plain mono text. Stats
become a plain line; the shelf link takes the same pill as *Open a Document*.

## Additions

**File names, where the title is ambiguous.** A reader holding several copies of one work saw the
same line repeated with no way to reach the file name. It now appears on the shelf row and above the
reader's page scrubber — on both, only when it says something the title does not, so an ordinary
shelf gains no clutter. `Books.disambiguatingFileName` decides.

**Sorting by title, recency or size.** Alphabetical answers neither "which was I last in" nor "what
is taking up space". Recency needs a stamp that outlives the recents list, which keeps only the
newest handful, so the reader now stamps each open; books predating the stamp fall back to the
file's own timestamp. Every mode breaks ties on title so the order is stable between visits. The
choice is remembered.

## Tests

Three new host JVM suites — `ShelfNotesFlagTest` (sidecar shapes built as the core lays them out),
`ShelfFileNameTest`, `ShelfSortTest` — 121 Kotlin tests in total. The notes suite was checked against
a build with the old directory-existence test to confirm four of its cases fail there.

`cargo fmt`, `cargo clippy -D warnings`, `cargo test --workspace`, `:app:testDebugUnitTest` and the
licence check all pass; the release APK assembles.

## Not covered

Home's three-cover recents row does not show file names — the staggered cover cells have no room for
a second line, and the shelf and reader now answer the same question. Item 5 is otherwise complete.
