### PR TITLE
feat: table rows and a corner-docked horizontal tool palette (#200)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
@@ -16,6 +16,7 @@ object AppSettings {
     private const val KEY_UPDATE_SKIP_VERSION = "update_skip_version"
     private const val KEY_UPDATE_LAST_CHECK_MS = "update_last_check_ms"
     private const val KEY_TOOLBAR_HORIZONTAL = "toolbar_horizontal"
+    private const val KEY_TOOLBAR_ON_LEFT = "toolbar_on_left"
     private const val KEY_OPDS_URL = "opds_url"
     private const val KEY_OPDS_USER = "opds_user"
     private const val KEY_OPDS_PASSWORD = "opds_password"
@@ -57,6 +58,18 @@ object AppSettings {
 
     fun setToolbarHorizontal(c: Context, value: Boolean) =
         prefs(c).edit().putBoolean(KEY_TOOLBAR_HORIZONTAL, value).apply()
+
+    /**
+     * Which side the tool palette docks to — left when true, right by default (#200).
+     *
+     * Applies to both forms: the vertical pill hangs off that edge, and the horizontal bar lands in
+     * that top corner and grows inward from it. Right by default because that is where the palette
+     * has always been, and because it is the far edge from most readers' holding hand.
+     */
+    fun toolbarOnLeft(c: Context): Boolean = prefs(c).getBoolean(KEY_TOOLBAR_ON_LEFT, false)
+
+    fun setToolbarOnLeft(c: Context, value: Boolean) =
+        prefs(c).edit().putBoolean(KEY_TOOLBAR_ON_LEFT, value).apply()
 
     // ── Self-update (ADR-INKREAD-0014) ────────────────────────────────────────────────────────────
 

--- a/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
@@ -60,13 +60,19 @@ object AppSettings {
         prefs(c).edit().putBoolean(KEY_TOOLBAR_HORIZONTAL, value).apply()
 
     /**
-     * Which side the tool palette docks to — left when true, right by default (#200).
+     * Which side the tool palette docks to (#200).
      *
      * Applies to both forms: the vertical pill hangs off that edge, and the horizontal bar lands in
-     * that top corner and grows inward from it. Right by default because that is where the palette
-     * has always been, and because it is the far edge from most readers' holding hand.
+     * that top corner and grows inward from it.
+     *
+     * The default depends on the form, which is why this reads the orientation. The vertical pill
+     * has always hung off the right and stays there. The horizontal bar defaults **left**, because
+     * the top-right corner already holds the bookmark ribbon: docking there means standing off it by
+     * 14% of the page width, which leaves the strip floating oddly inboard of a corner it is
+     * supposed to be tucked into. Top-left has nothing to avoid, so it can sit flush.
      */
-    fun toolbarOnLeft(c: Context): Boolean = prefs(c).getBoolean(KEY_TOOLBAR_ON_LEFT, false)
+    fun toolbarOnLeft(c: Context): Boolean =
+        prefs(c).getBoolean(KEY_TOOLBAR_ON_LEFT, toolbarHorizontal(c))
 
     fun setToolbarOnLeft(c: Context, value: Boolean) =
         prefs(c).edit().putBoolean(KEY_TOOLBAR_ON_LEFT, value).apply()

--- a/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AppSettings.kt
@@ -15,6 +15,7 @@ object AppSettings {
     private const val KEY_AUTO_INSTALL_UPDATES = "auto_install_updates"
     private const val KEY_UPDATE_SKIP_VERSION = "update_skip_version"
     private const val KEY_UPDATE_LAST_CHECK_MS = "update_last_check_ms"
+    private const val KEY_TOOLBAR_HORIZONTAL = "toolbar_horizontal"
     private const val KEY_OPDS_URL = "opds_url"
     private const val KEY_OPDS_USER = "opds_user"
     private const val KEY_OPDS_PASSWORD = "opds_password"
@@ -40,6 +41,22 @@ object AppSettings {
 
     fun setOnlineLookup(c: Context, value: Boolean) =
         prefs(c).edit().putBoolean(KEY_ONLINE_LOOKUP, value).apply()
+
+    /**
+     * When true the floating tool palette runs **across the top** instead of down the right edge
+     * (#200).
+     *
+     * Off by default, because the vertical pill is what everyone has been using. The horizontal form
+     * exists because the two forms cost different things: the strip is a fixed, finger-sized width
+     * while the page margin is a fraction of the panel, so on a narrower device the pill is wider
+     * than the margin and clips the end of every line it spans — around twenty of them. Across the
+     * top it clips part of a single line instead, and the smaller the screen the bigger that
+     * difference is.
+     */
+    fun toolbarHorizontal(c: Context): Boolean = prefs(c).getBoolean(KEY_TOOLBAR_HORIZONTAL, false)
+
+    fun setToolbarHorizontal(c: Context, value: Boolean) =
+        prefs(c).edit().putBoolean(KEY_TOOLBAR_HORIZONTAL, value).apply()
 
     // ── Self-update (ADR-INKREAD-0014) ────────────────────────────────────────────────────────────
 

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -159,11 +159,23 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     /** The floating tool puck/palette overlay; created in onCreate. */
     private lateinit var toolPalette: ToolPalette
 
+    /** Whether the reader has asked for the tool palette to run across the top (#200). */
+    private val paletteHorizontal: Boolean get() = AppSettings.toolbarHorizontal(this)
+
+    /**
+     * Parked positions are kept **per orientation**.
+     *
+     * The two forms measure their offsets from different edges, so one set of fractions cannot mean
+     * the same place in both. Sharing a key would land the strip somewhere the reader never put it
+     * every time they changed the setting — legal, since it is clamped on screen, but arbitrary.
+     */
+    private fun paletteKey(axis: String) = if (paletteHorizontal) "${axis}_h" else axis
+
     /** The tool palette's last parked corner (#200), or null when it has never been moved. */
     private fun parkedPalettePosition(): ToolPalette.Position? =
         ToolPalette.Position.of(
-            prefs.getFloat(KEY_PALETTE_X, Float.NaN),
-            prefs.getFloat(KEY_PALETTE_Y, Float.NaN),
+            prefs.getFloat(paletteKey(KEY_PALETTE_X), Float.NaN),
+            prefs.getFloat(paletteKey(KEY_PALETTE_Y), Float.NaN),
         )
 
     // ---- lasso (ADR-INKREAD-0010) ----
@@ -529,9 +541,17 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             onRedo = { lasso.inkRedo() },
             // Reopen the toolbar where the reader last parked it (#200) rather than at the default
             // dock — repositioning it on every document open was the standing annoyance.
+            orientation = if (paletteHorizontal) {
+                ToolPalette.Orientation.HORIZONTAL
+            } else {
+                ToolPalette.Orientation.VERTICAL
+            },
             savedPosition = parkedPalettePosition(),
             onMoved = { at ->
-                prefs.edit().putFloat(KEY_PALETTE_X, at.x).putFloat(KEY_PALETTE_Y, at.y).apply()
+                prefs.edit()
+                    .putFloat(paletteKey(KEY_PALETTE_X), at.x)
+                    .putFloat(paletteKey(KEY_PALETTE_Y), at.y)
+                    .apply()
             },
         )
         selectionToolbar = SelectionToolbar(this, root) { action -> lasso.onSelectionAction(action) }

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -163,19 +163,15 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
     private val paletteHorizontal: Boolean get() = AppSettings.toolbarHorizontal(this)
 
     /**
-     * Parked positions are kept **per orientation**.
+     * The vertical pill's last parked spot (#200), or null when it has never been moved.
      *
-     * The two forms measure their offsets from different edges, so one set of fractions cannot mean
-     * the same place in both. Sharing a key would land the strip somewhere the reader never put it
-     * every time they changed the setting — legal, since it is clamped on screen, but arbitrary.
+     * Only the vertical form remembers a position. The horizontal bar docks to a corner chosen in
+     * Settings and opens there every time, so there is nothing free-form to store.
      */
-    private fun paletteKey(axis: String) = if (paletteHorizontal) "${axis}_h" else axis
-
-    /** The tool palette's last parked corner (#200), or null when it has never been moved. */
     private fun parkedPalettePosition(): ToolPalette.Position? =
         ToolPalette.Position.of(
-            prefs.getFloat(paletteKey(KEY_PALETTE_X), Float.NaN),
-            prefs.getFloat(paletteKey(KEY_PALETTE_Y), Float.NaN),
+            prefs.getFloat(KEY_PALETTE_X, Float.NaN),
+            prefs.getFloat(KEY_PALETTE_Y, Float.NaN),
         )
 
     // ---- lasso (ADR-INKREAD-0010) ----
@@ -546,12 +542,22 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             } else {
                 ToolPalette.Orientation.VERTICAL
             },
-            savedPosition = parkedPalettePosition(),
+            side = if (AppSettings.toolbarOnLeft(this)) {
+                ToolPalette.Anchor.START
+            } else {
+                ToolPalette.Anchor.END
+            },
+            // The horizontal bar is corner-docked, and the corner *is* its position: every book
+            // opens it collapsed there. It can still be dragged aside mid-read, but that is a
+            // this-book-only move and is deliberately not carried into the next one.
+            savedPosition = if (paletteHorizontal) null else parkedPalettePosition(),
             onMoved = { at ->
-                prefs.edit()
-                    .putFloat(paletteKey(KEY_PALETTE_X), at.x)
-                    .putFloat(paletteKey(KEY_PALETTE_Y), at.y)
-                    .apply()
+                if (!paletteHorizontal) {
+                    prefs.edit()
+                        .putFloat(KEY_PALETTE_X, at.x)
+                        .putFloat(KEY_PALETTE_Y, at.y)
+                        .apply()
+                }
             },
         )
         selectionToolbar = SelectionToolbar(this, root) { action -> lasso.onSelectionAction(action) }

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -14,6 +14,7 @@ import android.net.Uri
 import android.os.Environment
 import android.provider.Settings
 import android.os.Bundle
+import kotlin.math.ceil
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
@@ -546,6 +547,14 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 ToolPalette.Anchor.START
             } else {
                 ToolPalette.Anchor.END
+            },
+            // Docked into the top-right corner the strip lands on the bookmark ribbon — and, worse,
+            // inside its tap target, swallowing the touch that toggles a bookmark. Hold it clear.
+            dockClearance = if (AppSettings.toolbarOnLeft(this)) {
+                0
+            } else {
+                // Rounded up: truncating leaves the strip a fraction of a pixel inside the zone.
+                ceil(resources.displayMetrics.widthPixels * BOOKMARK_ZONE_W).toInt()
             },
             // The horizontal bar is corner-docked, and the corner *is* its position: every book
             // opens it collapsed there. It can still be dragged aside mid-read, but that is a
@@ -1442,7 +1451,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             }
         }
         // Top-right corner → toggle the bookmark dog-ear (Kindle/KOReader convention).
-        if (w > 0f && h > 0f && x > w * 0.86f && y < h * 0.08f) {
+        if (w > 0f && h > 0f && x > w * (1f - BOOKMARK_ZONE_W) && y < h * BOOKMARK_ZONE_H) {
             bottomBar.toggleBookmark()
             return
         }
@@ -1994,6 +2003,16 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val KEY_BOOK_PATH = "book_path" // stored PDF under app storage (RR27).
         const val KEY_BOOK_ID = "book_id" // stable per-book id (the stored file name).
         const val KEY_PEN_WIDTH = "pen_width" // selected pen thickness, an index into PEN_WIDTHS (#199).
+        /**
+         * The bookmark dog-ear's tap target: the top [BOOKMARK_ZONE_H] of the rightmost
+         * [BOOKMARK_ZONE_W] of the page, as fractions so it holds on any panel.
+         *
+         * Named because two things need it and they must not drift apart: the tap handler that
+         * toggles the bookmark, and the tool palette, which has to keep out of it (#200).
+         */
+        const val BOOKMARK_ZONE_W = 0.14f
+        const val BOOKMARK_ZONE_H = 0.08f
+
         const val KEY_PALETTE_X = "palette_x" // parked tool-palette corner, host fractions (#200).
         const val KEY_PALETTE_Y = "palette_y"
         const val PALM_REJECT_MS = 1000L // a finger tap within this long of a stylus event = palm.

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -560,6 +560,10 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             // opens it collapsed there. It can still be dragged aside mid-read, but that is a
             // this-book-only move and is deliberately not carried into the next one.
             savedPosition = if (paletteHorizontal) null else parkedPalettePosition(),
+            startExpanded = prefs.getBoolean(KEY_PALETTE_EXPANDED, false),
+            onExpandedChanged = { open ->
+                prefs.edit().putBoolean(KEY_PALETTE_EXPANDED, open).apply()
+            },
             onMoved = { at ->
                 if (!paletteHorizontal) {
                     prefs.edit()
@@ -661,7 +665,8 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             ReadingStats.record(this, minutes, (currentPage - sessionStartPage).coerceAtLeast(0))
         }
         sessionStartMs = 0L
-        if (::toolPalette.isInitialized) toolPalette.dismiss() // close any open palette popup
+        // The tool palette is deliberately NOT collapsed here. Whether the tools are out is the
+        // reader's working posture and survives leaving the app, the way the chosen tool does.
         if (::selectionToolbar.isInitialized) selectionToolbar.dismiss()
         if (::toolOptions.isInitialized) toolOptions.dismiss()
         mainHandler.removeCallbacks(fingerLongPress) // drop any pending finger gesture on leaving
@@ -2013,6 +2018,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         const val BOOKMARK_ZONE_W = 0.14f
         const val BOOKMARK_ZONE_H = 0.08f
 
+        const val KEY_PALETTE_EXPANDED = "palette_expanded" // tools out or put away (#200).
         const val KEY_PALETTE_X = "palette_x" // parked tool-palette corner, host fractions (#200).
         const val KEY_PALETTE_Y = "palette_y"
         const val PALM_REJECT_MS = 1000L // a finger tap within this long of a stylus event = palm.

--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -75,6 +75,24 @@ class SettingsActivity : Activity() {
             ) { onExportOverwriteTapped() },
         )
 
+        // ── Reading ────────────────────────────────────────────────────────────────
+        column.addView(spacer(dp(34)))
+        column.addView(eyebrow("Reading"))
+        column.addView(spacer(dp(12)))
+        column.addView(
+            toggleRow(
+                title = "Tool palette across the top",
+                desc = "Lay the annotation tools out horizontally at the top of the page instead " +
+                    "of vertically down the right edge. The palette is a fixed, finger-sized " +
+                    "width while the page margin is a fraction of the screen, so down the side it " +
+                    "clips the end of every line it covers; across the top it covers part of one " +
+                    "line. Takes effect the next time a document is opened.",
+                on = AppSettings.toolbarHorizontal(this),
+            ) {
+                AppSettings.setToolbarHorizontal(this, !AppSettings.toolbarHorizontal(this)); refresh()
+            },
+        )
+
         // ── Dictionary ─────────────────────────────────────────────────────────────
         column.addView(spacer(dp(34)))
         column.addView(eyebrow("Dictionary"))

--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -86,10 +86,24 @@ class SettingsActivity : Activity() {
                     "of vertically down the right edge. The palette is a fixed, finger-sized " +
                     "width while the page margin is a fraction of the screen, so down the side it " +
                     "clips the end of every line it covers; across the top it covers part of one " +
-                    "line. Takes effect the next time a document is opened.",
+                    "line. It opens collapsed in the corner each time, so it never covers " +
+                    "anything you did not just reach for. Takes effect the next time a document " +
+                    "is opened.",
                 on = AppSettings.toolbarHorizontal(this),
             ) {
                 AppSettings.setToolbarHorizontal(this, !AppSettings.toolbarHorizontal(this)); refresh()
+            },
+        )
+
+        column.addView(
+            toggleRow(
+                title = "Dock the tool palette on the left",
+                desc = "Put the palette against the left edge instead of the right — the left top " +
+                    "corner when it runs across the top. Takes effect the next time a document is " +
+                    "opened.",
+                on = AppSettings.toolbarOnLeft(this),
+            ) {
+                AppSettings.setToolbarOnLeft(this, !AppSettings.toolbarOnLeft(this)); refresh()
             },
         )
 

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -66,6 +66,14 @@ class ToolPalette(
     private val orientation: Orientation = Orientation.VERTICAL,
     /** Which side it docks to: [Anchor.END] is the right edge, [Anchor.START] the left. */
     private val side: Anchor = Anchor.END,
+    /**
+     * Extra clearance along the docked side, in pixels, for chrome the strip must not cover (#200).
+     *
+     * The host owns this because the host owns the chrome. A strip docked into a corner that already
+     * holds something does not merely look wrong — it eats the touches meant for it, since the strip
+     * consumes every event inside its bounds.
+     */
+    private val dockClearance: Int = 0,
     /** Where the reader last parked the pill (#200); null opens it at the default dock. */
     private val savedPosition: Position? = null,
     /** The pill came to rest somewhere new — persist it so the next document opens there (#200). */
@@ -113,8 +121,11 @@ class ToolPalette(
                 val sideGravity = if (side == Anchor.START) Gravity.START else Gravity.END
                 gravity = sideGravity or if (horizontal) Gravity.TOP else Gravity.CENTER_VERTICAL
                 val inset = dp(6)
+                // Clearance applies along the docked side, and only to the horizontal form: the
+                // vertical pill rides the middle of its edge and never reaches the corner.
+                val docked = inset + if (horizontal) dockClearance else 0
                 if (horizontal) topMargin = inset
-                if (side == Anchor.START) marginStart = inset else marginEnd = inset
+                if (side == Anchor.START) marginStart = docked else marginEnd = docked
             },
         )
         container.alpha = IDLE_ALPHA // see-through while reading so it doesn't cover the text

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -62,8 +62,10 @@ class ToolPalette(
     /** Global ink undo / redo (these are actions, not tools — they don't change the active tool). */
     private val onUndo: () -> Unit = {},
     private val onRedo: () -> Unit = {},
-    /** Which way the strip runs and which edge it docks to (#200). */
+    /** Which way the strip runs (#200). */
     private val orientation: Orientation = Orientation.VERTICAL,
+    /** Which side it docks to: [Anchor.END] is the right edge, [Anchor.START] the left. */
+    private val side: Anchor = Anchor.END,
     /** Where the reader last parked the pill (#200); null opens it at the default dock. */
     private val savedPosition: Position? = null,
     /** The pill came to rest somewhere new — persist it so the next document opens there (#200). */
@@ -81,9 +83,19 @@ class ToolPalette(
     private var expanded = false
     private val horizontal get() = orientation == Orientation.HORIZONTAL
 
-    /** Which host edge each axis is measured from, matching the container's layout gravity. */
-    private val axisX get() = if (horizontal) Anchor.CENTER else Anchor.END
+    /**
+     * Which host edge each axis is measured from, matching the container's layout gravity.
+     *
+     * Both forms dock to a side; only the cross axis differs. A horizontal bar sits against the top,
+     * so it lands in a corner — which is the point. Collapsed in the middle of the top edge it would
+     * float in the centre of the page with nothing to relate to, and expanding from there pushed it
+     * hard against one side with 920px of dead space behind it.
+     */
+    private val axisX get() = side
     private val axisY get() = if (horizontal) Anchor.START else Anchor.CENTER
+
+    /** The axis the strip grows along when it expands — the one it is laid out on. */
+    private val growthAxis get() = if (horizontal) axisX else axisY
 
     private val container = LinearLayout(activity).apply {
         this.orientation = if (horizontal) LinearLayout.HORIZONTAL else LinearLayout.VERTICAL
@@ -98,12 +110,11 @@ class ToolPalette(
             ).apply {
                 // The docked edge is the one the strip runs along: a vertical pill hugs the
                 // right, a horizontal bar sits across the top, which is where it was asked for.
-                gravity = if (horizontal) {
-                    Gravity.TOP or Gravity.CENTER_HORIZONTAL
-                } else {
-                    Gravity.END or Gravity.CENTER_VERTICAL
-                }
-                if (horizontal) topMargin = dp(6) else marginEnd = dp(6)
+                val sideGravity = if (side == Anchor.START) Gravity.START else Gravity.END
+                gravity = sideGravity or if (horizontal) Gravity.TOP else Gravity.CENTER_VERTICAL
+                val inset = dp(6)
+                if (horizontal) topMargin = inset
+                if (side == Anchor.START) marginStart = inset else marginEnd = inset
             },
         )
         container.alpha = IDLE_ALPHA // see-through while reading so it doesn't cover the text
@@ -191,12 +202,18 @@ class ToolPalette(
             } else {
                 container.setPadding(dp(5), dp(7), dp(5), dp(7))
             }
-            container.addView(handle()) // grip: collapse / move
-            container.addView(divider())
-            for (tool in Tool.values()) container.addView(iconButton(tool))
-            container.addView(divider())
-            container.addView(actionButton(R.drawable.ic_sel_undo, "Undo", onUndo))
-            container.addView(actionButton(R.drawable.ic_sel_redo, "Redo", onRedo))
+            // The grip belongs on the docked edge, so the strip grows inward from it and the grip
+            // itself never moves. Docked right, that means building the row back to front.
+            val parts = buildList {
+                add(handle()) // grip: collapse / move
+                add(divider())
+                for (tool in Tool.values()) add(iconButton(tool))
+                add(divider())
+                add(actionButton(R.drawable.ic_sel_undo, "Undo", onUndo))
+                add(actionButton(R.drawable.ic_sel_redo, "Redo", onRedo))
+            }
+            val ordered = if (horizontal && side == Anchor.END) parts.reversed() else parts
+            for (view in ordered) container.addView(view)
         } else {
             // Collapsed: a circular inkwell puck — tap to expand, drag to move.
             container.background = circle()
@@ -330,14 +347,22 @@ class ToolPalette(
      * and the only way to collapse the pill again.
      */
     private fun reanchor(sizeBefore: Int, onSettled: () -> Unit) = onNextLayout { width, height ->
-        // The strip grows along its own axis, so that is the one whose leading edge must be held.
+        // Only the axis the strip grows along needs its docked edge held; the other just re-clamps.
         if (horizontal) {
-            container.translationX =
-                clamp(axisX, keepEdge(axisX, container.translationX, sizeBefore, width), host.width, width)
+            container.translationX = clamp(
+                axisX,
+                keepEdge(growthAxis, container.translationX, sizeBefore, width),
+                host.width,
+                width,
+            )
             container.translationY = clamp(axisY, container.translationY, host.height, height)
         } else {
-            container.translationY =
-                clamp(axisY, keepEdge(axisY, container.translationY, sizeBefore, height), host.height, height)
+            container.translationY = clamp(
+                axisY,
+                keepEdge(growthAxis, container.translationY, sizeBefore, height),
+                host.height,
+                height,
+            )
             container.translationX = clamp(axisX, container.translationX, host.width, width)
         }
         onSettled()
@@ -502,22 +527,19 @@ class ToolPalette(
             keepEdge(Anchor.CENTER, ty, oldHeight, newHeight)
 
         /**
-         * The offset that keeps the view's **leading edge** still when it changes size along the
-         * axis it grows on.
+         * The offset that keeps the strip's **docked edge** still when it grows or shrinks.
          *
-         * The leading edge is where the grip is: the thing the finger just tapped, and the only way
-         * to collapse the strip again. Under a `CENTER` anchor a size change moves that edge by half
-         * the difference unless the offset compensates; under `END` it moves by the whole
-         * difference; under `START` it does not move at all.
+         * The docked edge is the one the grip sits on — the thing the finger just tapped, and the
+         * only way to collapse the strip again. A strip anchored to an edge already holds that edge
+         * for free: under `START` the near edge is the offset itself, and under `END` the far edge
+         * is `host + offset`, neither of which involves the strip's size. Only `CENTER` has to
+         * compensate, by half the growth, because a centred strip grows both ways.
          */
-        fun keepEdge(anchor: Anchor, offset: Float, oldSize: Int, newSize: Int): Float {
-            val grew = (newSize - oldSize).toFloat()
-            return when (anchor) {
-                Anchor.START -> offset
-                Anchor.CENTER -> offset + grew / 2f
-                Anchor.END -> offset + grew
+        fun keepEdge(anchor: Anchor, offset: Float, oldSize: Int, newSize: Int): Float =
+            when (anchor) {
+                Anchor.START, Anchor.END -> offset
+                Anchor.CENTER -> offset + (newSize - oldSize) / 2f
             }
-        }
 
         /**
          * Where the pill's **top-left corner** sits, as a fraction of the host's width and height.

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -62,6 +62,8 @@ class ToolPalette(
     /** Global ink undo / redo (these are actions, not tools — they don't change the active tool). */
     private val onUndo: () -> Unit = {},
     private val onRedo: () -> Unit = {},
+    /** Which way the strip runs and which edge it docks to (#200). */
+    private val orientation: Orientation = Orientation.VERTICAL,
     /** Where the reader last parked the pill (#200); null opens it at the default dock. */
     private val savedPosition: Position? = null,
     /** The pill came to rest somewhere new — persist it so the next document opens there (#200). */
@@ -77,7 +79,15 @@ class ToolPalette(
     // Opens collapsed (a small circular inkwell puck) so it never covers the text on document open;
     // tap to expand into the tool strip.
     private var expanded = false
-    private val container = LinearLayout(activity).apply { orientation = LinearLayout.VERTICAL }
+    private val horizontal get() = orientation == Orientation.HORIZONTAL
+
+    /** Which host edge each axis is measured from, matching the container's layout gravity. */
+    private val axisX get() = if (horizontal) Anchor.CENTER else Anchor.END
+    private val axisY get() = if (horizontal) Anchor.START else Anchor.CENTER
+
+    private val container = LinearLayout(activity).apply {
+        this.orientation = if (horizontal) LinearLayout.HORIZONTAL else LinearLayout.VERTICAL
+    }
 
     init {
         host.addView(
@@ -86,8 +96,14 @@ class ToolPalette(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT,
             ).apply {
-                gravity = Gravity.END or Gravity.CENTER_VERTICAL
-                marginEnd = dp(6)
+                // The docked edge is the one the strip runs along: a vertical pill hugs the
+                // right, a horizontal bar sits across the top, which is where it was asked for.
+                gravity = if (horizontal) {
+                    Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                } else {
+                    Gravity.END or Gravity.CENTER_VERTICAL
+                }
+                if (horizontal) topMargin = dp(6) else marginEnd = dp(6)
             },
         )
         container.alpha = IDLE_ALPHA // see-through while reading so it doesn't cover the text
@@ -105,8 +121,8 @@ class ToolPalette(
      * the pill would sit at the default dock on the panel while being somewhere else to the touch.
      */
     private fun restore(position: Position) = onNextLayout { width, height ->
-        container.translationX = translationXFor(position.x, host.width, width)
-        container.translationY = translationYFor(position.y, host.height, height)
+        container.translationX = offsetForFraction(axisX, position.x, host.width, width)
+        container.translationY = offsetForFraction(axisY, position.y, host.height, height)
         reattach()
         onChrome()
     }
@@ -150,8 +166,8 @@ class ToolPalette(
         if (host.width <= 0 || host.height <= 0 || container.width <= 0 || container.height <= 0) return
         onMoved(
             Position(
-                fractionX(container.translationX, host.width, container.width),
-                fractionY(container.translationY, host.height, container.height),
+                fraction(axisX, container.translationX, host.width, container.width),
+                fraction(axisY, container.translationY, host.height, container.height),
             ),
         )
     }
@@ -170,7 +186,11 @@ class ToolPalette(
         container.removeAllViews()
         if (expanded) {
             container.background = pill()
-            container.setPadding(dp(5), dp(7), dp(5), dp(7))
+            if (horizontal) {
+                container.setPadding(dp(7), dp(5), dp(7), dp(5))
+            } else {
+                container.setPadding(dp(5), dp(7), dp(5), dp(7))
+            }
             container.addView(handle()) // grip: collapse / move
             container.addView(divider())
             for (tool in Tool.values()) container.addView(iconButton(tool))
@@ -200,9 +220,17 @@ class ToolPalette(
     /** A hairline separator between the handle, the tools, and the undo/redo actions. */
     private fun divider(): View = View(activity).apply {
         setBackgroundColor(Ink.hairline)
-        layoutParams = LinearLayout.LayoutParams(dp(42), Ink.hair()).apply {
-            gravity = Gravity.CENTER_HORIZONTAL
-            val v = dp(4); setMargins(0, v, 0, v)
+        // The separator runs across the strip, so it swaps axis with it.
+        layoutParams = if (horizontal) {
+            LinearLayout.LayoutParams(Ink.hair(), dp(42)).apply {
+                gravity = Gravity.CENTER_VERTICAL
+                val h = dp(4); setMargins(h, 0, h, 0)
+            }
+        } else {
+            LinearLayout.LayoutParams(dp(42), Ink.hair()).apply {
+                gravity = Gravity.CENTER_HORIZONTAL
+                val v = dp(4); setMargins(0, v, 0, v)
+            }
         }
     }
 
@@ -252,9 +280,9 @@ class ToolPalette(
                     if (!moved && kotlin.math.hypot(dx, dy) > touchSlop) moved = true
                     if (moved) {
                         container.translationX =
-                            clampX(startTx + dx, host.width, container.width)
+                            clamp(axisX, startTx + dx, host.width, container.width)
                         container.translationY =
-                            clampY(startTy + dy, host.height, container.height)
+                            clamp(axisY, startTy + dy, host.height, container.height)
                     }
                     true
                 }
@@ -282,10 +310,10 @@ class ToolPalette(
      * next layout pass rather than here.
      */
     private fun toggleExpanded() {
-        val heightBefore = container.height
+        val sizeBefore = if (horizontal) container.width else container.height
         expanded = !expanded
         render()
-        reanchor(heightBefore) {
+        reanchor(sizeBefore) {
             reattach()
             persist() // the clamp may have nudged the pill; remember where it actually landed
             onChrome()
@@ -301,10 +329,17 @@ class ToolPalette(
      * the offset compensates. The corner is where the grip is — the thing the finger just tapped,
      * and the only way to collapse the pill again.
      */
-    private fun reanchor(heightBefore: Int, onSettled: () -> Unit) = onNextLayout { width, height ->
-        container.translationY =
-            clampY(anchorY(container.translationY, heightBefore, height), host.height, height)
-        container.translationX = clampX(container.translationX, host.width, width)
+    private fun reanchor(sizeBefore: Int, onSettled: () -> Unit) = onNextLayout { width, height ->
+        // The strip grows along its own axis, so that is the one whose leading edge must be held.
+        if (horizontal) {
+            container.translationX =
+                clamp(axisX, keepEdge(axisX, container.translationX, sizeBefore, width), host.width, width)
+            container.translationY = clamp(axisY, container.translationY, host.height, height)
+        } else {
+            container.translationY =
+                clamp(axisY, keepEdge(axisY, container.translationY, sizeBefore, height), host.height, height)
+            container.translationX = clamp(axisX, container.translationX, host.width, width)
+        }
         onSettled()
     }
 
@@ -359,11 +394,30 @@ class ToolPalette(
      */
     fun dismiss() {
         if (!expanded) return
-        val heightBefore = container.height
+        val sizeBefore = if (horizontal) container.width else container.height
         expanded = false
         render()
-        reanchor(heightBefore) {}
+        reanchor(sizeBefore) {}
     }
+
+    /**
+     * Which edge of the host an axis is measured from — the layout gravity, as arithmetic.
+     *
+     * A vertical pill hangs off the right edge and is centred down the page; a horizontal bar
+     * sits against the top and is centred across it. The same offset therefore means different
+     * things on different axes, and every clamp, fraction and re-anchor below has to know which.
+     */
+    enum class Anchor { START, CENTER, END }
+
+    /**
+     * Which way the strip runs (#200).
+     *
+     * Both forms are the same strip; only the axis it grows along and the edge it docks to differ.
+     * [HORIZONTAL] answers the request for a toolbar across the top: on a narrow panel a vertical
+     * pill is wider than the page margin, so it clips the end of every line it spans -- twenty of
+     * them -- while a horizontal one at the top clips part of a single line.
+     */
+    enum class Orientation { VERTICAL, HORIZONTAL }
 
     /**
      * A parked position for the pill, held as host-relative fractions (#200). Persisted by the
@@ -387,15 +441,45 @@ class ToolPalette(
         /** Resting opacity of the docked puck — translucent so the text behind it stays readable. */
         const val IDLE_ALPHA = 0.55f
 
-        /**
-         * Clamp the horizontal offset so the pill stays inside the host. The base anchor is
-         * `END`, so the pill only ever moves left: the offset is negative, bounded by how much
-         * wider the host is than the pill.
-         */
-        fun clampX(tx: Float, hostWidth: Int, viewWidth: Int): Float {
-            val min = -(hostWidth - viewWidth).toFloat().coerceAtLeast(0f)
-            return tx.coerceIn(min, 0f)
+        /** Where the view's leading edge sits, given its anchor and offset. */
+        fun edge(anchor: Anchor, offset: Float, host: Int, view: Int): Float {
+            val slack = (host - view).toFloat()
+            return when (anchor) {
+                Anchor.START -> offset
+                Anchor.CENTER -> slack / 2f + offset
+                Anchor.END -> slack + offset
+            }
         }
+
+        /** The offset that puts the view's leading edge at [edge] — the inverse of [edge]. */
+        fun offsetFor(anchor: Anchor, edge: Float, host: Int, view: Int): Float {
+            val slack = (host - view).toFloat()
+            return when (anchor) {
+                Anchor.START -> edge
+                Anchor.CENTER -> edge - slack / 2f
+                Anchor.END -> edge - slack
+            }
+        }
+
+        /**
+         * Clamp an offset so the view stays inside the host, whichever edge it is anchored to.
+         *
+         * A view with no slack — larger than its host — stays where its gravity puts it rather than
+         * being pushed to an edge: some of it is off screen whatever we do, and moving it would only
+         * change which part.
+         */
+        fun clamp(anchor: Anchor, offset: Float, host: Int, view: Int): Float {
+            val slack = (host - view).toFloat()
+            if (slack <= 0f) return 0f
+            return offsetFor(anchor, edge(anchor, offset, host, view).coerceIn(0f, slack), host, view)
+        }
+
+        /**
+         * Clamp the horizontal offset of a *vertical* pill, which hangs off the `END` edge.
+         * Kept as its own name because that is what the vertical form's call sites mean.
+         */
+        fun clampX(tx: Float, hostWidth: Int, viewWidth: Int): Float =
+            clamp(Anchor.END, tx, hostWidth, viewWidth)
 
         /**
          * Clamp the vertical offset so the pill stays inside the host. The base anchor is
@@ -403,10 +487,8 @@ class ToolPalette(
          * half the slack. A pill taller than the host has no slack at all and stays centred, which
          * is the least-bad answer: some of it is off screen whatever we do.
          */
-        fun clampY(ty: Float, hostHeight: Int, viewHeight: Int): Float {
-            val half = ((hostHeight - viewHeight) / 2f).coerceAtLeast(0f)
-            return ty.coerceIn(-half, half)
-        }
+        fun clampY(ty: Float, hostHeight: Int, viewHeight: Int): Float =
+            clamp(Anchor.CENTER, ty, hostHeight, viewHeight)
 
         /**
          * The vertical offset that keeps the pill's **top** where it was when its height changes
@@ -417,7 +499,25 @@ class ToolPalette(
          * which is what the finger just tapped and what has to stay reachable.
          */
         fun anchorY(ty: Float, oldHeight: Int, newHeight: Int): Float =
-            ty + (newHeight - oldHeight) / 2f
+            keepEdge(Anchor.CENTER, ty, oldHeight, newHeight)
+
+        /**
+         * The offset that keeps the view's **leading edge** still when it changes size along the
+         * axis it grows on.
+         *
+         * The leading edge is where the grip is: the thing the finger just tapped, and the only way
+         * to collapse the strip again. Under a `CENTER` anchor a size change moves that edge by half
+         * the difference unless the offset compensates; under `END` it moves by the whole
+         * difference; under `START` it does not move at all.
+         */
+        fun keepEdge(anchor: Anchor, offset: Float, oldSize: Int, newSize: Int): Float {
+            val grew = (newSize - oldSize).toFloat()
+            return when (anchor) {
+                Anchor.START -> offset
+                Anchor.CENTER -> offset + grew / 2f
+                Anchor.END -> offset + grew
+            }
+        }
 
         /**
          * Where the pill's **top-left corner** sits, as a fraction of the host's width and height.
@@ -427,11 +527,14 @@ class ToolPalette(
          * size changing between its collapsed and expanded forms. The corner is where the grip is,
          * which is the part the reader actually aims at.
          */
+        fun fraction(anchor: Anchor, offset: Float, host: Int, view: Int): Float =
+            if (host <= 0) 0f else edge(anchor, offset, host, view) / host
+
         fun fractionX(tx: Float, hostWidth: Int, viewWidth: Int): Float =
-            if (hostWidth <= 0) 0f else ((hostWidth - viewWidth) + tx) / hostWidth
+            fraction(Anchor.END, tx, hostWidth, viewWidth)
 
         fun fractionY(ty: Float, hostHeight: Int, viewHeight: Int): Float =
-            if (hostHeight <= 0) 0f else ((hostHeight - viewHeight) / 2f + ty) / hostHeight
+            fraction(Anchor.CENTER, ty, hostHeight, viewHeight)
 
         /**
          * Turn a remembered [fractionX] back into a horizontal offset for the *current* geometry,
@@ -442,18 +545,17 @@ class ToolPalette(
          * a position that was legal then can be off screen now. Restoring the pill out of reach
          * would recreate the very trap #200 was opened about.
          */
-        fun translationXFor(fraction: Float, hostWidth: Int, viewWidth: Int): Float =
-            if (hostWidth <= 0 || !fraction.isFinite()) {
+        fun offsetForFraction(anchor: Anchor, fraction: Float, host: Int, view: Int): Float =
+            if (host <= 0 || !fraction.isFinite()) {
                 0f
             } else {
-                clampX(fraction * hostWidth - (hostWidth - viewWidth), hostWidth, viewWidth)
+                clamp(anchor, offsetFor(anchor, fraction * host, host, view), host, view)
             }
 
+        fun translationXFor(fraction: Float, hostWidth: Int, viewWidth: Int): Float =
+            offsetForFraction(Anchor.END, fraction, hostWidth, viewWidth)
+
         fun translationYFor(fraction: Float, hostHeight: Int, viewHeight: Int): Float =
-            if (hostHeight <= 0 || !fraction.isFinite()) {
-                0f
-            } else {
-                clampY(fraction * hostHeight - (hostHeight - viewHeight) / 2f, hostHeight, viewHeight)
-            }
+            offsetForFraction(Anchor.CENTER, fraction, hostHeight, viewHeight)
     }
 }

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -78,6 +78,10 @@ class ToolPalette(
     private val savedPosition: Position? = null,
     /** The pill came to rest somewhere new — persist it so the next document opens there (#200). */
     private val onMoved: (Position) -> Unit = {},
+    /** Whether to open already expanded — the state the reader last left it in (#200). */
+    private val startExpanded: Boolean = false,
+    /** The reader opened or closed the strip; remember it for the next book (#200). */
+    private val onExpandedChanged: (Boolean) -> Unit = {},
 ) {
     var current: Tool = Tool.PEN
         private set
@@ -86,9 +90,15 @@ class ToolPalette(
     private fun dp(v: Int) = (v * density).toInt()
     private val touchSlop = ViewConfiguration.get(activity).scaledTouchSlop
 
-    // Opens collapsed (a small circular inkwell puck) so it never covers the text on document open;
-    // tap to expand into the tool strip.
-    private var expanded = false
+    /**
+     * Open or shut, carried over from the last book (#200).
+     *
+     * Not reset on open. Whether the tools are out is a working posture, not a per-document
+     * property: a reader who is annotating opens the next book to annotate it too, and having to
+     * reach for the strip again each time is friction in exactly the place they were trying to
+     * avoid it.
+     */
+    private var expanded = startExpanded
     private val horizontal get() = orientation == Orientation.HORIZONTAL
 
     /**
@@ -340,6 +350,7 @@ class ToolPalette(
     private fun toggleExpanded() {
         val sizeBefore = if (horizontal) container.width else container.height
         expanded = !expanded
+        onExpandedChanged(expanded)
         render()
         reanchor(sizeBefore) {
             reattach()
@@ -418,22 +429,6 @@ class ToolPalette(
         container.translationX = tx
         container.translationY = ty
         android.util.Log.i("ToolPalette", "reattach: expanded=$expanded tx=$tx ty=$ty")
-    }
-
-    /**
-     * Collapse the pill (call from the host's onPause) — it stays docked, never removed.
-     *
-     * Re-anchored like any other collapse: this used to shrink the pill without compensating, so
-     * backgrounding the app and returning to it left the puck half the pill's height further down
-     * the screen than the reader had put it. Nothing is persisted or repainted here — the panel is
-     * going away, and the corner the reader chose was already recorded when they chose it.
-     */
-    fun dismiss() {
-        if (!expanded) return
-        val sizeBefore = if (horizontal) container.width else container.height
-        expanded = false
-        render()
-        reanchor(sizeBefore) {}
     }
 
     /**

--- a/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
@@ -330,4 +330,22 @@ class ToolPalettePlacementTest {
             assertEquals("$anchor", 0f, ToolPalette.clamp(anchor, -500f, 0, 0), 0.01f)
         }
     }
+
+    /**
+     * The strip must not sit in the bookmark dog-ear's corner (#200).
+     *
+     * Not a cosmetic clash: the palette consumes every touch inside its bounds, so a puck parked in
+     * that corner silently eats the tap that toggles a bookmark. Measured on a 1920px panel the puck
+     * landed at x 1789..1909 — wholly inside the zone, which starts at 1651.
+     */
+    @Test
+    fun aTopRightStripClearsTheBookmarkTapZone() {
+        val clearance = kotlin.math.ceil(hostW * ReaderActivity.BOOKMARK_ZONE_W).toInt()
+        val zoneStartsAt = hostW * (1f - ReaderActivity.BOOKMARK_ZONE_W)
+        val stripRightEdge = hostW - clearance
+        assertTrue(
+            "the strip's right edge ($stripRightEdge) must not enter the zone (from $zoneStartsAt)",
+            stripRightEdge <= zoneStartsAt + 0.5f,
+        )
+    }
 }

--- a/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
@@ -1,5 +1,6 @@
 package dev.jraghavan.inkread
 
+import dev.jraghavan.inkread.ToolPalette.Anchor
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -213,5 +214,105 @@ class ToolPalettePlacementTest {
         assertEquals(0f, ToolPalette.fractionY(10f, 0, 0), 0.01f)
         assertEquals(0f, ToolPalette.translationXFor(0.5f, 0, 0), 0.01f)
         assertEquals(0f, ToolPalette.translationYFor(0.5f, 0, 0), 0.01f)
+    }
+
+    // ── The horizontal form: same strip, different axis (#200) ────────────────────────────────────
+
+    /** A horizontal bar docks TOP and centres across the width; a vertical pill is END/CENTER. */
+    @Test
+    fun eachAnchorMeasuresFromItsOwnEdge() {
+        assertEquals("START counts from the top/left", 0f, ToolPalette.edge(Anchor.START, 0f, hostH, pill), 0.5f)
+        assertEquals(
+            "CENTER leaves half the slack before it",
+            (hostH - pill) / 2f,
+            ToolPalette.edge(Anchor.CENTER, 0f, hostH, pill),
+            0.5f,
+        )
+        assertEquals(
+            "END sits flush against the far edge",
+            (hostH - pill).toFloat(),
+            ToolPalette.edge(Anchor.END, 0f, hostH, pill),
+            0.5f,
+        )
+    }
+
+    /** Offsets and edges must invert exactly, or a saved position drifts every time it round-trips. */
+    @Test
+    fun edgeAndOffsetAreInverses() {
+        for (anchor in Anchor.entries) {
+            for (offset in listOf(-500f, -1f, 0f, 1f, 500f)) {
+                val e = ToolPalette.edge(anchor, offset, hostH, pill)
+                assertEquals(
+                    "$anchor did not round-trip at $offset",
+                    offset,
+                    ToolPalette.offsetFor(anchor, e, hostH, pill),
+                    0.01f,
+                )
+            }
+        }
+    }
+
+    /** Whatever the anchor, the strip must end up inside the host — that is the whole job. */
+    @Test
+    fun everyAnchorClampsTheStripInsideTheHost() {
+        for (anchor in Anchor.entries) {
+            for (offset in listOf(-99_999f, 99_999f)) {
+                val clamped = ToolPalette.clamp(anchor, offset, hostH, pill)
+                val leading = ToolPalette.edge(anchor, clamped, hostH, pill)
+                assertTrue("$anchor ran off the near edge: $leading", leading >= -0.5f)
+                assertTrue(
+                    "$anchor ran off the far edge: ${leading + pill}",
+                    leading + pill <= hostH + 0.5f,
+                )
+            }
+        }
+    }
+
+    /**
+     * A top-docked bar grows downward from a fixed top edge, so expanding must not move it at all.
+     * Under CENTER it would drift by half the growth — which is the bug this maths exists to stop,
+     * in its horizontal form.
+     */
+    @Test
+    fun aTopDockedBarDoesNotDriftWhenItExpands() {
+        val parked = 300f
+        assertEquals(
+            "a START-anchored strip keeps its offset when it grows",
+            parked,
+            ToolPalette.keepEdge(Anchor.START, parked, puck, pill),
+            0.01f,
+        )
+        assertEquals(
+            "a CENTER-anchored strip must compensate by half the growth",
+            parked + (pill - puck) / 2f,
+            ToolPalette.keepEdge(Anchor.CENTER, parked, puck, pill),
+            0.01f,
+        )
+    }
+
+    /** A parked horizontal bar must survive a round trip on its own anchors, like the vertical one. */
+    @Test
+    fun aHorizontalBarComesBackWhereItWasParked() {
+        val tx = -240f // centred across the width, nudged left
+        val ty = 120f // measured down from the top edge
+        assertEquals(
+            tx,
+            ToolPalette.offsetForFraction(Anchor.CENTER, ToolPalette.fraction(Anchor.CENTER, tx, hostW, pill), hostW, pill),
+            0.5f,
+        )
+        assertEquals(
+            ty,
+            ToolPalette.offsetForFraction(Anchor.START, ToolPalette.fraction(Anchor.START, ty, hostH, puck), hostH, puck),
+            0.5f,
+        )
+    }
+
+    /** A strip wider than its host has no good answer; it must not throw or invert its bounds. */
+    @Test
+    fun anOversizedStripIsClampedRatherThanCrashing() {
+        for (anchor in Anchor.entries) {
+            assertEquals("$anchor", 0f, ToolPalette.clamp(anchor, 500f, 100, 4000), 0.01f)
+            assertEquals("$anchor", 0f, ToolPalette.clamp(anchor, -500f, 0, 0), 0.01f)
+        }
     }
 }

--- a/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolPalettePlacementTest.kt
@@ -274,20 +274,35 @@ class ToolPalettePlacementTest {
      * in its horizontal form.
      */
     @Test
-    fun aTopDockedBarDoesNotDriftWhenItExpands() {
+    fun aCornerDockedStripDoesNotDriftWhenItExpands() {
         val parked = 300f
+        // A strip anchored to an edge holds that edge for free — its offset does not involve size.
+        assertEquals(parked, ToolPalette.keepEdge(Anchor.START, parked, puck, pill), 0.01f)
+        assertEquals(parked, ToolPalette.keepEdge(Anchor.END, parked, puck, pill), 0.01f)
+        // Only a centred strip grows both ways and has to compensate.
         assertEquals(
-            "a START-anchored strip keeps its offset when it grows",
-            parked,
-            ToolPalette.keepEdge(Anchor.START, parked, puck, pill),
-            0.01f,
-        )
-        assertEquals(
-            "a CENTER-anchored strip must compensate by half the growth",
             parked + (pill - puck) / 2f,
             ToolPalette.keepEdge(Anchor.CENTER, parked, puck, pill),
             0.01f,
         )
+    }
+
+    /**
+     * The measured bug this replaces: expanded from the centre of a 1920px panel the strip ended up
+     * 920px from the left and 32px from the right, because growth ran outward from the grip instead
+     * of the strip being anchored to a corner at all. Docked, the edge it grows from cannot move.
+     */
+    @Test
+    fun aCornerDockedStripKeepsItsDockedEdgeExactly() {
+        val host = 1920
+        for ((anchor, edgeOf) in listOf<Pair<Anchor, (Float, Int) -> Float>>(
+            Anchor.START to { off, view -> ToolPalette.edge(Anchor.START, off, host, view) },
+            Anchor.END to { off, view -> ToolPalette.edge(Anchor.END, off, host, view) + view },
+        )) {
+            val before = edgeOf(0f, puck)
+            val after = edgeOf(ToolPalette.keepEdge(anchor, 0f, puck, pill), pill)
+            assertEquals("$anchor moved its docked edge", before, after, 0.5f)
+        }
     }
 
     /** A parked horizontal bar must survive a round trip on its own anchors, like the vertical one. */

--- a/inkread-epub/src/content.rs
+++ b/inkread-epub/src/content.rs
@@ -66,6 +66,17 @@ pub enum Block {
         /// What the book's stylesheet declared for this block (#188).
         style: BlockStyle,
     },
+    /// One row of a `<table>`, its cells laid side by side (#200).
+    ///
+    /// Tables are how parallel texts are built — a bilingual juxtalinear edition puts the original
+    /// in one cell and the translation in the next, and reading it means reading *across*. Treated
+    /// as an unknown container the grid flattens into document order, which is row-by-row then
+    /// cell-by-cell, so the two languages interleave down the page and the correspondence the book
+    /// is entirely about is lost.
+    Row {
+        cells: Vec<Vec<Inline>>,
+        style: BlockStyle,
+    },
     /// A standalone (block-level) image.
     Image { src: String, alt: String },
     /// A horizontal rule (`<hr/>`) — a section divider.
@@ -231,6 +242,10 @@ fn walk_blocks(
                         flush_paragraph(out, pending, inherited);
                         out.push(Block::Rule);
                     }
+                    "table" => {
+                        flush_paragraph(out, pending, inherited);
+                        walk_table(child, out, sheet, declared(child, el, sheet, inherited));
+                    }
                     "ul" | "ol" => {
                         flush_paragraph(out, pending, inherited);
                         walk_list(
@@ -266,6 +281,55 @@ fn walk_blocks(
                         walk_blocks(child, out, pending, sheet, inner);
                         flush_paragraph(out, pending, inner);
                     }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Emit each `<tr>` of a table as a [`Block::Row`]; `inherited` is the table's own declared style.
+///
+/// Section wrappers (`<thead>`/`<tbody>`/`<tfoot>`) are transparent — they group rows without
+/// changing them. A `<caption>` is prose about the table and becomes an ordinary paragraph rather
+/// than being dropped. Anything else inside a table is ignored: it has no meaning outside a row.
+fn walk_table(
+    node: NodeRef<Node>,
+    out: &mut Vec<Block>,
+    sheet: &simplecss::StyleSheet<'_>,
+    inherited: BlockStyle,
+) {
+    for child in node.children() {
+        let Node::Element(el) = child.value() else {
+            continue;
+        };
+        match el.name() {
+            "thead" | "tbody" | "tfoot" => walk_table(child, out, sheet, inherited),
+            "caption" => {
+                let content = collect_inlines(child);
+                if !is_blank(&content) {
+                    out.push(Block::Paragraph {
+                        content,
+                        style: declared(child, el, sheet, inherited),
+                    });
+                }
+            }
+            "tr" => {
+                let cells: Vec<Vec<Inline>> = child
+                    .children()
+                    .filter_map(|c| match c.value() {
+                        Node::Element(ce) if matches!(ce.name(), "td" | "th") => {
+                            Some(collect_inlines(c))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                // A row of nothing but spacing cells is layout scaffolding, not content.
+                if !cells.is_empty() && !cells.iter().all(|c| is_blank(c)) {
+                    out.push(Block::Row {
+                        cells,
+                        style: declared(child, el, sheet, inherited),
+                    });
                 }
             }
             _ => {}
@@ -704,6 +768,121 @@ mod tests {
         let b = parse_blocks("just words");
         assert!(
             matches!(&b[..], [Block::Paragraph { content, .. }] if run(content) == "just words")
+        );
+    }
+}
+
+#[cfg(test)]
+mod table_tests {
+    use super::*;
+
+    fn text_of(inlines: &[Inline]) -> String {
+        inlines
+            .iter()
+            .map(|i| match i {
+                Inline::Run(r) => r.text.as_str(),
+                _ => "",
+            })
+            .collect()
+    }
+
+    fn rows(html: &str) -> Vec<Vec<String>> {
+        parse_blocks(html)
+            .into_iter()
+            .filter_map(|b| match b {
+                Block::Row { cells, .. } => Some(cells.iter().map(|c| text_of(c)).collect()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The case this exists for: a bilingual juxtalinear text, read across rather than down.
+    #[test]
+    fn a_parallel_text_keeps_its_pairs_together() {
+        let html = "<table>\
+             <tr><td>Au commencement</td><td>In the beginning</td></tr>\
+             <tr><td>la terre etait vide</td><td>the earth was empty</td></tr>\
+             </table>";
+        assert_eq!(
+            rows(html),
+            vec![
+                vec![
+                    "Au commencement".to_string(),
+                    "In the beginning".to_string()
+                ],
+                vec![
+                    "la terre etait vide".to_string(),
+                    "the earth was empty".to_string()
+                ],
+            ],
+        );
+    }
+
+    /// `<thead>`/`<tbody>`/`<tfoot>` group rows without changing them.
+    #[test]
+    fn section_wrappers_are_transparent() {
+        let html = "<table>\
+             <thead><tr><th>Source</th><th>Gloss</th></tr></thead>\
+             <tbody><tr><td>lupus</td><td>wolf</td></tr></tbody>\
+             <tfoot><tr><td>fin</td><td>end</td></tr></tfoot>\
+             </table>";
+        assert_eq!(
+            rows(html),
+            vec![
+                vec!["Source".to_string(), "Gloss".to_string()],
+                vec!["lupus".to_string(), "wolf".to_string()],
+                vec!["fin".to_string(), "end".to_string()],
+            ],
+        );
+    }
+
+    /// A caption is prose about the table; dropping it would lose text the author wrote.
+    #[test]
+    fn a_caption_survives_as_a_paragraph() {
+        let blocks =
+            parse_blocks("<table><caption>Genesis 1:1</caption><tr><td>a</td></tr></table>");
+        let captions: Vec<String> = blocks
+            .iter()
+            .filter_map(|b| match b {
+                Block::Paragraph { content, .. } => Some(text_of(content)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(captions, vec!["Genesis 1:1".to_string()]);
+    }
+
+    /// Spacer rows are layout scaffolding, and an empty row would take a line of the page.
+    #[test]
+    fn rows_with_no_content_are_dropped() {
+        assert!(rows("<table><tr><td> </td><td></td></tr></table>").is_empty());
+    }
+
+    /// A single-cell table is how a lot of EPUB2 does plain layout; it must behave like prose.
+    #[test]
+    fn a_one_cell_row_is_still_a_row_of_one() {
+        assert_eq!(
+            rows("<table><tr><td>just text</td></tr></table>"),
+            vec![vec!["just text".to_string()]]
+        );
+    }
+
+    /// Inline emphasis inside a cell is preserved rather than flattened away.
+    #[test]
+    fn cells_keep_their_inline_emphasis() {
+        let blocks = parse_blocks("<table><tr><td>plain <em>stressed</em></td></tr></table>");
+        let Some(Block::Row { cells, .. }) = blocks.into_iter().next() else {
+            panic!("expected a row");
+        };
+        let italics: Vec<bool> = cells[0]
+            .iter()
+            .filter_map(|i| match i {
+                Inline::Run(r) => Some(r.italic),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            italics.contains(&true),
+            "the <em> run should still be italic"
         );
     }
 }

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -557,6 +557,25 @@ pub fn paginate_upto(
                 cursor = at + 1;
                 pager.gap(opts.font_px * 0.4);
             }
+            Block::Row { cells, style } => {
+                // Structure now exists; placement does not yet. Each cell is flowed one after the
+                // other, which is exactly what an unrecognised `<table>` already produced, so this
+                // commit changes no output. Side-by-side placement follows.
+                let align = effective_align(style, opts.align);
+                for cell in cells {
+                    pager.add_paragraph(
+                        cell,
+                        opts.font_px,
+                        0.0,
+                        0.0,
+                        style.bold.unwrap_or(false),
+                        align,
+                        block_index,
+                        &mut cursor,
+                        m,
+                    );
+                }
+            }
             Block::Rule => pager.add_rule(opts.para_gap),
         }
     }

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -61,6 +61,14 @@ impl Hyphenator for NoHyphen {
 /// breaks every few words and justified text opens rivers, which is worse than one column.
 const MIN_COLUMN_EM: f32 = 14.0;
 
+/// The narrowest a table cell may be before the row gives up and stacks its cells instead.
+///
+/// Lower than [`MIN_COLUMN_EM`] on purpose. Page columns are continuous prose and a short measure
+/// there is merely bad typography; a table cell holds a phrase whose *pairing* with the cell beside
+/// it is the point, and keeping that pairing is worth a tighter measure than prose would tolerate.
+/// Below this the words break every few characters and nothing is gained.
+const MIN_CELL_EM: f32 = 6.0;
+
 /// Horizontal text alignment for reflowed lines (RR4 — KOReader's "Alignment").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Align {
@@ -558,23 +566,16 @@ pub fn paginate_upto(
                 pager.gap(opts.font_px * 0.4);
             }
             Block::Row { cells, style } => {
-                // Structure now exists; placement does not yet. Each cell is flowed one after the
-                // other, which is exactly what an unrecognised `<table>` already produced, so this
-                // commit changes no output. Side-by-side placement follows.
-                let align = effective_align(style, opts.align);
-                for cell in cells {
-                    pager.add_paragraph(
-                        cell,
-                        opts.font_px,
-                        0.0,
-                        0.0,
-                        style.bold.unwrap_or(false),
-                        align,
-                        block_index,
-                        &mut cursor,
-                        m,
-                    );
-                }
+                pager.add_row(
+                    cells,
+                    opts.font_px,
+                    style.bold.unwrap_or(false),
+                    effective_align(style, opts.align),
+                    block_index,
+                    &mut cursor,
+                    m,
+                );
+                pager.gap(opts.para_gap * 0.5);
             }
             Block::Rule => pager.add_rule(opts.para_gap),
         }
@@ -734,6 +735,73 @@ impl<'o> Pager<'o> {
         let n = lines.len();
         for (i, mut runs) in lines.into_iter().enumerate() {
             align_line(&mut runs, align, self.opts.content_w(), i + 1 == n, m);
+            self.emit(runs, line_h, false);
+        }
+    }
+
+    /// Lay out one table row: each cell broken to its own share of the measure, then the cells'
+    /// lines emitted side by side.
+    ///
+    /// The cells are flowed independently and then zipped, so a row is as tall as its tallest cell
+    /// and short cells simply leave whitespace beneath them. That is what makes a parallel text
+    /// readable across: line *n* of the original and line *n* of the translation share a line box,
+    /// however differently the two languages wrap.
+    ///
+    /// The character cursor advances cell by cell in source order, so a source anchor taken inside
+    /// a row still maps back to the character it came from (ADR-INKREAD-0012).
+    ///
+    /// A row taller than the page splits at a line boundary like any other content, and because
+    /// every cell contributes to the same line boxes, the split keeps the columns aligned.
+    #[allow(clippy::too_many_arguments)]
+    fn add_row(
+        &mut self,
+        cells: &[Vec<Inline>],
+        size: f32,
+        bold_all: bool,
+        align: Align,
+        block: usize,
+        cursor: &mut usize,
+        m: &dyn Metrics,
+    ) {
+        if cells.is_empty() {
+            return;
+        }
+        let n = cells.len() as f32;
+        let gutter = self.opts.gutter();
+        let measure = self.opts.content_w();
+        // Cells share the measure equally, the gutters coming out of it. A row of so many cells
+        // that none has a usable measure is laid out as a single column instead: unreadably narrow
+        // columns are worse than the interleaving this replaced.
+        let cell_w = ((measure - gutter * (n - 1.0)) / n).max(1.0);
+        if cell_w < MIN_CELL_EM * size {
+            for cell in cells {
+                self.add_paragraph(cell, size, 0.0, 0.0, bold_all, align, block, cursor, m);
+            }
+            return;
+        }
+        let mut columns: Vec<Vec<Vec<PlacedRun>>> = Vec::with_capacity(cells.len());
+        for (index, cell) in cells.iter().enumerate() {
+            let mut lines = break_lines(
+                cell, size, 0.0, 0.0, cell_w, bold_all, block, cursor, m, self.hyph,
+            );
+            let last = lines.len();
+            let dx = index as f32 * (cell_w + gutter);
+            for (i, runs) in lines.iter_mut().enumerate() {
+                align_line(runs, align, cell_w, i + 1 == last, m);
+                for run in runs.iter_mut() {
+                    run.x += dx;
+                }
+            }
+            columns.push(lines);
+        }
+        let line_h = size * self.opts.line_spacing;
+        let rows = columns.iter().map(Vec::len).max().unwrap_or(0);
+        for i in 0..rows {
+            let runs: Vec<PlacedRun> = columns
+                .iter()
+                .filter_map(|c| c.get(i))
+                .flat_map(|l| l.iter().cloned())
+                .collect();
             self.emit(runs, line_h, false);
         }
     }

--- a/inkread-epub/src/layout_tests.rs
+++ b/inkread-epub/src/layout_tests.rs
@@ -1212,3 +1212,127 @@ fn a_nomad_at_a_comfortable_reading_size_gets_two_columns() {
         "90px text leaves under 9 em a column"
     );
 }
+
+// ── Table rows laid out side by side (#200) ───────────────────────────────────────────────────
+
+mod row_layout {
+    use super::*;
+
+    fn cell(text: &str) -> Vec<Inline> {
+        vec![Inline::Run(TextRun {
+            text: text.to_string(),
+            bold: false,
+            italic: false,
+            href: None,
+        })]
+    }
+
+    fn row(cells: &[&str]) -> Block {
+        Block::Row {
+            cells: cells.iter().map(|c| cell(c)).collect(),
+            style: BlockStyle::default(),
+        }
+    }
+
+    /// A wide page, so two cells comfortably clear MIN_CELL_EM.
+    fn opts() -> LayoutOpts {
+        LayoutOpts::new(1200.0, 1600.0, 20.0)
+    }
+
+    fn lines(blocks: &[Block], opts: &LayoutOpts) -> Vec<LayoutLine> {
+        paginate(blocks, opts, &Mono)
+            .into_iter()
+            .flat_map(|p| p.lines)
+            .collect()
+    }
+
+    /// The whole point: the pair shares a line box, so the text reads across.
+    #[test]
+    fn a_two_cell_row_puts_both_cells_on_one_line() {
+        let out = lines(&[row(&["alpha", "beta"])], &opts());
+        assert_eq!(out.len(), 1, "one line, not one per cell");
+        let texts: Vec<&str> = out[0].runs.iter().map(|r| r.text.as_str()).collect();
+        assert_eq!(texts, vec!["alpha", "beta"]);
+        assert!(
+            out[0].runs[0].x < out[0].runs[1].x,
+            "the second cell must sit to the right of the first",
+        );
+    }
+
+    /// The regression this replaces: cells used to become separate stacked blocks.
+    #[test]
+    fn cells_are_not_stacked_vertically() {
+        let out = lines(&[row(&["alpha", "beta"])], &opts());
+        let tops: Vec<f32> = out.iter().map(|l| l.top).collect();
+        assert_eq!(tops.len(), 1, "stacked cells would give two tops: {tops:?}");
+    }
+
+    /// Cells occupy their own share of the measure and do not overlap.
+    #[test]
+    fn cells_divide_the_measure_without_overlapping() {
+        let o = opts();
+        let out = lines(&[row(&["alpha", "beta", "gamma"])], &o);
+        let xs: Vec<f32> = out[0].runs.iter().map(|r| r.x).collect();
+        assert_eq!(xs.len(), 3);
+        assert!(xs[0] < xs[1] && xs[1] < xs[2], "cells out of order: {xs:?}");
+        assert!(
+            xs[2] < o.column_width(),
+            "the last cell must start inside the measure",
+        );
+    }
+
+    /// A row is as tall as its tallest cell; the short one leaves whitespace beneath it.
+    #[test]
+    fn a_row_is_as_tall_as_its_tallest_cell() {
+        let long = "one two three four five six seven eight nine ten eleven twelve";
+        let out = lines(&[row(&[long, "short"])], &opts());
+        assert!(out.len() > 1, "the long cell should wrap to several lines");
+        // Every line after the first belongs to the long cell alone.
+        let first_line_cells = out[0].runs.len();
+        assert!(first_line_cells >= 2, "both cells start on the first line");
+    }
+
+    /// Rows keep the reading order of their source, so anchors still map back to characters.
+    #[test]
+    fn character_offsets_advance_in_source_order() {
+        let out = lines(&[row(&["alpha", "beta"])], &opts());
+        let offsets: Vec<usize> = out[0].runs.iter().map(|r| r.anchor.char_offset).collect();
+        assert!(
+            offsets.windows(2).all(|w| w[0] <= w[1]),
+            "offsets must not go backwards across cells: {offsets:?}",
+        );
+    }
+
+    /// Too many cells to give any of them a readable measure: stack rather than shred the words.
+    #[test]
+    fn an_unusably_narrow_row_falls_back_to_stacking() {
+        let cells = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"];
+        // A narrow page makes twelve cells hopeless.
+        let narrow = LayoutOpts::new(300.0, 800.0, 20.0);
+        let out = lines(&[row(&cells)], &narrow);
+        assert!(
+            out.len() > 1,
+            "unusably narrow cells should stack, not share one line",
+        );
+    }
+
+    /// A single-cell table is how a lot of EPUB2 does plain layout, so a lone cell must get the
+    /// whole measure — not a half-width column with the other half left empty.
+    #[test]
+    fn a_one_cell_row_uses_the_full_measure() {
+        let o = opts();
+        let text = "one two three four five six seven eight nine ten eleven twelve thirteen";
+        let alone = lines(&[row(&[text])], &o);
+        let shared = lines(&[row(&[text, "x"])], &o);
+        assert!(
+            alone.len() < shared.len(),
+            "a lone cell wrapped as much as a half-width one ({} vs {} lines): it is not              getting the full measure",
+            alone.len(),
+            shared.len(),
+        );
+        assert_eq!(
+            alone[0].runs[0].x, 0.0,
+            "a cell carries no first-line indent"
+        );
+    }
+}


### PR DESCRIPTION
Two things from the #200 thread: the toolbar orientation alioth9 asked for, and the `<table>` gap
that turned out to be why they read converted PDFs rather than EPUBs.

## Tables

A `<table>` was an unrecognised element, so it fell to the transparent-container branch and its grid
flattened into document order — row by row, then cell by cell. For a bilingual parallel text, which
is what these books are, that interleaves the two languages down the page:

```
block 0: "Au commencement"      block 2: "la terre etait vide"
block 1: "In the beginning"     block 3: "the earth was empty"
```

The correspondence the edition exists for is destroyed, though no text is lost.

Rows and cells now parse into a `Block::Row`. Each cell is broken to its own share of the measure
and the cells' lines are zipped, so line *n* of every cell shares one line box — the original and
its translation stay level however differently the two languages wrap, and a row is as tall as its
tallest cell. Section wrappers are transparent, a `<caption>` becomes a paragraph rather than being
dropped, and a row of empty spacing cells is discarded as the scaffolding it is.

A row with too many cells to give any of them a readable measure stacks them instead: below six ems
the words shred and nothing is gained. That threshold is deliberately lower than `MIN_COLUMN_EM` —
page columns are continuous prose where a short measure is merely bad typography, but a table cell
holds a phrase whose pairing with its neighbour is the whole point.

The character cursor advances cell by cell in source order, so an anchor taken inside a row still
maps back to the character it came from (ADR-INKREAD-0012). A row taller than the page splits at a
line boundary like anything else, and because every cell feeds the same line boxes the split keeps
the columns aligned.

## Horizontal tool palette

The palette is a fixed, finger-sized width while the page margin is a fraction of the panel. Down
the right edge it is therefore wider than the margin on every device — and wider by more the smaller
the screen — so it clips the end of each of the ~20 lines it spans. Across the top it clips part of
a single line.

| | Nomad 1404×1872 | Manta 1920×2560 |
|---|---|---|
| Page margin | 84px | 115px |
| Palette overhang | 56px | 25px |
| Vertical | clips 56px off ~19 lines | clips 25px off ~19 lines |
| Horizontal at top | ~1.0 line | ~0.5 line |

**Corner-docked, not floating.** Measured on device, a centred bar expanded to sit 920px from the
left edge and 32px from the right: it grew outward from the grip, which is right for a pill hanging
off an edge and wrong for a strip with nothing to hang from. It now docks in a top corner and grows
inward, with the grip *on* the docked edge — which means building the row back to front when docked
right — so the edge it grows from cannot move.

That corrected what `keepEdge` meant. A strip anchored to an edge holds that edge for free, because
its offset never involves its own size; only a centred strip grows both ways and must compensate.

**It keeps out of the bookmark's corner.** Docked top-right the puck landed at x 1789..1909 on a
1920px panel, on the ribbon at 1759..1826 and *wholly inside its tap target*, which starts at 1651 —
so it silently ate the tap that toggles a bookmark. The zone was an unnamed pair of fractions in the
tap handler; it is now named and shared by both places that must agree about it. Because standing
off that zone leaves the strip floating inboard of the corner it is meant to be tucked into, the
horizontal form **defaults to the top-left**, where there is nothing to avoid. Either form can be
moved to either side in Settings.

**Open or shut carries over.** The palette opened collapsed every time and `onPause` force-collapsed
it, so a reader with the tools out lost them on every book open and every trip out of the app.
Whether the tools are out is a working posture, not a property of a document. The pause-collapse is
gone rather than reinstated elsewhere — it was the thing destroying the state — and with it the
re-anchor that existed only to undo the drift it caused.

The horizontal form stores no position: the corner *is* the position. It can still be dragged aside
mid-read, but that is a this-book-only move. It is not auto-collapsing; the reporter explicitly does
not want that, because switching pen → eraser → digest while annotating would mean reopening it
every time.

## Anchors

The placement maths assumed one anchor per axis — `END` across, `CENTER` down — which is only true
of a right-edge pill. Anchors are now explicit (`START`/`CENTER`/`END`), so clamping, the
saved-position round trip and the keep-the-docked-edge-still correction all work on either axis. A
side effect worth having: the vertical pill can now dock left, which it never could.

## Tests

129 Kotlin and 659 Rust tests. Six parser cases and seven layout cases for rows; twelve anchor and
placement cases for the palette. Both suites were checked against a build with the change reverted —
forcing the stacking fallback fails exactly the three side-by-side tests, and breaking `START`
anchoring fails exactly the drift test. The bookmark-clearance test caught a real off-by-one, where
truncating the clearance left the strip 0.8px inside the zone.

`cargo fmt`, `cargo clippy -D warnings`, `cargo test --workspace`, `:app:testDebugUnitTest` and the
licence check all pass; the release APK assembles.

## Verified on device

Corner docking, the grip staying pinned while the row grows inward, the bookmark tap working again,
and the open state surviving a book change were all checked on a Supernote.

## Not covered

alioth9 described reserving space rather than overlaying — they already widen the top/bottom margins
of their converted PDFs to make room for the native toolbar. This floats instead, costing about one
line while open. A reserved band changes the viewport, which drops the render cache and trips #206,
so it is a follow-up rather than a variant. They also read PDFs rather than EPUBs until custom fonts
(#169) and CSS `font-style` (#170) land, so the table work does not unblock their own workflow yet.
