### PR TITLE
fix(refresh): keep the reader's refresh settings across a rotation (#206)

### DIFF
--- a/reader-core/src/policy/eink_policy.rs
+++ b/reader-core/src/policy/eink_policy.rs
@@ -10,6 +10,11 @@ use device_eink::{DeviceCapabilities, Rect, RefreshCommand, RefreshIntent, Refre
 /// Default partial-refreshes-before-flash (RR3-FR3; KOReader `DEFAULT_FULL_REFRESH_COUNT`).
 pub const DEFAULT_GHOST_CLEAR_INTERVAL: u32 = 6;
 
+/// An interval of 0 would mean "promote never"; treat it as 1 (every turn flashes) instead.
+fn clamp_interval(interval: u32) -> u32 {
+    interval.max(1)
+}
+
 /// The reader's refresh policy. Constructed with the device capabilities + the panel size
 /// (used for the full-screen fallback) + the ghost-clear interval.
 #[derive(Debug, Clone)]
@@ -44,9 +49,10 @@ impl EinkRefreshPolicy {
         Self::with_interval(caps, screen, DEFAULT_GHOST_CLEAR_INTERVAL)
     }
 
-    /// A policy with an explicit ghost-clear interval (RR3-FR3, user-configurable).
+    /// A policy with an explicit ghost-clear interval (RR3-FR3, user-configurable), applied to
+    /// both the day and night cadence; [`Self::with_night_interval`] separates them.
     ///
-    /// An interval of 0 is treated as 1 (every page flashes) to avoid a divide-by-never.
+    /// An interval of 0 is treated as 1 (every turn flashes) to avoid a promote-never.
     #[must_use]
     pub fn with_interval(
         caps: DeviceCapabilities,
@@ -57,12 +63,12 @@ impl EinkRefreshPolicy {
             caps,
             screen,
             partial_count: 0,
-            ghost_clear_interval: ghost_clear_interval.max(1),
+            ghost_clear_interval: clamp_interval(ghost_clear_interval),
             dither: false,
             currently_scrolling: false,
             night_mode: false,
             night_partial_count: 0,
-            night_ghost_clear_interval: ghost_clear_interval.max(1),
+            night_ghost_clear_interval: clamp_interval(ghost_clear_interval),
             avoid_flashing: false,
         }
     }
@@ -76,18 +82,56 @@ impl EinkRefreshPolicy {
 
     /// Set the night-mode flash-promotion interval, independent of the day interval (RR3-FR6).
     ///
-    /// An interval of 0 is clamped to 1 (every night-mode turn flashes).
+    /// An interval of 0 is treated as 1 (every night-mode turn flashes).
     #[must_use]
     pub fn with_night_interval(mut self, night_ghost_clear_interval: u32) -> Self {
-        self.night_ghost_clear_interval = night_ghost_clear_interval.max(1);
+        self.set_night_interval(night_ghost_clear_interval);
         self
     }
 
     /// Enable the avoid-flashing downgrade: Full/Flash* promotions become Partial (RR3-FR7).
     #[must_use]
     pub fn with_avoid_flashing(mut self, avoid: bool) -> Self {
-        self.avoid_flashing = avoid;
+        self.set_avoid_flashing(avoid);
         self
+    }
+
+    // ---- In-place configuration ----------------------------------------------------------
+    //
+    // A live policy is re-configured through these rather than rebuilt. A rebuild makes every
+    // configured field the caller's responsibility to re-supply, so the ones it does not know
+    // about revert to defaults behind the user's back — which is precisely how a rotation came
+    // to reset the flash intervals and avoid-flashing (#206). Mutating in place cannot drop a
+    // field the caller never mentions, so a setting added here is not silently lost tomorrow.
+
+    /// Set the day flash-promotion interval (RR3-FR3). 0 is treated as 1 (every turn flashes).
+    pub fn set_interval(&mut self, ghost_clear_interval: u32) {
+        self.ghost_clear_interval = clamp_interval(ghost_clear_interval);
+    }
+
+    /// Set the night-mode flash-promotion interval, independent of the day interval (RR3-FR6).
+    /// 0 is treated as 1 (every night-mode turn flashes).
+    pub fn set_night_interval(&mut self, night_ghost_clear_interval: u32) {
+        self.night_ghost_clear_interval = clamp_interval(night_ghost_clear_interval);
+    }
+
+    /// Enable or disable the avoid-flashing downgrade (RR3-FR7).
+    pub fn set_avoid_flashing(&mut self, avoid: bool) {
+        self.avoid_flashing = avoid;
+    }
+
+    /// Re-point the policy at a new panel geometry — rotation, or any `surfaceChanged` that
+    /// changes the metrics (RR21-FR4).
+    ///
+    /// Only the geometry and the *transient* state move: both flash counters restart and any
+    /// in-progress scroll is forgotten, because the surface that gesture belonged to is gone and a
+    /// metrics change is followed by a fresh full anyway. Everything the reader configured — the
+    /// day and night intervals, avoid-flashing, dithering, and the night flag — is kept.
+    pub fn set_screen(&mut self, screen: Rect) {
+        self.screen = screen;
+        self.partial_count = 0;
+        self.night_partial_count = 0;
+        self.currently_scrolling = false;
     }
 
     /// The current partial-refresh counter (test/diagnostic accessor).

--- a/reader-core/src/policy/eink_policy_tests.rs
+++ b/reader-core/src/policy/eink_policy_tests.rs
@@ -526,3 +526,110 @@ fn builder_order_is_independent() {
     }
     assert_eq!(drive(&mut a), drive(&mut b));
 }
+
+// ---- Rotation / geometry change (RR21-FR4, #206) ----
+
+fn rotated() -> Rect {
+    Rect::full(1872, 1404) // the same panel on its side
+}
+
+// #206: changing the panel geometry must not disturb anything the reader configured. This is the
+// regression the rebuild-on-rotation caused — the intervals and avoid-flashing reverted to their
+// defaults while the UI still showed the reader's choice.
+#[test]
+fn set_screen_keeps_the_configuration_a_rebuild_would_drop() {
+    let caps = DeviceCapabilities::supernote_full();
+    let mut policy = EinkRefreshPolicy::with_interval(caps, screen(), 2)
+        .with_night_interval(3)
+        .with_avoid_flashing(true)
+        .with_dither(true);
+    policy.on_night_mode(true);
+
+    policy.set_screen(rotated());
+
+    assert!(
+        policy.is_night(),
+        "night is the active theme, not a per-gesture flag — a rotation does not leave it"
+    );
+    // Two Partials, then the third night turn hits the night interval (3). It still promotes —
+    // the counter resets — but avoid_flashing downgrades the flash to a Partial, and the dither
+    // request rides along. A rebuilt policy would have flashed on turn 6 with dither off.
+    policy.on_page_turn(page());
+    policy.on_page_turn(page());
+    assert_eq!(
+        policy.on_page_turn(page()),
+        vec![RefreshCommand::Update {
+            rect: page(),
+            intent: RefreshIntent::Partial,
+            dither: true,
+        }]
+    );
+    assert_eq!(
+        policy.night_partial_count(),
+        0,
+        "the promotion still happened; only its flash was downgraded"
+    );
+}
+
+// The flip side: the counters are transient, and a metrics change is followed by a fresh full
+// anyway, so both cadences restart from zero.
+#[test]
+fn set_screen_restarts_both_flash_cadences() {
+    let caps = DeviceCapabilities::supernote_full();
+    let mut policy = EinkRefreshPolicy::with_interval(caps, screen(), 6);
+    for _ in 0..5 {
+        policy.on_page_turn(page());
+    }
+    policy.on_night_mode(true);
+    for _ in 0..4 {
+        policy.on_page_turn(page());
+    }
+    assert_eq!(policy.partial_count(), 5);
+    assert_eq!(policy.night_partial_count(), 4);
+
+    policy.set_screen(rotated());
+
+    assert_eq!(policy.partial_count(), 0);
+    assert_eq!(policy.night_partial_count(), 0);
+}
+
+// The screen rect is the full-screen fallback for a basic panel (RR3-FR10 / RR2-FR4) — after a
+// rotation it has to describe the panel the reader is actually looking at.
+#[test]
+fn set_screen_moves_the_full_screen_fallback_to_the_new_panel() {
+    let caps = DeviceCapabilities::supernote_baseline();
+    let mut policy = EinkRefreshPolicy::new(caps, screen());
+
+    policy.set_screen(rotated());
+
+    assert_eq!(
+        policy.on_page_turn(page()),
+        vec![RefreshCommand::Update {
+            rect: rotated(),
+            intent: RefreshIntent::Full,
+            dither: false,
+        }]
+    );
+}
+
+// The setters share the builders' clamp: an interval of 0 means every turn flashes, not never.
+#[test]
+fn interval_setters_clamp_zero_to_one() {
+    let caps = DeviceCapabilities::supernote_full();
+    let mut policy = EinkRefreshPolicy::with_interval(caps, screen(), 6);
+    policy.set_interval(0);
+    policy.set_night_interval(0);
+
+    let day = policy.on_page_turn(page());
+    assert_eq!(
+        day.len(),
+        2,
+        "day interval 0 promotes on the very first turn"
+    );
+    assert_eq!(day[0], RefreshCommand::WaitForLast);
+
+    policy.on_night_mode(true);
+    let night = policy.on_page_turn(page());
+    assert_eq!(night.len(), 2, "and so does night interval 0");
+    assert_eq!(night[0], RefreshCommand::WaitForLast);
+}

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -378,15 +378,15 @@ impl ReaderSession {
         Ok(())
     }
 
-    /// Rebuild the refresh policy from a settings snapshot for `book` — flash interval, night
+    /// Apply a settings snapshot for `book` to the refresh policy — flash interval, night
     /// interval, and avoid-flashing all come from settings (RR23 ↔ RR3-FR3/FR6/FR7). The shell
     /// calls this on open and whenever a relevant setting changes.
     pub fn apply_settings(&mut self, settings: &SettingsSnapshot, book: Option<&BookId>) {
-        let caps = self.policy.capabilities();
-        let screen = Rect::full(self.viewport.width, self.viewport.height);
-        self.policy = EinkRefreshPolicy::with_interval(caps, screen, settings.flash_interval(book))
-            .with_night_interval(settings.night_flash_interval(book))
-            .with_avoid_flashing(settings.avoid_flashing(book));
+        self.policy.set_interval(settings.flash_interval(book));
+        self.policy
+            .set_night_interval(settings.night_flash_interval(book));
+        self.policy
+            .set_avoid_flashing(settings.avoid_flashing(book));
     }
 
     /// Persist the current reading position (RR12-FR3). For a reflowable document it also stores the
@@ -490,11 +490,14 @@ impl ReaderSession {
             return;
         }
         self.viewport = viewport;
-        let caps = self.policy.capabilities();
-        let screen = Rect::full(viewport.width, viewport.height);
-        // Preserve nothing of the partial counter on a metrics change — a fresh full is
-        // expected after a viewport change anyway (RR21-FR4).
-        self.policy = EinkRefreshPolicy::new(caps, screen);
+        // Re-point the policy at the new panel rather than rebuilding it. A rebuild reverted the
+        // reader's flash interval, night interval and avoid-flashing to their defaults, silently
+        // and for the rest of the session — the UI and the store still held the chosen values, so
+        // only the policy actually driving the panel had forgotten them (#206). `set_screen` still
+        // restarts the flash counters, which is all the rebuild was wanted for: a fresh full is
+        // expected after a metrics change anyway (RR21-FR4).
+        self.policy
+            .set_screen(Rect::full(viewport.width, viewport.height));
         // Cached renders are sized to the old viewport and laid out for it — drop them.
         self.invalidate_render_cache();
     }

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -412,6 +412,96 @@ fn settings_drive_the_policy_interval() {
     assert_eq!(second[0], RefreshCommand::WaitForLast);
 }
 
+// #206: rotating the device used to rebuild the policy from scratch, reverting the persisted
+// flash interval, night interval and avoid-flashing to their defaults for the rest of the session.
+// The reader saw the chosen values in the UI while the panel ignored them.
+//
+// Only page turns reach the policy through the session, so these two cover the day interval and
+// avoid-flashing; the night interval and the night flag are covered against `set_screen` directly
+// in the policy's own tests.
+#[test]
+fn a_viewport_change_keeps_the_persisted_flash_interval() {
+    let mut s = session_with_refresh_settings(&[(SettingKey::FlashInterval, SettingValue::Int(2))]);
+
+    s.set_viewport(Viewport::new(120, 100, 226)); // rotate
+
+    assert!(matches!(
+        s.on_gesture(Gesture::NextPage).as_slice(),
+        [RefreshCommand::Update {
+            intent: RefreshIntent::Partial,
+            ..
+        }]
+    ));
+    let second = s.on_gesture(Gesture::NextPage);
+    assert_eq!(
+        second.len(),
+        2,
+        "turn 2 promotes on the persisted interval; on the default 6 it would still be a Partial"
+    );
+    assert_eq!(second[0], RefreshCommand::WaitForLast);
+}
+
+#[test]
+fn a_viewport_change_keeps_avoid_flashing() {
+    let mut s = session_with_refresh_settings(&[
+        (SettingKey::FlashInterval, SettingValue::Int(2)),
+        (SettingKey::AvoidFlashing, SettingValue::Bool(true)),
+    ]);
+
+    s.set_viewport(Viewport::new(120, 100, 226)); // rotate
+
+    // Avoid-flashing downgrades every promotion, so no turn ever flashes. Rebuilt, the policy
+    // would drop back to interval 6 with the downgrade off and flash on the sixth turn.
+    for turn in 1..=6 {
+        assert!(
+            matches!(
+                s.on_gesture(Gesture::NextPage).as_slice(),
+                [RefreshCommand::Update {
+                    intent: RefreshIntent::Partial,
+                    ..
+                }]
+            ),
+            "turn {turn} flashed despite avoid-flashing"
+        );
+    }
+}
+
+// The same viewport change still restarts the flash cadence — the counter is transient, and a
+// metrics change is followed by a fresh full anyway (RR21-FR4).
+#[test]
+fn a_viewport_change_restarts_the_flash_cadence() {
+    let mut s = session_with_refresh_settings(&[(SettingKey::FlashInterval, SettingValue::Int(2))]);
+
+    s.on_gesture(Gesture::NextPage); // one turn into a 2-turn cadence
+    s.set_viewport(Viewport::new(120, 100, 226));
+
+    assert!(
+        matches!(
+            s.on_gesture(Gesture::NextPage).as_slice(),
+            [RefreshCommand::Update {
+                intent: RefreshIntent::Partial,
+                ..
+            }]
+        ),
+        "the first turn after the change starts the cadence over, so it does not promote"
+    );
+    let second = s.on_gesture(Gesture::NextPage);
+    assert_eq!(second.len(), 2);
+    assert_eq!(second[0], RefreshCommand::WaitForLast);
+}
+
+/// A 10-page session over an in-memory store carrying `settings`, opened at 100x120 so a test can
+/// rotate it to 120x100.
+fn session_with_refresh_settings(settings: &[(SettingKey, SettingValue)]) -> ReaderSession {
+    let store: Arc<dyn ReaderStore> = Arc::new(SqliteStore::open_in_memory().unwrap());
+    for (key, value) in settings {
+        store
+            .put_setting(Scope::Global, *key, value.clone())
+            .unwrap();
+    }
+    store_session(10, store, BookId::new("b").unwrap())
+}
+
 // RR24-FR3: the session's onTrimMemory hook trims the caches.
 #[test]
 fn on_trim_memory_clears_caches() {


### PR DESCRIPTION
Fixes #206.

`ReaderSession::set_viewport` rebuilt the refresh policy from scratch:

```rust
self.policy = EinkRefreshPolicy::new(caps, screen);
```

`::new` takes no intervals and no avoid-flashing flag, so rotating an open document reverted the
flash interval, the night flash interval and avoid-flashing to their defaults. Nothing re-applied
the settings snapshot afterwards, so they stayed reverted for the rest of the session — the policy
is only configured once, from `attach_store` on open.

The fix is to stop reconstructing the policy at all. `set_viewport` now re-points the existing one
at the new panel:

```rust
self.policy.set_screen(Rect::full(viewport.width, viewport.height));
```

and `apply_settings` configures it in place rather than replacing it.

## Why in place rather than re-applying the settings after the rebuild

Re-applying would have worked, but it leaves the shape that caused this. A rebuild makes every
configured field the caller's responsibility to re-supply, and `set_viewport` only ever knew about
`caps`. That is why `avoid_flashing` was dropped: it was added to the policy after `set_viewport`
was written, and `set_viewport` was never taught about it. The same would happen to the next field
someone adds.

So the policy now owns its own configuration and exposes setters for it — `set_interval`,
`set_night_interval`, `set_avoid_flashing`, `set_screen`. The `with_*` builders delegate to those,
which also puts the `>= 1` interval clamp in one place instead of three. A caller that changes
geometry can no longer drop a field it never mentions.

`set_screen` keeps the split explicit. Geometry and transient state move — both flash counters
restart, and the in-progress-scroll flag clears — because a metrics change is followed by a fresh
full anyway (RR21-FR4), and that restart is the only thing the rebuild was actually wanted for.
Everything configured stays: the day and night intervals, avoid-flashing, dithering, and the night
flag.

`apply_settings` no longer resets the counters as a side effect of rebuilding. Its only caller is
`attach_store`, which runs on a freshly opened session's policy where they are zero regardless, so
nothing observable changes.

## Scope

**The night interval is inert regardless.** `RefreshPolicy::on_night_mode` has no caller outside
tests — `nativeSetNight` routes to `ReaderSession::set_night`, which flips the session's render
invert flag and never touches the policy. So `policy.night_mode` is permanently `false` at runtime
and `night_ghost_clear_interval` never selects a cadence. Of the three settings #206 names, that one
could not have taken effect even with this fix. Preserving it across a rotation is still correct,
and it is covered at the policy level where it can be observed.

These three settings currently have no writer outside the core. There is no JNI entry point that
puts them and no shell UI that sets them — `put_setting` appears only in the sqlite tests — so they
always hold their registered defaults, and reverting them to defaults reverts them to what they
already were. The fault is real but latent today.

The flash control the reader actually has is the shell's own `RefreshCadence` (#99), driven by
`DisplayPrefs.fullRefreshEvery` and applied on top of the core's command stream in `postJump`. That
path does not have this bug: `ReaderActivity` declares `configChanges="orientation|screenSize"`, so
a rotation never recreates it and the interval survives.

This corrects the core and is a prerequisite for exposing the settings. It is worth noting that
landing that UI would mean two flash cadences running at once — the core's and the shell's — and
that is a decision to make separately.

## Tests

Host only; no device check needed.

At the policy level, `set_screen` keeps a configured night interval, avoid-flashing, dithering and
the night flag across a geometry change, restarts both cadences, and moves the full-screen fallback
rect to the new panel. At the session level, rotating a session with a persisted interval of 2 still
promotes on turn 2, still suppresses the flash across six turns with avoid-flashing on, and still
restarts the cadence at the change.

The three session tests fail against the previous behaviour — I restored the rebuild to confirm it
rather than assume it.

`cargo fmt --all --check`, `cargo clippy --all --all-targets -- -D warnings` and
`cargo test --workspace` are green (685 passing).

## Also on this branch

`EinkRefreshPolicy::capabilities()` is deleted — its only two callers were the rebuild sites this
branch removes, and being `pub` it drew no dead-code warning.

The interval clamp's documented rationale was wrong, and had been before this branch: an unclamped
0 promotes on *every* turn, not never, because `on_page_turn` increments before testing
`>= interval`. 0 and 1 are therefore indistinguishable, which makes the clamp normalisation rather
than a guard. The docs now say that, and the clamp is asserted directly instead of through a page
turn — the behavioural version passed with the clamp deleted.

`set_interval` is renamed `set_day_interval`: it sets only the day cadence, while the similarly
named `with_interval` seeds both, and nothing catches a caller who expects otherwise.

`currently_scrolling` is written in four places and read in none, so the comment justifying its
write in `on_page_turn` — a guard "against a lost `on_scroll_end` leaving promotion suppressed" —
described a branch that does not exist. The field stays, since RR3-FR4 names it as state the policy
carries, but the comment now says where that requirement is actually met: `on_scroll_start` resets
the flash counter and `on_scroll_update` never advances it, which is what stops a long scroll
mid-flashing. Two clamp tests were renamed for the same reason — they pass with the clamp deleted,
so they document behaviour rather than pinning the clamp, and their names now say so.
