### PR TITLE
fix: define a word the line break split, and stop printing "well--"

### DIFF
--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -274,6 +274,25 @@ pub struct PlacedRun {
     pub href: Option<String>,
     /// Source anchor of this run's first character (ADR-INKREAD-0012).
     pub anchor: SourceAnchor,
+    /// Set when this run ends its line **mid-word** — the word continues on the next line, and this
+    /// says whether the hyphen shown at the break is one of ours. `None` on every other run, which
+    /// is nearly all of them: a line normally ends at a word boundary.
+    pub wrap: Option<Wrap>,
+}
+
+/// How a line break split the word that ends a line. Only the layout knows this — the two cases
+/// print identically ("self-evident" broken before its hyphen and "well-known" broken at its own
+/// both show a line ending "self-"/"well-") — so it records the fact for selection, search and copy
+/// to rejoin the halves faithfully (RR11).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Wrap {
+    /// The break needed a hyphen and the layout **inserted** one. It is not in the source text, so
+    /// rejoining the halves drops it: "pontifi-" + "cate" = "pontificate".
+    SoftHyphen,
+    /// The break needed no hyphen — the word already had one there, or it is unspaced script (CJK).
+    /// Every character on the line is the source's, so rejoining keeps them all: "well-" + "known"
+    /// = "well-known".
+    Kept,
 }
 
 /// One laid-out line: its `top` (content-relative), `height` (the line box), and positioned runs.
@@ -852,6 +871,7 @@ impl<'o> Pager<'o> {
                     italic: false,
                     href: None,
                     anchor: marker_anchor,
+                    wrap: None,
                 },
             );
         } else {
@@ -863,6 +883,7 @@ impl<'o> Pager<'o> {
                 italic: false,
                 href: None,
                 anchor: marker_anchor,
+                wrap: None,
             }]);
         }
         let line_h = size * self.opts.line_spacing;
@@ -1076,7 +1097,7 @@ fn break_lines(
                         block: anchor.block,
                         char_offset: anchor.char_offset + off,
                     };
-                    let push = |cur: &mut Vec<PlacedRun>, txt: String, px: f32| {
+                    let push = |cur: &mut Vec<PlacedRun>, txt: String, px: f32, wrap| {
                         cur.push(PlacedRun {
                             x: indent + px,
                             text: txt,
@@ -1085,24 +1106,35 @@ fn break_lines(
                             italic,
                             href: href.map(str::to_string),
                             anchor,
+                            wrap,
                         });
                     };
                     if rest_w <= room {
-                        push(&mut cur, rest.to_string(), start);
+                        push(&mut cur, rest.to_string(), start, None);
                         x = start + rest_w;
                         break;
                     }
                     // Two ways to split the token mid-word: an unspaced-script (CJK) break at a
                     // UAX #14 opportunity (no hyphen — for a spaceless paragraph this is the only
                     // way it wraps), else a soft-hyphenated Latin break. Same head-and-wrap tail.
+                    // Each records which it was, so selection can rejoin the halves (see [`Wrap`]).
                     let split = unspaced_break_fit(rest, room, m, size, bold, italic)
-                        .map(|(head, chars)| (head.to_string(), head.len(), chars))
+                        .map(|(head, chars)| (head.to_string(), head.len(), chars, Wrap::Kept))
                         .or_else(|| {
-                            hyphenate_fit(rest, room, hyph, m, size, bold, italic)
-                                .map(|(head, chars)| (format!("{head}-"), head.len(), chars))
+                            hyphenate_fit(rest, room, hyph, m, size, bold, italic).map(
+                                |(head, chars)| {
+                                    // A compound broken at the hyphen it already has needs no
+                                    // second one — "well-known" must not print as "well--".
+                                    if ends_with_hyphen(head) {
+                                        (head.to_string(), head.len(), chars, Wrap::Kept)
+                                    } else {
+                                        (format!("{head}-"), head.len(), chars, Wrap::SoftHyphen)
+                                    }
+                                },
+                            )
                         });
-                    if let Some((fragment, head_len, head_chars)) = split {
-                        push(&mut cur, fragment, start);
+                    if let Some((fragment, head_len, head_chars, wrap)) = split {
+                        push(&mut cur, fragment, start, Some(wrap));
                         lines.push(std::mem::take(&mut cur));
                         rest = &rest[head_len..];
                         off += head_chars;
@@ -1118,7 +1150,7 @@ fn break_lines(
                         continue;
                     }
                     // Fresh line, no break point, still too wide → place it overflowing.
-                    push(&mut cur, rest.to_string(), 0.0);
+                    push(&mut cur, rest.to_string(), 0.0, None);
                     x = rest_w;
                     break;
                 }
@@ -1206,8 +1238,16 @@ fn unspaced_break_fit<'w>(
     best
 }
 
+/// Whether `s` already ends in a hyphen, so a break after it needs no second one. ASCII and the
+/// Unicode hyphen; the soft hyphen never survives into a laid-out fragment.
+fn ends_with_hyphen(s: &str) -> bool {
+    s.ends_with(['-', '\u{2010}'])
+}
+
 /// The longest prefix of `word` ending at a hyphenation opportunity whose text plus a trailing
-/// hyphen fits within `room` px; returns `(head, head_char_count)`, or `None` if none fits.
+/// hyphen fits within `room` px; returns `(head, head_char_count)`, or `None` if none fits. The
+/// hyphen is measured even for a prefix that already ends in one (which is placed without a second)
+/// — conservative by one hyphen's width, and it keeps every existing pagination unchanged.
 fn hyphenate_fit<'w>(
     word: &'w str,
     room: f32,

--- a/inkread-epub/src/layout_tests.rs
+++ b/inkread-epub/src/layout_tests.rs
@@ -677,6 +677,55 @@ fn long_word_hyphenates_and_suffix_keeps_its_anchor() {
 }
 
 #[test]
+fn soft_hyphenated_break_is_flagged_as_inserted() {
+    let pages = paginate_with(
+        &[para("hyphenation")],
+        &narrow_para(),
+        &Mono,
+        &HyphenAt(vec![5]),
+    );
+    let runs: Vec<_> = pages[0].lines.iter().flat_map(|l| l.runs.iter()).collect();
+    assert_eq!(runs[0].wrap, Some(Wrap::SoftHyphen), "we added that hyphen");
+    assert_eq!(runs[1].wrap, None, "the last line of the word ends it");
+}
+
+#[test]
+fn compound_broken_at_its_own_hyphen_gets_no_second_one() {
+    // en-US patterns offer "well-known" exactly one break, at byte 5 — right after the hyphen it
+    // already has. Printing "well--" there is wrong, and the hyphen shown is the source's own.
+    let pages = paginate_with(
+        &[para("well-known")],
+        &narrow_para(),
+        &Mono,
+        &HyphenAt(vec![5]),
+    );
+    let runs: Vec<_> = pages[0].lines.iter().flat_map(|l| l.runs.iter()).collect();
+    assert_eq!(runs[0].text, "well-", "no doubled hyphen");
+    assert_eq!(runs[1].text, "known");
+    assert_eq!(
+        runs[0].wrap,
+        Some(Wrap::Kept),
+        "every character is the source's, so rejoining keeps the hyphen"
+    );
+}
+
+#[test]
+fn compound_broken_before_its_own_hyphen_keeps_it_on_the_next_line() {
+    // The mirror: "self-evident" broken at byte 4 prints "self-" too, but that hyphen IS ours and
+    // the source's own opens the continuation. Identical on the page, opposite in meaning.
+    let pages = paginate_with(
+        &[para("self-evident")],
+        &narrow_para(),
+        &Mono,
+        &HyphenAt(vec![4]),
+    );
+    let runs: Vec<_> = pages[0].lines.iter().flat_map(|l| l.runs.iter()).collect();
+    assert_eq!(runs[0].text, "self-");
+    assert_eq!(runs[1].text, "-evident");
+    assert_eq!(runs[0].wrap, Some(Wrap::SoftHyphen), "that hyphen is ours");
+}
+
+#[test]
 fn default_paginate_never_hyphenates() {
     // The default ([`NoHyphen`]) places an overflowing word whole, on its own line.
     let pages = paginate(&[para("hyphenation")], &narrow_para(), &Mono);

--- a/inkread-epub/src/render.rs
+++ b/inkread-epub/src/render.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use ab_glyph::{point, Font, FontVec, GlyphId, PxScale, ScaleFont};
 use hyphenation::{Hyphenator as _, Language, Load, Standard};
 
-use crate::layout::{Hyphenator, LayoutOpts, Metrics, Page, SourceAnchor};
+use crate::layout::{Hyphenator, LayoutOpts, Metrics, Page, SourceAnchor, Wrap};
 
 /// The bundled default reading face — Spectral Regular (SIL OFL 1.1; see `fonts/OFL.txt`).
 const DEFAULT_FONT: &[u8] = include_bytes!("../fonts/Spectral-Regular.ttf");
@@ -397,6 +397,9 @@ pub struct PlacedGlyph {
     /// glyph's chapter-relative `char_offset`. Lets `reader-core` mint a `PinPosition` from a
     /// selection or a page's first glyph.
     pub anchor: SourceAnchor,
+    /// Set on the **last** glyph of a line the layout broke mid-word ([`Wrap`]) — the flag its run
+    /// carries, moved onto the glyph selection actually reaches. `None` on every other glyph.
+    pub wrap: Option<Wrap>,
 }
 
 /// Extract a laid-out [`Page`]'s glyphs as positioned boxes (pixel space), walking runs **exactly**
@@ -428,11 +431,13 @@ pub fn page_glyphs(page: &Page, opts: &LayoutOpts, font: &AbFont) -> Vec<PlacedG
                         x1: run_start,
                         y1,
                         anchor: prev_anchor,
+                        wrap: None,
                     });
                 }
             }
             let mut pen_x = run_start;
             let mut prev: Option<(&FontVec, GlyphId)> = None;
+            let run_first = out.len();
             // The glyph's chapter-relative offset = the run's first-char offset + its index in the run.
             for (i, ch) in run.text.chars().enumerate() {
                 let face = font.face_for(ch);
@@ -454,9 +459,17 @@ pub fn page_glyphs(page: &Page, opts: &LayoutOpts, font: &AbFont) -> Vec<PlacedG
                         block: run.anchor.block,
                         char_offset: run.anchor.char_offset + i,
                     },
+                    wrap: None,
                 });
                 pen_x += adv;
                 prev = Some((face, id));
+            }
+            // A run that ends its line mid-word hands the fact to its last glyph, which is the one
+            // selection meets at the break.
+            if run.wrap.is_some() && out.len() > run_first {
+                if let Some(last) = out.last_mut() {
+                    last.wrap = run.wrap;
+                }
             }
             let run_end_anchor = SourceAnchor {
                 block: run.anchor.block,

--- a/reader-core/src/document/fixed/pdf.rs
+++ b/reader-core/src/document/fixed/pdf.rs
@@ -584,6 +584,9 @@ impl PdfBackend {
                 },
                 // Fixed-layout PDF: the page index is the anchor; no reflow anchor (ADR-0012).
                 anchor: None,
+                // Nor any line-break knowledge — the page was broken by whoever typeset it, so a
+                // split word is read off the printed hyphen instead (`text_select::wrap_of`).
+                wrap: None,
             });
         }
         out

--- a/reader-core/src/document/reflow_view.rs
+++ b/reader-core/src/document/reflow_view.rs
@@ -13,12 +13,12 @@
 
 use std::cell::{Cell, RefCell};
 
-use inkread_epub::layout::{paginate, Align, LayoutOpts, Page};
+use inkread_epub::layout::{paginate, Align, LayoutOpts, Page, Wrap as LayoutWrap};
 use inkread_epub::measure::CachedMetrics;
 use inkread_epub::render::{page_glyphs, render_page as raster_page, AbFont, GrayCanvas};
 use inkread_epub::Block;
 
-use crate::document::text_select::{CharBox, NormRect, TextAnchor};
+use crate::document::text_select::{CharBox, NormRect, TextAnchor, Wrap};
 use crate::error::{CoreError, CoreResult};
 use crate::render::PixelBuffer;
 
@@ -42,6 +42,10 @@ pub(crate) fn page_charboxes(page: &Page, opts: &LayoutOpts, font: &AbFont) -> V
             anchor: Some(TextAnchor {
                 block: g.anchor.block,
                 char_offset: g.anchor.char_offset,
+            }),
+            wrap: g.wrap.map(|w| match w {
+                LayoutWrap::SoftHyphen => Wrap::SoftHyphen,
+                LayoutWrap::Kept => Wrap::Kept,
             }),
         })
         .collect()
@@ -285,7 +289,88 @@ fn layout_all(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::text_select::{word_at, Wrap};
+    use inkread_epub::layout::paginate_with;
+    use inkread_epub::render::EnHyphenator;
     use inkread_epub::{BlockStyle, Inline, TextRun};
+
+    /// One paragraph of `text`, laid out with soft hyphenation into a measure `page_w` wide, as the
+    /// EPUB backend does — the only path that hyphenates.
+    fn hyphenated(text: &str, page_w: f32) -> Vec<CharBox> {
+        let blocks = vec![Block::Paragraph {
+            content: vec![Inline::Run(TextRun {
+                text: text.to_string(),
+                bold: false,
+                italic: false,
+                href: None,
+            })],
+            style: BlockStyle::default(),
+        }];
+        let opts = LayoutOpts::new(page_w, 800.0, 38.0);
+        let font = AbFont::default_font();
+        let pages = paginate_with(&blocks, &opts, &font, &EnHyphenator::new());
+        page_charboxes(&pages[0], &opts, &font)
+    }
+
+    /// The whole chain the flag travels: `layout` splits the word and records how, `page_glyphs`
+    /// moves that onto the glyph at the break, `page_charboxes` converts it, and `word_at` rejoins
+    /// the halves — from either side, without the hyphen we inserted.
+    #[test]
+    fn a_soft_hyphenated_word_is_read_back_whole() {
+        let chars = hyphenated("pontificate", 150.0);
+        let line1: String = chars
+            .iter()
+            .take_while(|c| c.wrap.is_none())
+            .map(|c| c.ch)
+            .collect();
+        assert!(
+            !line1.is_empty() && line1.len() < "pontificate".len(),
+            "the measure must actually split the word, got {line1:?}"
+        );
+        let brk = chars
+            .iter()
+            .position(|c| c.wrap.is_some())
+            .expect("a break");
+        assert_eq!(chars[brk].ch, '-', "the break shows a hyphen");
+        assert_eq!(chars[brk].wrap, Some(Wrap::SoftHyphen), "which we inserted");
+
+        let mid = |c: &CharBox| ((c.rect.x0 + c.rect.x1) * 0.5, (c.rect.y0 + c.rect.y1) * 0.5);
+        let (hx, hy) = mid(&chars[brk - 1]);
+        let (tx, ty) = mid(&chars[brk + 1]);
+        let head = word_at(&chars, hx, hy).expect("a word at the first half");
+        let tail = word_at(&chars, tx, ty).expect("a word at the continuation");
+        assert_eq!(head.text, "pontificate");
+        assert_eq!(tail.text, "pontificate");
+        assert_eq!(head.boxes.len(), 2, "highlighted on both lines");
+    }
+
+    /// The mirror: a compound broken at the hyphen it already had prints one hyphen, not two, and
+    /// reads back with it — the "well--" defect and the lookup that depended on it.
+    #[test]
+    fn a_compound_broken_at_its_own_hyphen_reads_back_with_it() {
+        let chars = hyphenated("well-known", 150.0);
+        let text: String = chars.iter().map(|c| c.ch).collect();
+        assert!(
+            !text.contains("--"),
+            "no doubled hyphen on the page: {text:?}"
+        );
+        let brk = chars
+            .iter()
+            .position(|c| c.wrap.is_some())
+            .expect("a break");
+        assert_eq!(
+            chars[brk].wrap,
+            Some(Wrap::Kept),
+            "that hyphen is the book's"
+        );
+        let c = &chars[brk - 1];
+        let sel = word_at(
+            &chars,
+            (c.rect.x0 + c.rect.x1) * 0.5,
+            (c.rect.y0 + c.rect.y1) * 0.5,
+        );
+        assert_eq!(sel.expect("a word").text, "well-known");
+    }
 
     // A heading flowed through the whole reflow pipeline (layout → render → page_chars) keeps its
     // words intact across font sizes — guards the device "regressio n" / "valu e" regression at the

--- a/reader-core/src/document/text_select.rs
+++ b/reader-core/src/document/text_select.rs
@@ -60,6 +60,28 @@ pub struct CharBox {
     /// fixed-layout PDF (its position *is* the page). Reflow backends fill it so a selection or a
     /// page's first glyph can be turned into a `PinPosition` that survives a font-size change.
     pub anchor: Option<TextAnchor>,
+    /// Set on the last glyph of a line the layout broke **mid-word** — see [`Wrap`]. `None` on
+    /// every other glyph, and on every glyph of a fixed-layout backend, which lays nothing out and
+    /// therefore knows nothing (there, selection reads the break off the page; see [`wrap_of`]).
+    pub wrap: Option<Wrap>,
+}
+
+/// What a line break did to the word it split. Only a backend that performed the layout can say:
+/// the two cases print identically — "self-evident" broken before its hyphen and "well-known"
+/// broken at its own both end a line "self-"/"well-" — so the fact travels with the glyph instead
+/// of being guessed from it.
+///
+/// Field-identical to `inkread_epub::layout::Wrap` but kept as the core's own selection-domain type
+/// so the selection model isn't coupled to the renderer's glyph type, exactly like [`TextAnchor`]
+/// (the backends convert at the boundary).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Wrap {
+    /// The layout **inserted** the hyphen shown at the break. It is not in the source text, so
+    /// rejoining the halves drops it: "pontifi-" + "cate" = "pontificate".
+    SoftHyphen,
+    /// The break needed no hyphen — the word already had one there, or it is unspaced script (CJK).
+    /// Every character is the source's, so rejoining keeps them all: "well-" + "known".
+    Kept,
 }
 
 /// A reflow-stable text anchor: the source block (reading-order index in the chapter) and the
@@ -121,7 +143,7 @@ pub fn find_matches(chars: &[CharBox], query: &str) -> Vec<SearchMatch> {
     let mut hay: Vec<char> = Vec::with_capacity(chars.len());
     let mut src: Vec<usize> = Vec::with_capacity(chars.len());
     let mut prev_space = false;
-    let mut prev_rect: Option<NormRect> = None;
+    let mut prev: Option<usize> = None;
     for (i, c) in chars.iter().enumerate() {
         if c.ch.is_whitespace() {
             if !prev_space && !hay.is_empty() {
@@ -131,13 +153,26 @@ pub fn find_matches(chars: &[CharBox], query: &str) -> Vec<SearchMatch> {
             }
         } else {
             // A line break with no explicit space glyph (text wrap) still separates words, so the
-            // query "foo bar" matches across the wrap.
-            if !prev_space {
-                if let Some(pr) = prev_rect {
-                    if !same_line(&pr, &c.rect) {
+            // query "foo bar" matches across the wrap — unless the break split a word, in which
+            // case the halves are one word and the search reads them as `word_at` defines them
+            // ("pontificate" finds "pontifi-" / "cate", "well-known" finds "well-" / "known").
+            if let Some(p) = prev.filter(|&p| !same_line(&chars[p].rect, &c.rect)) {
+                match wrap_of(chars, p).filter(|_| is_word_char(c.ch) || is_hyphen(c.ch)) {
+                    Some(wrap) => {
+                        while hay.last() == Some(&' ') {
+                            hay.pop();
+                            src.pop();
+                        }
+                        if wrap == Wrap::SoftHyphen {
+                            hay.pop();
+                            src.pop();
+                        }
+                    }
+                    None if !prev_space => {
                         hay.push(' ');
                         src.push(i);
                     }
+                    None => {}
                 }
             }
             for lc in c.ch.to_lowercase() {
@@ -145,7 +180,7 @@ pub fn find_matches(chars: &[CharBox], query: &str) -> Vec<SearchMatch> {
                 src.push(i);
             }
             prev_space = false;
-            prev_rect = Some(c.rect);
+            prev = Some(i);
         }
     }
 
@@ -213,25 +248,38 @@ const HIT_TOLERANCE: f32 = 0.03;
 
 /// The word under `(x, y)` (tap / long-press), or `None` if the point isn't on a word glyph
 /// (whitespace, punctuation, or empty space). Expands across letters/digits and *internal*
-/// apostrophes/hyphens (`don't`, `well-known`).
+/// apostrophes/hyphens (`don't`, `well-known`), and across a line break that split the word
+/// (see [`wrap_before`]) so either half defines the whole word.
 #[must_use]
 pub fn word_at(chars: &[CharBox], x: f32, y: f32) -> Option<TextSelection> {
     let hit = hit_char(chars, x, y)?;
     if !is_word_char(chars[hit].ch) {
         return None;
     }
-    let mut start = hit;
-    while start > 0 && joins(&chars[start - 1], &chars[start]) {
-        start -= 1;
+    let (mut start, mut end) = word_run(chars, hit);
+    // Soft hyphenation splits a word across two lines (or, on a two-column page, two columns). Both
+    // halves are one word; only a hyphen the layout *inserted* is dropped when they rejoin, so
+    // tapping either "pontifi-" or "cate" defines "pontificate" while "well-" / "known" keeps the
+    // hyphen it came with.
+    let mut breaks = Vec::new();
+    if let Some((wrap, brk, head)) = wrap_before(chars, start) {
+        if wrap == Wrap::SoftHyphen {
+            breaks.push(brk);
+        }
+        start = word_run(chars, head).0;
     }
-    let mut end = hit;
-    while end + 1 < chars.len() && joins(&chars[end], &chars[end + 1]) {
-        end += 1;
+    if let Some((wrap, brk, tail)) = wrap_after(chars, end) {
+        if wrap == Wrap::SoftHyphen {
+            breaks.push(brk);
+        }
+        end = word_run(chars, tail).1;
     }
     let run = &chars[start..=end];
     let text = run
         .iter()
-        .map(|c| c.ch)
+        .enumerate()
+        .filter(|(i, c)| !c.ch.is_whitespace() && !breaks.contains(&(start + i)))
+        .map(|(_, c)| c.ch)
         .collect::<String>()
         .trim_matches(is_connector)
         .to_string();
@@ -242,6 +290,121 @@ pub fn word_at(chars: &[CharBox], x: f32, y: f32) -> Option<TextSelection> {
         text,
         boxes: line_boxes(run),
     })
+}
+
+/// The word run around `chars[i]` as `(start, end)`, inclusive — letters/digits and internal
+/// connectors, on one line (a line break ends the run; [`wrap_before`]/[`wrap_after`] cross it).
+fn word_run(chars: &[CharBox], i: usize) -> (usize, usize) {
+    let mut start = i;
+    while start > 0 && joins(&chars[start - 1], &chars[start]) {
+        start -= 1;
+    }
+    let mut end = i;
+    while end + 1 < chars.len() && joins(&chars[end], &chars[end + 1]) {
+        end += 1;
+    }
+    (start, end)
+}
+
+/// What the line break after `chars[i]` did to the word it split, or `None` if it split none.
+///
+/// A backend that laid the text out states it outright ([`CharBox::wrap`]), and is believed
+/// including when it says nothing happened — it knows, and the alternative is guessing wrong on a
+/// line that simply ends in a hyphen ("well- known", two words). A fixed-layout backend fills
+/// neither `wrap` nor `anchor`: there the break is read off the page, where a line-ending hyphen
+/// with a letter in front of it is a split word by printing convention, and goes when they rejoin.
+fn wrap_of(chars: &[CharBox], i: usize) -> Option<Wrap> {
+    if chars[i].anchor.is_some() {
+        return chars[i].wrap;
+    }
+    word_before_hyphen(chars, i).map(|_| Wrap::SoftHyphen)
+}
+
+/// The line break *before* the word run starting at `start`, when it split a word: `(what it did,
+/// the glyph at the break, a glyph of the first half)`. `None` when `start` begins a word of its own.
+fn wrap_before(chars: &[CharBox], start: usize) -> Option<(Wrap, usize, usize)> {
+    let brk = prev_glyph(chars, start)?;
+    if same_line(&chars[brk].rect, &chars[start].rect) {
+        return None;
+    }
+    let wrap = wrap_of(chars, brk)?;
+    // The first half is whatever run that glyph belongs to: itself when the break needed no hyphen
+    // (unspaced script), else the letter in front of the hyphen.
+    let head = if is_word_char(chars[brk].ch) {
+        brk
+    } else {
+        word_before_hyphen(chars, brk)?
+    };
+    Some((wrap, brk, head))
+}
+
+/// The mirror of [`wrap_before`]: the run ending at `end` is the first half of a split word.
+/// `(what the break did, the glyph at the break, the first glyph of the continuation)`, or `None`
+/// when the word really does end there (or the page does).
+fn wrap_after(chars: &[CharBox], end: usize) -> Option<(Wrap, usize, usize)> {
+    // Step over a second hyphen: `joins` won't pair two connectors, so a page that prints a word's
+    // own hyphen *and* a break hyphen ("well--") leaves the run short of the break. Our layout no
+    // longer emits that pair, but a fixed-layout page can still show it.
+    let mut brk = end;
+    while chars
+        .get(brk + 1)
+        .is_some_and(|c| is_hyphen(c.ch) && same_line(&c.rect, &chars[brk].rect))
+    {
+        brk += 1;
+    }
+    let wrap = wrap_of(chars, brk)?;
+    let tail = next_glyph(chars, brk)?;
+    (starts_word(chars, tail) && !same_line(&chars[brk].rect, &chars[tail].rect))
+        .then_some((wrap, brk, tail))
+}
+
+/// The letter or digit that the line-ending hyphen at `i` belongs to, scanning back over any
+/// further hyphens on its line. `None` when `chars[i]` isn't a hyphen that ends a word — a dash
+/// used as punctuation has a space in front of it, and nothing on the line before it counts.
+///
+/// The scan matters because the layout appends *its own* hyphen to whatever fragment it breaks
+/// (`inkread_epub::layout`), so a compound broken at the hyphen it already had ends the line in two
+/// ("well-known" → "well--" / "known"). Exactly one of them — the last — is the join.
+fn word_before_hyphen(chars: &[CharBox], i: usize) -> Option<usize> {
+    if !is_hyphen(chars[i].ch) {
+        return None;
+    }
+    let mut j = i;
+    while j > 0 && same_line(&chars[j - 1].rect, &chars[j].rect) {
+        j -= 1;
+        if is_word_char(chars[j].ch) {
+            return Some(j);
+        }
+        if !is_hyphen(chars[j].ch) {
+            return None;
+        }
+    }
+    None
+}
+
+/// Whether `chars[i]` starts a word: a letter or digit, or the hyphen a compound kept when the
+/// break fell in front of it ("self-evident" → "self-" / "-evident").
+fn starts_word(chars: &[CharBox], i: usize) -> bool {
+    is_word_char(chars[i].ch)
+        || (is_hyphen(chars[i].ch)
+            && chars
+                .get(i + 1)
+                .is_some_and(|c| is_word_char(c.ch) && same_line(&c.rect, &chars[i].rect)))
+}
+
+/// The nearest non-whitespace glyph before `i` (a backend may or may not emit a glyph for the line
+/// break itself, so neither wrap test may assume adjacency across it).
+fn prev_glyph(chars: &[CharBox], i: usize) -> Option<usize> {
+    chars[..i].iter().rposition(|c| !c.ch.is_whitespace())
+}
+
+/// The nearest non-whitespace glyph after `i`.
+fn next_glyph(chars: &[CharBox], i: usize) -> Option<usize> {
+    chars
+        .get(i + 1..)?
+        .iter()
+        .position(|c| !c.ch.is_whitespace())
+        .map(|j| i + 1 + j)
 }
 
 /// A column gutter must be at least this multiple of the median glyph width — an interior vertical
@@ -382,16 +545,17 @@ pub fn text_in_rect(chars: &[CharBox], rect: NormRect) -> TextSelection {
             _ => lines.push(vec![c]),
         }
     }
-    let mut parts = Vec::with_capacity(lines.len());
+    let mut parts: Vec<(String, Option<Wrap>)> = Vec::with_capacity(lines.len());
     let mut boxes = Vec::with_capacity(lines.len());
     for line in &lines {
-        parts.push(
-            line.iter()
-                .map(|c| c.ch)
-                .collect::<String>()
-                .trim()
-                .to_string(),
-        );
+        let text = line
+            .iter()
+            .map(|c| c.ch)
+            .collect::<String>()
+            .trim()
+            .to_string();
+        let wrap = line.last().and_then(|last| wrap_after_part(last, &text));
+        parts.push((text, wrap));
         let mut b = line[0].rect;
         for c in &line[1..] {
             b = b.union(&c.rect);
@@ -399,7 +563,7 @@ pub fn text_in_rect(chars: &[CharBox], rect: NormRect) -> TextSelection {
         boxes.push(b);
     }
     TextSelection {
-        text: parts.join(" ").trim().to_string(),
+        text: join_lines(&parts).trim().to_string(),
         boxes,
     }
 }
@@ -491,7 +655,7 @@ pub fn text_line_span(chars: &[CharBox], start: (f32, f32), end: (f32, f32)) -> 
     let (fy0, fy1) = line_span(&lines[focus]);
     let clip_focus = sel.len() > 1 && end.1 >= fy0 && end.1 <= fy1;
 
-    let mut parts: Vec<String> = Vec::new();
+    let mut parts: Vec<(String, Option<Wrap>)> = Vec::new();
     let mut boxes: Vec<NormRect> = Vec::new();
     for &idx in &sel {
         let line = &lines[idx];
@@ -519,21 +683,22 @@ pub fn text_line_span(chars: &[CharBox], start: (f32, f32), end: (f32, f32)) -> 
         for c in &take[1..] {
             bx = bx.union(&c.rect);
         }
-        parts.push(
-            take.iter()
-                .map(|c| c.ch)
-                .collect::<String>()
-                .trim()
-                .to_string(),
-        );
+        let text = take
+            .iter()
+            .map(|c| c.ch)
+            .collect::<String>()
+            .trim()
+            .to_string();
+        let wrap = take.last().and_then(|last| wrap_after_part(last, &text));
+        parts.push((text, wrap));
         boxes.push(bx);
     }
     // Drop word-less edge lines (a stray blank line clipped at an end).
-    while parts.last().is_some_and(String::is_empty) {
+    while parts.last().is_some_and(|p| p.0.is_empty()) {
         parts.pop();
         boxes.pop();
     }
-    while parts.first().is_some_and(String::is_empty) {
+    while parts.first().is_some_and(|p| p.0.is_empty()) {
         parts.remove(0);
         boxes.remove(0);
     }
@@ -548,7 +713,7 @@ pub fn text_line_span(chars: &[CharBox], start: (f32, f32), end: (f32, f32)) -> 
         }
     }
     TextSelection {
-        text: parts.join(" ").trim().to_string(),
+        text: join_lines(&parts).trim().to_string(),
         boxes,
     }
 }
@@ -575,11 +740,61 @@ fn hit_char(chars: &[CharBox], x: f32, y: f32) -> Option<usize> {
     best.filter(|_| best_d <= HIT_TOLERANCE)
 }
 
-/// Union the boxes of a single-line glyph run into per-line highlight rects (a word is one line,
-/// but guard for a run that wraps).
+/// Join a selection's per-line runs — each its text and what the break after it did ([`Wrap`]) —
+/// into one string. A line that broke mid-word runs straight on into the next with no space, minus
+/// the hyphen if the layout was the one that put it there: "pontifi-" + "cate" = "pontificate",
+/// "well-" + "known" = "well-known". Every other pair of lines is joined by a single space.
+fn join_lines(parts: &[(String, Option<Wrap>)]) -> String {
+    let mut out = String::new();
+    for (i, (text, _)) in parts.iter().enumerate() {
+        if i > 0 {
+            match parts[i - 1].1.filter(|_| starts_mid_word(text)) {
+                Some(Wrap::SoftHyphen) => {
+                    out.pop(); // that hyphen is the join, not a character of the word
+                }
+                Some(Wrap::Kept) => {}
+                None => out.push(' '),
+            }
+        }
+        out.push_str(text);
+    }
+    out
+}
+
+/// What the break after a selected line run did to the word it ends. The glyph carries it when the
+/// backend laid the text out; otherwise it is read off the run's own text, like [`wrap_of`].
+fn wrap_after_part(last: &CharBox, text: &str) -> Option<Wrap> {
+    if last.anchor.is_some() {
+        return last.wrap;
+    }
+    ends_mid_word(text).then_some(Wrap::SoftHyphen)
+}
+
+/// Whether `s` ends a line mid-word: a hyphen — possibly the second of two, see
+/// [`word_before_hyphen`] — with a letter or digit in front of it. A dash used as punctuation
+/// ("a word - ") has a space there, so it never joins.
+fn ends_mid_word(s: &str) -> bool {
+    let mut back = s.chars().rev();
+    back.next().is_some_and(is_hyphen) && back.find(|c| !is_hyphen(*c)).is_some_and(is_word_char)
+}
+
+/// Whether `s` continues a split word: it starts with a letter or digit, or with the hyphen a
+/// compound kept when the break fell in front of it ("self-" / "-evident"). Mirrors [`starts_word`].
+fn starts_mid_word(s: &str) -> bool {
+    let mut fwd = s.chars();
+    match fwd.next() {
+        Some(c) if is_word_char(c) => true,
+        Some(c) if is_hyphen(c) => fwd.next().is_some_and(is_word_char),
+        _ => false,
+    }
+}
+
+/// Union the boxes of a glyph run into per-line highlight rects (a word is one line, but a
+/// hyphenated or searched-across wrap spans two). Whitespace glyphs are skipped: a backend may box
+/// them degenerately (or off the line), which would split a run into spurious rects.
 fn line_boxes(run: &[CharBox]) -> Vec<NormRect> {
     let mut boxes = Vec::new();
-    for c in run {
+    for c in run.iter().filter(|c| !c.ch.is_whitespace()) {
         match boxes.last_mut() {
             Some(b) if same_line(b, &c.rect) => *b = b.union(&c.rect),
             _ => boxes.push(c.rect),
@@ -608,7 +823,12 @@ fn is_word_char(c: char) -> bool {
 }
 
 fn is_connector(c: char) -> bool {
-    matches!(c, '\'' | '\u{2019}' | '-')
+    matches!(c, '\'' | '\u{2019}') || is_hyphen(c)
+}
+
+/// Hyphens a line break can split a word across: ASCII, Unicode, and the soft hyphen.
+fn is_hyphen(c: char) -> bool {
+    matches!(c, '-' | '\u{2010}' | '\u{00ad}')
 }
 
 fn is_word_or_connector(c: char) -> bool {
@@ -634,8 +854,25 @@ mod tests {
                     y1: y + h,
                 },
                 anchor: None,
+                wrap: None,
             })
             .collect()
+    }
+
+    /// The same, but as a **reflow** backend emits it: every glyph anchored (so [`wrap_of`] trusts
+    /// the layout rather than reading the page), with `wrap` on the line's last glyph.
+    fn laid_out(s: &str, x0: f32, x1: f32, y: f32, h: f32, wrap: Option<Wrap>) -> Vec<CharBox> {
+        let mut chars = line(s, x0, x1, y, h);
+        for (i, c) in chars.iter_mut().enumerate() {
+            c.anchor = Some(TextAnchor {
+                block: 0,
+                char_offset: i,
+            });
+        }
+        if let Some(last) = chars.last_mut() {
+            last.wrap = wrap;
+        }
+        chars
     }
 
     fn rect(x0: f32, y0: f32, x1: f32, y1: f32) -> NormRect {
@@ -792,6 +1029,168 @@ mod tests {
         assert_eq!(sel.unwrap().text, "hi");
     }
 
+    /// A word soft-hyphenated across a line break: "pontifi-" then "cate" on the next line.
+    fn split_word() -> Vec<CharBox> {
+        let mut chars = line("the pontifi-", 0.0, 0.6, 0.10, 0.03);
+        chars.extend(line("cate rule", 0.0, 0.45, 0.16, 0.03));
+        chars
+    }
+
+    #[test]
+    fn word_at_joins_a_word_the_line_break_split() {
+        let chars = split_word();
+        // Tapping the first half ("pontifi-", second token on the top line)...
+        let head = word_at(&chars, 0.35, 0.115).expect("a glyph of the first half");
+        assert_eq!(
+            head.text, "pontificate",
+            "the hyphen joins the halves, it isn't a character"
+        );
+        assert_eq!(
+            head.boxes.len(),
+            2,
+            "one highlight box per line the word spans"
+        );
+        // ...and tapping the continuation gives the same word.
+        let tail = word_at(&chars, 0.04, 0.175).expect("a glyph of the second half");
+        assert_eq!(tail.text, "pontificate");
+        assert_eq!(
+            tail.boxes, head.boxes,
+            "either half selects the same two boxes"
+        );
+    }
+
+    #[test]
+    fn word_at_leaves_a_neighbouring_word_of_a_split_alone() {
+        let chars = split_word();
+        assert_eq!(word_at(&chars, 0.08, 0.115).unwrap().text, "the");
+        assert_eq!(word_at(&chars, 0.35, 0.175).unwrap().text, "rule");
+    }
+
+    #[test]
+    fn word_at_drops_only_the_hyphen_the_layout_inserted() {
+        let mut chars = laid_out("the pontifi-", 0.0, 0.6, 0.10, 0.03, Some(Wrap::SoftHyphen));
+        chars.extend(laid_out("cate rule", 0.0, 0.45, 0.16, 0.03, None));
+        assert_eq!(word_at(&chars, 0.35, 0.115).unwrap().text, "pontificate");
+        assert_eq!(word_at(&chars, 0.04, 0.175).unwrap().text, "pontificate");
+    }
+
+    #[test]
+    fn word_at_keeps_a_compounds_own_hyphen_across_the_break() {
+        // The layout broke "well-known" at the hyphen it already had, so it added none: both halves
+        // rejoin with that hyphen intact. Identical on the page to the case above.
+        let mut chars = laid_out("well-", 0.0, 0.25, 0.10, 0.03, Some(Wrap::Kept));
+        chars.extend(laid_out("known", 0.0, 0.25, 0.16, 0.03, None));
+        assert_eq!(word_at(&chars, 0.05, 0.115).unwrap().text, "well-known");
+        assert_eq!(word_at(&chars, 0.10, 0.175).unwrap().text, "well-known");
+    }
+
+    #[test]
+    fn word_at_believes_a_layout_that_reports_no_split() {
+        // The same two lines, but the layout says it split nothing — the source really is "well-"
+        // followed by "known" (two tokens). Guessing from the hyphen would fuse them.
+        let mut chars = laid_out("well-", 0.0, 0.25, 0.10, 0.03, None);
+        chars.extend(laid_out("known", 0.0, 0.25, 0.16, 0.03, None));
+        assert_eq!(word_at(&chars, 0.05, 0.115).unwrap().text, "well");
+        assert_eq!(word_at(&chars, 0.10, 0.175).unwrap().text, "known");
+    }
+
+    #[test]
+    fn word_at_joins_an_unspaced_script_break() {
+        // A CJK line break needs no hyphen at all, so there is nothing to drop.
+        let mut chars = laid_out("\u{6f22}\u{5b57}", 0.0, 0.2, 0.10, 0.03, Some(Wrap::Kept));
+        chars.extend(laid_out("\u{6e2c}\u{8a66}", 0.0, 0.2, 0.16, 0.03, None));
+        let sel = word_at(&chars, 0.05, 0.115).unwrap();
+        assert_eq!(sel.text, "\u{6f22}\u{5b57}\u{6e2c}\u{8a66}");
+        assert_eq!(sel.boxes.len(), 2);
+    }
+
+    #[test]
+    fn selection_and_search_follow_the_layout_across_a_kept_hyphen() {
+        let mut chars = laid_out("a well-", 0.0, 0.35, 0.10, 0.03, Some(Wrap::Kept));
+        chars.extend(laid_out("known fact", 0.0, 0.5, 0.16, 0.03, None));
+        let sel = text_line_span(&chars, (0.02, 0.115), (0.48, 0.175));
+        assert_eq!(
+            sel.text, "a well-known fact",
+            "copied text keeps the hyphen"
+        );
+        assert_eq!(find_matches(&chars, "well-known").len(), 1);
+        assert!(
+            find_matches(&chars, "wellknown").is_empty(),
+            "the hyphen is real, so it is searched for"
+        );
+    }
+
+    #[test]
+    fn word_at_rebuilds_a_compound_broken_at_its_own_hyphen() {
+        // en-US patterns offer "well-known" exactly one break — at byte 5, right after its own
+        // hyphen — so the layout appends a second one and the line ends "well--". Only the appended
+        // hyphen is the join; the word keeps the one it came with.
+        let mut chars = line("well--", 0.0, 0.3, 0.10, 0.03);
+        chars.extend(line("known", 0.0, 0.25, 0.16, 0.03));
+        assert_eq!(word_at(&chars, 0.05, 0.115).unwrap().text, "well-known");
+        assert_eq!(word_at(&chars, 0.10, 0.175).unwrap().text, "well-known");
+    }
+
+    #[test]
+    fn word_at_rebuilds_a_compound_broken_before_its_own_hyphen() {
+        // "self-evident" breaks at byte 4, so the hyphen it keeps opens the continuation.
+        let mut chars = line("self-", 0.0, 0.25, 0.10, 0.03);
+        chars.extend(line("-evident", 0.0, 0.4, 0.16, 0.03));
+        assert_eq!(word_at(&chars, 0.05, 0.115).unwrap().text, "self-evident");
+        assert_eq!(word_at(&chars, 0.2, 0.175).unwrap().text, "self-evident");
+    }
+
+    #[test]
+    fn word_at_does_not_join_across_a_dash_ending_a_line() {
+        // A dash used as punctuation has a space in front of it — not a split word.
+        let mut chars = line("one -", 0.0, 0.25, 0.10, 0.03);
+        chars.extend(line("two", 0.0, 0.15, 0.16, 0.03));
+        assert_eq!(word_at(&chars, 0.05, 0.175).unwrap().text, "two");
+        assert_eq!(word_at(&chars, 0.03, 0.115).unwrap().text, "one");
+    }
+
+    #[test]
+    fn word_at_keeps_a_trailing_hyphen_off_the_word_at_a_page_end() {
+        // Nothing follows the hyphen (the wrap continues on the next page) — unchanged behaviour.
+        let chars = line("pontifi-", 0.0, 0.4, 0.10, 0.03);
+        assert_eq!(word_at(&chars, 0.2, 0.115).unwrap().text, "pontifi");
+    }
+
+    #[test]
+    fn word_at_joins_a_word_split_across_two_columns() {
+        // A two-column page (#194) breaks a word at the foot of column 1 and continues it at the
+        // head of column 2 — the continuation is to the right and *above*, but next in reading
+        // order, which is what the join follows.
+        let mut chars = line("the pontifi-", 0.05, 0.45, 0.90, 0.03);
+        chars.extend(line("cate rule", 0.55, 0.90, 0.05, 0.03));
+        let sel = word_at(&chars, 0.30, 0.915).expect("a glyph of the first half");
+        assert_eq!(sel.text, "pontificate");
+        assert_eq!(sel.boxes.len(), 2, "one box in each column");
+        assert_eq!(word_at(&chars, 0.58, 0.065).unwrap().text, "pontificate");
+    }
+
+    #[test]
+    fn drag_selection_heals_a_word_the_line_break_split() {
+        let chars = split_word();
+        let sel = text_line_span(&chars, (0.02, 0.115), (0.44, 0.175));
+        assert_eq!(
+            sel.text, "the pontificate rule",
+            "copied text reads as the source does"
+        );
+    }
+
+    #[test]
+    fn find_matches_spans_a_word_the_line_break_split() {
+        let chars = split_word();
+        let hits = find_matches(&chars, "pontificate");
+        assert_eq!(hits.len(), 1, "the split word is still findable whole");
+        assert_eq!(hits[0].boxes.len(), 2, "highlighted on both lines");
+        assert!(hits[0].snippet.contains("pontificate rule"));
+        // The wrap still separates two whole words.
+        assert_eq!(find_matches(&chars, "pontificate rule").len(), 1);
+        assert!(find_matches(&chars, "pontifi-cate").is_empty());
+    }
+
     #[test]
     fn text_in_rect_collects_a_span_in_order() {
         let chars = line("hello world", 0.0, 0.55, 0.10, 0.03);
@@ -871,6 +1270,7 @@ mod tests {
                 y1: 0.13,
             },
             anchor: None,
+            wrap: None,
         });
         chars.extend(line("second line two", 0.0, 0.8, 0.16, 0.03));
         let sel = text_line_span(&chars, (0.1, 0.115), (0.9, 0.175));


### PR DESCRIPTION
Selecting a word that soft hyphenation had split across a line looked up only its first half — reported from a two-column read: `pontificate`, broken as `pontifi-` / `cate`, came back as *"pontifi" not found*.

## Cause

`text_select::word_at` grew a word with `joins()`, which requires both glyphs on one line, so expansion stopped at the break; `trim_matches` then dropped the hyphen. The result looked like an ordinary word, so no stem candidate or online fallback could recognise it as half of one.

Two columns is what surfaced it — a column measure is half as wide, so hyphenation fires far more often — but the bug is not specific to columns. The same gap made a split word unfindable by in-document search and mis-copied by a drag (`"pontifi- cate"`).

## What the layout now records

The hyphen at a break is not always ours, and the two cases print identically, so guessing from the glyphs cannot work:

| Source | en-US break | Prints as | Rejoins to |
|---|---|---|---|
| `pontificate` | 7 | `pontifi-` / `cate` | `pontificate` |
| `well-known` | 5 — after its own hyphen | `well-` / `known` | `well-known` |
| `self-evident` | 4 — before its own hyphen | `self-` / `-evident` | `self-evident` |

Each break now carries a `Wrap` saying whether the hyphen shown belongs to the source or was inserted here. It rides `PlacedRun` → `PlacedGlyph` → `CharBox`, converted at the backend boundary like `SourceAnchor` → `TextAnchor` so the selection domain stays uncoupled from the renderer.

Row two also fixes a rendering defect found while tracing this: `well-known` printed **`well--`**, because the layout appended its own hyphen to a fragment that already ended in one. Line breaking is unchanged — `hyphenate_fit` still measures a hyphen's width for a prefix that will not get one, so no break point and no pagination moves.

## Behaviour

- `word_at`, `find_matches`, and the line joiner behind copy / lasso-Define all follow one rule: rejoin the halves, dropping only a hyphen the layout inserted.
- The layout is believed when it reports **no** split, so a line that merely ends in a hyphen (`well- known`, two words) is left alone.
- A fixed-layout PDF supplies no flag and falls back to the printing convention: a line-ending hyphen with a letter in front of it split a word.
- A word split across a *page* break still resolves to its first half — the continuation is not among that page's glyphs.

## Tests

`cargo fmt`, `cargo clippy --all --all-targets -D warnings`, and 678 workspace tests pass; each commit was gated on its own.

Three layout tests cover the three break kinds and the absent double hyphen. In `reader-core`: unit tests for `SoftHyphen`, `Kept`, an unspaced-script (CJK) break, and a layout reporting no split; the fixed-layout fallbacks; and two end-to-end tests driving the real chain (`paginate_with` → `page_glyphs` → `page_charboxes` → `word_at`).

## Device check — done

Verified on a Manta (1920x2560) with a purpose-built EPUB: long words that hyphenate, compounds
that already carry a hyphen, and dashes used as punctuation as a control.

- Tapping either half of a split word defines the whole word.
- In-document search finds a word broken across a line.
- Drag-select and copy brings the word out whole.
- A compound broken at its own hyphen shows one hyphen. The page contained `so-` / `called`, which
  is exactly the case that printed `so--` before this change; no `--` appears anywhere on it.
- Dashes used as punctuation are unaffected.

Clean logcat throughout — no crash, no panic across the JNI boundary, no `wordAt` or `textInRect`
failure.
