### PR TITLE
feat: configurable EPUB page margins (#167)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -305,7 +305,7 @@ class AdjustSheetController(private val host: Host) {
         return container
     }
 
-    /** The "Page" tab: reflow Line Spacing + Alignment (EPUB; a toast on fixed-layout PDF). */
+    /** The "Page" tab: reflow Margin + Line Spacing + Alignment (EPUB; a toast on fixed-layout PDF). */
     private fun pagePanel(): View {
         fun applyReflow(call: () -> Int) =
             runReflow(call, whenFixedLayout = "Page layout adjusts reflowable books (EPUB)")
@@ -319,6 +319,13 @@ class AdjustSheetController(private val host: Host) {
                 host.setReflowMode(which == 1)
             }))
         }
+        // #167. The default margin was reported as too wide, and the bezel already eats usable
+        // width, so the range runs down to none rather than only trimming the default a little.
+        container.addView(settingRow("Margin", segmented(DisplayPrefs.MARGIN_LABELS, prefs.marginIndex()) { which ->
+            prefs.marginPct = DisplayPrefs.MARGINS[which]
+            host.diag { "DIAG margin=${DisplayPrefs.MARGINS[which]}%" }
+            applyReflow { NativeBridge.nativeSetMargin(host.docHandle, DisplayPrefs.MARGINS[which]) }
+        }))
         container.addView(settingRow("Line Spacing", segmented(DisplayPrefs.LINE_SPACING_LABELS, prefs.lineSpacingIndex()) { which ->
             prefs.lineSpacingMult = DisplayPrefs.LINE_SPACINGS[which]
             host.diag { "DIAG line spacing=${DisplayPrefs.LINE_SPACINGS[which]}" }

--- a/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
@@ -94,6 +94,18 @@ class DisplayPrefs(private val context: Context) {
         get() = typography.getInt("columns", 1).coerceIn(1, 2)
         set(i) = typography.edit().putInt("columns", i.coerceIn(1, 2)).apply()
 
+    /** Page margin as a percentage of page width (RR16-FR2; #167). Mirrors the core's
+     *  `DEFAULT_MARGIN_PCT`, so a book that has never been adjusted lays out as it always did.
+     *  Read coerced to a valid [MARGINS] step. */
+    var marginPct: Int
+        get() = typography.getInt("margin_pct", DEFAULT_MARGIN_PCT)
+            .let { if (it in MARGINS) it else DEFAULT_MARGIN_PCT }
+        set(p) = typography.edit().putInt("margin_pct", p).apply()
+
+    /** The segmented index for the saved margin. [marginPct] already coerces to a [MARGINS] step,
+     *  so this always finds one. */
+    fun marginIndex(): Int = MARGINS.indexOf(marginPct)
+
     /** The segmented index for the saved multiplier (nearest [LINE_SPACINGS] entry; default Medium). */
     fun lineSpacingIndex(): Int {
         val m = lineSpacingMult
@@ -123,6 +135,16 @@ class DisplayPrefs(private val context: Context) {
         val UI_SCALE_LABELS = listOf("S", "M", "L", "XL", "2XL")
 
         /** Page-turn intervals for the periodic full refresh (#99); index 0 = Off, the default. */
+        /** Page margin steps offered, as a percentage of page width (#167). The reader asked for
+         *  margins narrower than the default, and the Supernote bezel already eats usable width;
+         *  the top of the range stops where the measure gets too short to read. */
+        val MARGINS = listOf(0, 2, 4, 6, 9, 12)
+        val MARGIN_LABELS = listOf("None", "XS", "S", "M", "L", "XL")
+
+        /** Mirrors `reader-core`'s `DEFAULT_MARGIN_PCT` — the layout engine's own proportional
+         *  default, so an unadjusted book paginates exactly as it did before this was settable. */
+        const val DEFAULT_MARGIN_PCT = 6
+
         val REFRESH_INTERVALS = listOf(0, 1, 3, 5, 10)
         val REFRESH_INTERVAL_LABELS = listOf("Off", "1", "3", "5", "10")
 

--- a/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/NativeBridge.kt
@@ -57,6 +57,7 @@ object NativeBridge {
         lineSpacing: Float,
         alignCode: Int,
         columns: Int,
+        marginPct: Int,
     ): Long
 
     /** Persist the current reading position (RR12-FR3); store-less session = no-op. */
@@ -256,9 +257,14 @@ object NativeBridge {
      *  for (#194). Lets the shell say a request was declined rather than leave it looking ignored. */
     external fun nativeEffectiveColumns(handle: Long): Int
 
+    /** Reflow page margin as a percentage of page width (RR16-FR2; #167); repaginates EPUB.
+     *  Clamped by the core, so an out-of-range value is a setting rather than an error. Returns the
+     *  new page, or -1 for a fixed-layout PDF. Re-render after. */
+    external fun nativeSetMargin(handle: Long, marginPct: Int): Int
+
     /** Apply ALL reflow typography at once, repaginating ONCE (RR4). Use this on the open path to
-     *  restore persisted settings — the individual setters each repaginate, so applying four of
-     *  them in a row costs four full passes over the book (#161/#162). Returns the new page, or -1
+     *  restore persisted settings — the individual setters each repaginate, so applying them in a
+     *  row costs a full pass over the book each (#161/#162). Returns the new page, or -1
      *  for a fixed-layout PDF. Re-render after. */
     external fun nativeSetTypography(
         handle: Long,
@@ -267,6 +273,7 @@ object NativeBridge {
         lineSpacing: Float,
         alignCode: Int,
         columns: Int,
+        marginPct: Int,
     ): Int
 
     /** Chapters laid out so far, packed as `(done shl 32) or total` (#161). `total == 0` means no

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -861,6 +861,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                 path, capsBytes, viewW, viewH, DPI, dbPath, bookId,
                 displayPrefs.textScale, displayPrefs.font,
                 displayPrefs.lineSpacingMult, displayPrefs.alignment, displayPrefs.columns,
+                displayPrefs.marginPct,
             )
         } catch (e: RuntimeException) {
             Log.e(TAG, "open failed: ${e.message}")
@@ -1944,6 +1945,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
                             displayPrefs.lineSpacingMult,
                             displayPrefs.alignment,
                             displayPrefs.columns,
+                            displayPrefs.marginPct,
                         )
                     } catch (e: RuntimeException) {}
                 }

--- a/reader-core/src/document/mod.rs
+++ b/reader-core/src/document/mod.rs
@@ -105,6 +105,8 @@ pub struct Typography {
     pub align_code: i32,
     /// Text columns per page — 1 or 2 (#194).
     pub columns: i32,
+    /// Page margin as a percentage of page width (RR16-FR2 / #167).
+    pub margin_pct: i32,
 }
 
 impl Default for Typography {
@@ -117,6 +119,7 @@ impl Default for Typography {
             line_spacing: 1.4,
             align_code: 0,
             columns: 1,
+            margin_pct: crate::document::reflow::DEFAULT_MARGIN_PCT as i32,
         }
     }
 }
@@ -482,6 +485,13 @@ pub trait Document {
         None
     }
 
+    /// Set the reflow **page margin**, as a percentage of page width, and repaginate, preserving
+    /// the chapter (RR16-FR2 / RR9-FR4 / #167). Returns the new page, or `None` for a fixed-layout
+    /// format (PDF), which has margins of its own that reflow does not own. Default: unsupported.
+    fn set_margin(&self, _margin_pct: i32, _current_page: usize) -> Option<usize> {
+        None
+    }
+
     /// Columns the layout is **actually** using, which is not always what was asked for: a page too
     /// narrow for a readable measure lays out single-column regardless (#194). The shell needs this
     /// to tell the reader their request was declined rather than ignored. Default: 1.
@@ -515,6 +525,7 @@ pub trait Document {
             t.line_spacing,
             t.align_code,
             t.columns,
+            t.margin_pct,
             current_page,
         )
     }
@@ -534,6 +545,7 @@ pub trait Document {
         line_spacing: f32,
         align_code: i32,
         columns: i32,
+        margin_pct: i32,
         current_page: usize,
     ) -> Option<usize> {
         // Threaded, not batched: each step repaginates, so the next must resolve its chapter
@@ -558,6 +570,10 @@ pub trait Document {
             at = p;
         }
         if let Some(p) = self.set_columns(columns, at) {
+            page = Some(p);
+            at = p;
+        }
+        if let Some(p) = self.set_margin(margin_pct, at) {
             page = Some(p);
         }
         page

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -40,6 +40,24 @@ const MAX_SCALE: f32 = 3.0;
 /// Default line-spacing multiple (RR4). Mirrors the shell's `DisplayPrefs.DEFAULT_LINE_SPACING`.
 const DEFAULT_LINE_SPACING: f32 = 1.4;
 
+/// Default page margin, as a percentage of page width (RR16-FR2 / #167). Matches the proportional
+/// default the layout engine picks for itself, so an unset margin lays out exactly as it always did.
+pub const DEFAULT_MARGIN_PCT: u8 = 6;
+
+/// Widest margin offered. Past this the measure gets too short to read on a portrait panel, which
+/// is the same reason two columns are declined below a minimum measure (#194).
+pub const MAX_MARGIN_PCT: u8 = 15;
+
+/// The narrowest margin the layout is given, whatever the reader asks for. A page with glyphs
+/// running into the panel edge clips their side bearings, so the smallest setting still keeps a
+/// hair — imperceptible at this size, and a fraction of a percent on any panel we ship on.
+const MIN_MARGIN_PX: f32 = 8.0;
+
+/// Resolve a margin percentage against a page width (RR16-FR2 / #167).
+fn margin_px(page_w: f32, pct: u8) -> f32 {
+    (page_w * f32::from(pct.min(MAX_MARGIN_PCT)) / 100.0).max(MIN_MARGIN_PX)
+}
+
 /// How many materialized chapters to keep. Reading walks forward through one chapter at a time, so
 /// a couple of entries covers a page turn across a chapter boundary and a jump back, while keeping
 /// the retained page structures bounded regardless of how long the book is.
@@ -65,6 +83,8 @@ struct LayoutRequest {
     align: Align,
     /// Text columns per page (#194).
     columns: u8,
+    /// Page margin as a percentage of page width (RR16-FR2 / #167).
+    margin_pct: u8,
     /// The bundled reading face. Not part of [`LayoutOpts`], but a different face means different
     /// metrics, so it belongs in the staleness key.
     font_id: usize,
@@ -167,6 +187,8 @@ pub struct EpubBackend {
     align: Cell<Align>,
     /// Text columns per page (#194 — default 1). Drives repagination.
     columns: Cell<u8>,
+    /// Page margin as a percentage of page width (RR16-FR2 / #167).
+    margin_pct: Cell<u8>,
     /// The page size to lay out for; updated by the render path when the buffer changes.
     viewport: Cell<(u32, u32)>,
     /// The current pagination index, or `None` before the first one is needed. Laying out lazily
@@ -239,6 +261,7 @@ impl EpubBackend {
             line_spacing: Cell::new(DEFAULT_LINE_SPACING),
             align: Cell::new(Align::default()),
             columns: Cell::new(1),
+            margin_pct: Cell::new(DEFAULT_MARGIN_PCT),
             viewport: Cell::new((viewport.width, viewport.height)),
             // Deferred: the first read paginates, so the saved typography applied right after open
             // is folded into that single pass rather than triggering one pass per setting.
@@ -276,6 +299,7 @@ impl EpubBackend {
             line_spacing: Cell::new(DEFAULT_LINE_SPACING),
             align: Cell::new(Align::default()),
             columns: Cell::new(1),
+            margin_pct: Cell::new(DEFAULT_MARGIN_PCT),
             viewport: Cell::new((viewport.width, viewport.height)),
             laid: RefCell::new(None),
             chapter_pages: RefCell::new(Vec::new()),
@@ -440,6 +464,7 @@ impl EpubBackend {
             line_spacing: self.line_spacing.get(),
             align: self.align.get(),
             columns: self.columns.get(),
+            margin_pct: self.margin_pct.get(),
             font_id: self.font_id.get(),
         }
     }
@@ -451,6 +476,7 @@ impl EpubBackend {
         opts.line_spacing = request.line_spacing;
         opts.align = request.align;
         opts.columns = request.columns;
+        opts.margin = margin_px(w as f32, request.margin_pct);
         opts
     }
 
@@ -794,6 +820,22 @@ impl Document for EpubBackend {
         self.repaginate_keeping_chapter(current_page, pin)
     }
 
+    fn set_margin(&self, margin_pct: i32, current_page: usize) -> Option<usize> {
+        // Captured before the setting changes, for the same reason as every other reflow setter:
+        // reading it afterwards goes through `laid()`, which rebuilds, and would pin the position
+        // against the pagination we are about to replace (#160). Skipped when nothing is laid out
+        // yet — the open path restoring saved typography, where forcing a pagination is exactly
+        // what the lazy open exists to avoid (#161/#162/#186).
+        let pin = if self.laid.borrow().is_some() {
+            self.page_pin(current_page)
+        } else {
+            None
+        };
+        self.margin_pct
+            .set(margin_pct.clamp(0, i32::from(MAX_MARGIN_PCT)) as u8);
+        self.repaginate_keeping_chapter(current_page, pin)
+    }
+
     fn effective_columns(&self) -> i32 {
         i32::from(Self::opts_for(&self.current_request()).effective_columns())
     }
@@ -829,6 +871,7 @@ impl Document for EpubBackend {
         line_spacing: f32,
         align_code: i32,
         columns: i32,
+        margin_pct: i32,
         current_page: usize,
     ) -> Option<usize> {
         // Captured before the setting changes: reading it afterwards would go through `laid()`,
@@ -846,6 +889,8 @@ impl Document for EpubBackend {
         self.line_spacing.set(clamp_line_spacing(line_spacing));
         self.align.set(Align::from_code(align_code));
         self.columns.set(columns.clamp(1, 2) as u8);
+        self.margin_pct
+            .set(margin_pct.clamp(0, i32::from(MAX_MARGIN_PCT)) as u8);
         self.repaginate_keeping_chapter(current_page, pin)
     }
 

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -315,7 +315,7 @@ fn restoring_saved_typography_over_a_cold_open_costs_one_pagination() {
     reset_layout_passes();
     let b = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
     // Exactly what the shell does on open: restore four persisted settings, then read the count.
-    let page = b.set_typography(1.25, 1, 1.7, 2, 1, 0);
+    let page = b.set_typography(1.25, 1, 1.7, 2, 1, i32::from(DEFAULT_MARGIN_PCT), 0);
     let count = b.page_count();
     assert_eq!(
         layout_passes(),
@@ -357,17 +357,18 @@ fn an_out_of_range_font_id_resolves_to_the_default_face_without_repaginating() {
 }
 
 #[test]
-fn set_typography_lays_out_the_same_book_as_the_four_setters_do() {
+fn set_typography_lays_out_the_same_book_as_the_individual_setters_do() {
     // The batched path is an optimization, so it must be indistinguishable from the individual
     // setters it replaces — same page count, same page content.
     let batched = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
-    assert_eq!(batched.set_typography(1.5, 2, 1.2, 3, 1, 0), Some(0));
+    assert_eq!(batched.set_typography(1.5, 2, 1.2, 3, 1, 3, 0), Some(0));
 
     let stepwise = EpubBackend::open(SAMPLE.to_vec(), vp(400, 600)).unwrap();
     let _ = stepwise.set_font(2, 0);
     let _ = stepwise.set_text_scale(1.5, 0);
     let _ = stepwise.set_line_spacing(1.2, 0);
     let _ = stepwise.set_alignment(3, 0);
+    let _ = stepwise.set_margin(3, 0);
 
     assert_eq!(batched.page_count(), stepwise.page_count());
     assert!(batched.page_count() > 0);
@@ -748,7 +749,15 @@ fn a_cancel_restores_the_request_exactly_across_the_whole_settings_range() {
             for align_code in 0..4 {
                 let (w, _) = watcher(Some(1));
                 b.set_pagination_progress(w);
-                let _ = b.set_typography(scale, 1, spacing, align_code, 1, 0);
+                let _ = b.set_typography(
+                    scale,
+                    1,
+                    spacing,
+                    align_code,
+                    1,
+                    i32::from(DEFAULT_MARGIN_PCT),
+                    0,
+                );
 
                 assert_eq!(
                     b.current_request(),
@@ -1367,6 +1376,91 @@ fn selecting_two_columns_repaginates_and_keeps_the_chapter() {
         before,
         "single column should be as it was"
     );
+}
+
+/// #167 (RR16-FR2 / RR9-FR4): the page margin is a reflow setting like any other — it changes the
+/// measure, so it repaginates and keeps the reader where they were.
+#[test]
+fn narrowing_the_margin_repaginates_and_keeps_the_chapter() {
+    let doc = EpubBackend::open(SAMPLE.to_vec(), vp(1200, 1600)).expect("sample opens");
+    let default_pages = doc.page_count();
+    assert!(default_pages > 0);
+
+    let moved = doc
+        .set_margin(1, 0)
+        .expect("a reflowable document supports margins");
+    assert!(
+        moved < doc.page_count(),
+        "position must land inside the new pagination"
+    );
+
+    // A narrower margin is a wider measure, so the book cannot get longer.
+    assert!(
+        doc.page_count() <= default_pages,
+        "{} pages at 1% vs {default_pages} at the default",
+        doc.page_count()
+    );
+
+    // A wider margin is a shorter measure, so it cannot get shorter.
+    doc.set_margin(12, 0);
+    assert!(
+        doc.page_count() >= default_pages,
+        "{} pages at 12% vs {default_pages} at the default",
+        doc.page_count()
+    );
+
+    // And returning to the default reproduces the original pagination exactly.
+    doc.set_margin(i32::from(DEFAULT_MARGIN_PCT), 0);
+    assert_eq!(doc.page_count(), default_pages);
+}
+
+/// The default must lay a book out exactly as it did before the margin was configurable, or every
+/// pagination already cached on a device is invalidated for nothing (#162/#186).
+#[test]
+fn the_default_margin_matches_the_layout_engines_own() {
+    let configured = EpubBackend::open(SAMPLE.to_vec(), vp(1200, 1600)).expect("sample opens");
+    let pages = configured.page_count();
+
+    let engine_default = inkread_epub::LayoutOpts::new(1200.0, 1600.0, 56.0).margin;
+    let ours = super::margin_px(1200.0, DEFAULT_MARGIN_PCT);
+    assert!(
+        (engine_default - ours).abs() < f32::EPSILON,
+        "engine default {engine_default}px vs configured default {ours}px"
+    );
+    assert!(pages > 0);
+}
+
+/// Out-of-range margins are clamped rather than trusted — the value crosses JNI (RR21-FR3).
+#[test]
+fn an_out_of_range_margin_is_clamped() {
+    let doc = EpubBackend::open(SAMPLE.to_vec(), vp(1200, 1600)).expect("sample opens");
+
+    doc.set_margin(i32::from(MAX_MARGIN_PCT), 0);
+    let widest = doc.page_count();
+    for absurd in [99, i32::MAX] {
+        doc.set_margin(absurd, 0);
+        assert_eq!(doc.page_count(), widest, "clamped to the widest ({absurd})");
+    }
+
+    doc.set_margin(0, 0);
+    let narrowest = doc.page_count();
+    for absurd in [-1, i32::MIN] {
+        doc.set_margin(absurd, 0);
+        assert_eq!(
+            doc.page_count(),
+            narrowest,
+            "clamped to the narrowest ({absurd})"
+        );
+    }
+}
+
+/// A zero margin still keeps a hair, so glyph side bearings are never clipped against the panel
+/// edge — the reader gets the narrowest margin we can draw, not literally none.
+#[test]
+fn a_zero_margin_keeps_a_minimum_gutter() {
+    assert!(super::margin_px(1200.0, 0) > 0.0);
+    // On any panel we ship on, the floor is what a 0% request resolves to.
+    assert!((super::margin_px(1920.0, 0) - super::margin_px(1404.0, 0)).abs() < f32::EPSILON);
 }
 
 /// The request is stored even when the page is too narrow to honour it, so a later font-size

--- a/reader-core/src/jni.rs
+++ b/reader-core/src/jni.rs
@@ -213,6 +213,7 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeOpenDocumen
     line_spacing: jfloat,
     align_code: jint,
     columns: jint,
+    margin_pct: jint,
 ) -> jlong {
     env.with_env(|env| -> jni::errors::Result<jlong> {
         let path: String = path.try_to_string(env)?;
@@ -228,6 +229,7 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeOpenDocumen
             line_spacing,
             align_code,
             columns,
+            margin_pct,
         };
 
         let bytes = read_document_file(&path).map_err(|e| throw(env, &e))?;
@@ -1037,9 +1039,9 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeCancelPagin
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>();
 }
 
-// nativeSetTypography(handle, scale, fontId, lineSpacing, alignCode) : int — apply all four reflow
-// typography settings and repaginate ONCE (RR4). The open path restores persisted settings with
-// this instead of four separate calls: one repagination instead of four, which on a large book is
+// nativeSetTypography(handle, scale, fontId, lineSpacing, alignCode, columns, marginPct) : int —
+// apply every reflow typography setting and repaginate ONCE (RR4). The open path restores persisted
+// settings with this instead of one call each: one repagination instead of six, which on a large book is
 // the difference between opening in seconds and opening in minutes (#161/#162). Returns the new
 // page index, or -1 for a fixed-layout PDF. Re-render after.
 #[unsafe(no_mangle)]
@@ -1052,10 +1054,39 @@ pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetTypograp
     line_spacing: jfloat,
     align_code: jint,
     columns: jint,
+    margin_pct: jint,
 ) -> jint {
     env.with_env(|env| -> jni::errors::Result<jint> {
         let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
-        if session.set_typography(scale, font_id, line_spacing, align_code, columns) {
+        if session.set_typography(
+            scale,
+            font_id,
+            line_spacing,
+            align_code,
+            columns,
+            margin_pct,
+        ) {
+            Ok(session.current_page() as jint)
+        } else {
+            Ok(-1)
+        }
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+}
+
+// nativeSetMargin(handle, marginPct) : int — reflow page margin as a percentage of page width
+// (RR16-FR2 / #167); repaginates EPUB. Out-of-range values are clamped by the backend, not rejected
+// (RR21-FR3). Returns the new page index, or -1 for a fixed-layout PDF. Re-render after.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_jraghavan_inkread_NativeBridge_nativeSetMargin<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    margin_pct: jint,
+) -> jint {
+    env.with_env(|env| -> jni::errors::Result<jint> {
+        let session = unsafe { session_mut(handle) }.map_err(|e| throw(env, &e))?;
+        if session.set_margin(margin_pct) {
             Ok(session.current_page() as jint)
         } else {
             Ok(-1)

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -867,6 +867,21 @@ impl ReaderSession {
         }
     }
 
+    /// Set the reflow page margin as a percentage of page width and repaginate, preserving the
+    /// chapter (RR16-FR2 / RR9-FR4 / #167). `true` if the document reflowed; `false` for a
+    /// fixed-layout PDF. Re-render after.
+    pub fn set_margin(&mut self, margin_pct: i32) -> bool {
+        match self.document.set_margin(margin_pct, self.page) {
+            Some(new_page) => {
+                self.page = new_page.min(self.page_count().saturating_sub(1));
+                self.invalidate_render_cache(); // repagination changes what each page index renders
+                self.load_ink_for_current_page();
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Set the reflow alignment (`0=Left,1=Justify,2=Center,3=Right`; RR4); repaginates EPUB
     /// preserving the chapter. `false` for a fixed-layout PDF. Re-render after.
     pub fn set_alignment(&mut self, align_code: i32) -> bool {

--- a/reader-core/src/session.rs
+++ b/reader-core/src/session.rs
@@ -899,6 +899,7 @@ impl ReaderSession {
         line_spacing: f32,
         align_code: i32,
         columns: i32,
+        margin_pct: i32,
     ) -> bool {
         match self.document.set_typography(
             scale,
@@ -906,6 +907,7 @@ impl ReaderSession {
             line_spacing,
             align_code,
             columns,
+            margin_pct,
             self.page,
         ) {
             Some(new_page) => {

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -1438,6 +1438,7 @@ fn reading_typography() -> Typography {
         line_spacing: 1.7,
         align_code: 1,
         columns: 1,
+        margin_pct: i32::from(crate::document::reflow::DEFAULT_MARGIN_PCT),
     }
 }
 

--- a/reader-core/src/session_tests.rs
+++ b/reader-core/src/session_tests.rs
@@ -1458,6 +1458,31 @@ fn open_sample(store: Arc<dyn ReaderStore>, book: BookId, typography: Typography
     .unwrap()
 }
 
+// #167: the margin reaches the layout through the session the same way every other reflow setting
+// does — it repaginates, and the session's page stays inside the new pagination.
+#[test]
+fn setting_the_margin_repaginates_an_epub_through_the_session() {
+    let store: Arc<dyn ReaderStore> = Arc::new(SqliteStore::open_in_memory().unwrap());
+    let mut s = open_sample(store, BookId::new("margins").unwrap(), reading_typography());
+    let before = s.page_count();
+    assert!(before > 0);
+
+    assert!(s.set_margin(1), "an EPUB reflows");
+    assert!(
+        s.page_count() <= before,
+        "a narrower margin cannot add pages"
+    );
+    assert!(s.current_page() < s.page_count());
+}
+
+// A fixed-layout document has margins of its own that reflow does not own, so the call reports that
+// nothing happened rather than pretending it did.
+#[test]
+fn setting_the_margin_reports_no_reflow_on_a_fixed_document() {
+    let mut s = session(3, DeviceCapabilities::supernote_full());
+    assert!(!s.set_margin(2));
+}
+
 #[test]
 fn a_first_open_paginates_once_and_a_re_open_not_at_all() {
     let store: Arc<dyn ReaderStore> = Arc::new(SqliteStore::open_in_memory().unwrap());


### PR DESCRIPTION
Fixes #167.

The EPUB margin was fixed at 6% of page width inside the layout engine:

```rust
margin: (page_w * 0.06).max(8.0),
```

so there was nothing for a setting to change. This makes it a reflow parameter like font size and
line spacing, and puts a Margin control in the Adjust sheet's Page tab.

RR16-FR2 and RR9-FR4 already put margin in the MVP settings subset next to font size and line
spacing, and `SettingKey::Margin` has been registered but unread since RR23-FR2.

## The range

Six steps as a percentage of page width — 0, 2, 4, 6, 9, 12, labelled None to XL.

It runs all the way down to none rather than only trimming the default a little, because that is
what the report actually asks for: the default reads as too wide *and* the bezel has already taken
usable width before the layout gets a say. The top stops at 12 because past that the measure gets
too short to read on a portrait panel. The core clamps to 0..=15 independently, so a value arriving
across JNI outside the range offered is a setting rather than an error (RR21-FR3).

A zero margin still resolves to an 8px floor so glyph side bearings are never clipped against the
panel edge. On a Manta that is 0.4% of the width — flush, in practice.

## Default

6%, which is exactly what the layout engine picks for itself, on both sides of the bridge
(`DEFAULT_MARGIN_PCT` in the core, `DisplayPrefs.DEFAULT_MARGIN_PCT` in the shell). A book nobody
has adjusted lays out identically to before, so every pagination already cached on a device stays
valid — rebuilding those is the cost #162/#186 are about.

## How it threads through

`Typography` carries `margin_pct`, so the open path restores a saved margin in the same single
pagination as the rest of the typography instead of adding a second pass (#161/#162). `LayoutRequest`
carries it into the staleness comparison, and `opts_for` resolves the percentage against the page
width. `set_margin` behaves like every other reflow setter — capture the pin before the setting
changes, repaginate, keep the chapter (#160).

`LayoutOpts::layout_digest` already folded in `margin`, so a margin change misses the persisted
pagination cache and repaginates on its own. Nothing needed adding there, and the reading position
re-anchors through `PinPosition` the same way a font-size change does (RR12-FR4).

Across JNI: `nativeSetMargin` for a live change, plus a `marginPct` parameter on
`nativeOpenDocumentWithStore` and `nativeSetTypography`.

## Tests

Host only. Narrowing the margin repaginates, keeps the chapter and cannot lengthen the book;
widening it cannot shorten it; returning to the default reproduces the original pagination exactly.
The configured default is asserted equal to the layout engine's own, which is what protects the
cached paginations. Out-of-range values are clamped at both ends, and a zero margin keeps its floor.

`cargo fmt --all --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --workspace`
(684 passing), `:app:compileDebugKotlin` and `:app:testDebugUnitTest` are all green.

I have not run this on a device. Worth a look on a Nomad and a Manta to confirm the step spacing
feels right — particularly whether None is usable in practice or whether the bezel makes the two
narrowest steps read the same.
