### PR TITLE
fix(ui): open the tool options beside the toolbar, and let Menu Size reach the palette (#200)

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -56,6 +56,9 @@ class AdjustSheetController(private val host: Host) {
         /** Apply a changed periodic full-refresh interval (#99) to the live page-turn cadence. */
         fun applyFullRefreshInterval(n: Int)
 
+        /** Rebuild the floating tool palette at the current [Ink.uiScale] (#133 / #200). */
+        fun refreshToolPalette()
+
         /** Toggle PDF reflow; owns the zoom/pan/progress-dialog state the toggle disturbs. */
         fun setReflowMode(on: Boolean)
 
@@ -423,14 +426,19 @@ class AdjustSheetController(private val host: Host) {
         return container
     }
 
-    /** Persist + apply the menu/chrome scale (#133) for large panels (e.g. the Manta). The reader's
-     *  menus read [Ink.uiScale] as they build, so the new size lands as each menu/sheet is next
-     *  opened; this open sheet keeps its current size, so a toast confirms the change. */
+    /** Persist + apply the menu/chrome scale (#133) for large panels (e.g. the Manta).
+     *
+     *  Menus read [Ink.uiScale] as they build, so most of the reader's chrome takes the new size
+     *  when it is next opened. The tool palette is the exception: it is built once and stays on
+     *  screen, so it is rebuilt here. Without that it kept its old size until something unrelated
+     *  happened to re-render it, and the reader — looking straight at the toolbar while the toast
+     *  told them to reopen a menu — would reasonably conclude the setting did not cover it (#200). */
     private fun applyUiScale(scale: Float) {
         prefs.uiScale = scale
         Ink.uiScale = scale
+        host.refreshToolPalette()
         val label = DisplayPrefs.UI_SCALE_LABELS[DisplayPrefs.nearestUiScaleIndex(scale)]
-        Toast.makeText(activity, "Menu size $label — reopen a menu to see it", Toast.LENGTH_SHORT).show()
+        Toast.makeText(activity, "Menu size $label — menus resize as you reopen them", Toast.LENGTH_SHORT).show()
     }
 
     /** A reading style preset (1.10): a bundle of (text scale, line-spacing index, contrast step,

--- a/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DisplayPrefs.kt
@@ -117,10 +117,15 @@ class DisplayPrefs(private val context: Context) {
         /** Reflow font-size steps (multiples of the core's base body size); 1.0 = default. */
         val TEXT_SCALES = floatArrayOf(0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.15f, 1.3f, 1.5f, 1.75f, 2.0f, 2.5f, 3.0f)
 
-        /** Menu/chrome scale steps (#133); 1.0 = current sizing, the default (index 1). Kept small
-         *  and coarse so the segmented control stays e-ink-tappable. */
-        val UI_SCALES = floatArrayOf(0.9f, 1.0f, 1.15f, 1.3f, 1.5f)
-        val UI_SCALE_LABELS = listOf("S", "M", "L", "XL", "2XL")
+        /** Menu/chrome scale steps (#133); 1.0 = the default sizing. Kept small and coarse so the
+         *  segmented control stays e-ink-tappable.
+         *
+         *  XS (0.8) exists because the tool palette read as oversized once it could be docked along
+         *  the top (#200). It is the smallest step offered on purpose: it puts the palette's 60dp
+         *  button on exactly 48dp, the minimum touch target the platform recommends. Anything
+         *  smaller is below that floor and is not offered without a device in hand. */
+        val UI_SCALES = floatArrayOf(0.8f, 0.9f, 1.0f, 1.15f, 1.3f, 1.5f)
+        val UI_SCALE_LABELS = listOf("XS", "S", "M", "L", "XL", "2XL")
 
         /** Page-turn intervals for the periodic full refresh (#99); index 0 = Off, the default. */
         val REFRESH_INTERVALS = listOf(0, 1, 3, 5, 10)

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -574,7 +574,16 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             },
         )
         selectionToolbar = SelectionToolbar(this, root) { action -> lasso.onSelectionAction(action) }
-        toolOptions = ToolOptions(this, root)
+        // The column opens beside the pill wherever it is parked, so docking the bar left or on
+        // top no longer strands the colours on the right of the page (#200). Read through lambdas
+        // rather than captured once: the pill is draggable, so its position is only true at the
+        // moment the column is shown.
+        toolOptions = ToolOptions(
+            this,
+            root,
+            paletteBounds = { if (::toolPalette.isInitialized) toolPalette.boundsInHost() else null },
+            paletteIsHorizontal = { ::toolPalette.isInitialized && toolPalette.isHorizontal },
+        )
         // Restore the saved pen thickness (#199) before any stroke can be committed, so the first
         // stroke after a relaunch is the width the reader chose rather than the default.
         stylus.penWidthIndex = prefs

--- a/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ReaderActivity.kt
@@ -211,6 +211,9 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
             refreshCadence.interval = n // @Volatile — safe from this UI-thread setter
             engine.execute { refreshCadence.reset() } // restart the count on the engine thread (#99)
         }
+        override fun refreshToolPalette() {
+            if (::toolPalette.isInitialized) toolPalette.refreshChrome()
+        }
         override fun setReflowMode(on: Boolean) = this@ReaderActivity.setReflowMode(on)
         override fun zoomIn() = zoomBy(ZOOM_STEP)
         override fun zoomOut() = zoomBy(1f / ZOOM_STEP)
@@ -578,12 +581,7 @@ class ReaderActivity : Activity(), SurfaceHolder.Callback {
         // top no longer strands the colours on the right of the page (#200). Read through lambdas
         // rather than captured once: the pill is draggable, so its position is only true at the
         // moment the column is shown.
-        toolOptions = ToolOptions(
-            this,
-            root,
-            paletteBounds = { if (::toolPalette.isInitialized) toolPalette.boundsInHost() else null },
-            paletteIsHorizontal = { ::toolPalette.isInitialized && toolPalette.isHorizontal },
-        )
+        toolOptions = ToolOptions(this, root, toolbar = { toolPalette.placement() })
         // Restore the saved pen thickness (#199) before any stroke can be committed, so the first
         // stroke after a relaunch is the width the reader chose rather than the default.
         stylus.penWidthIndex = prefs

--- a/app/src/main/java/dev/jraghavan/inkread/ToolOptions.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolOptions.kt
@@ -32,14 +32,16 @@ class ToolOptions(
     private val activity: Activity,
     private val host: FrameLayout,
     /**
-     * Where the tool palette currently sits, in host coordinates, or `null` before it has been laid
-     * out. The column opens beside the pill rather than at a fixed edge — it used to be pinned to
-     * the right whatever the reader had chosen, so docking the bar left or on top left the colours
-     * and thicknesses stranded on the far side of the page (#200).
+     * Where the tool palette currently sits, or `null` before it has been laid out. The column
+     * opens beside the pill rather than at a fixed edge — it used to be pinned to the right
+     * whatever the reader had chosen, so docking the bar left or on top left the colours and
+     * thicknesses stranded on the far side of the page (#200).
+     *
+     * Read at [show] time, not captured: the pill is draggable. The column does **not** follow a
+     * drag that happens while it is already open — re-placing a mounted view would cost an EPD
+     * repaint, and the pill moving out from under its own options is rare next to that.
      */
-    private val paletteBounds: () -> android.graphics.Rect? = { null },
-    /** Whether that palette is the horizontal (top-docked) bar rather than a vertical pill. */
-    private val paletteIsHorizontal: () -> Boolean = { false },
+    private val toolbar: () -> ToolPalette.Placement? = { null },
 ) {
     private val density = activity.resources.displayMetrics.density
     private fun dp(v: Int) = (v * density).toInt()
@@ -121,69 +123,91 @@ class ToolOptions(
     /**
      * Lay the column out beside the palette.
      *
-     * Only the axis the pill docks along is derived; the other stays centred. Centring cannot put
-     * the column off-screen, whereas aligning it to the pill's near edge could — the pill is
-     * free-dragged and can rest hard against a corner, and the column's own size is not known until
-     * it has been measured. Kept deliberately simple for that reason.
+     * The column is displaced from the pill along one axis — across from a vertical pill, above or
+     * below a horizontal bar — and lines up with the pill's docked edge on the other. Both are on
+     * screen by construction: the pill's drag is clamped to keep it fully within the host, so a
+     * margin measured from one of its edges cannot be negative or push past the far side.
      *
      * With no palette laid out yet, this falls back to the right edge, which is where the palette
-     * itself starts.
+     * itself starts. Only reachable before first layout, when no tool button exists to tap.
      */
     private fun placement(): FrameLayout.LayoutParams {
         val lp = FrameLayout.LayoutParams(
             ViewGroup.LayoutParams.WRAP_CONTENT,
             ViewGroup.LayoutParams.WRAP_CONTENT,
         )
-        val pill = paletteBounds()
-        val gap = dp(16)
-        when (
-            sideFor(
-                hasPill = pill != null,
-                horizontal = paletteIsHorizontal(),
-                pillCenterX = pill?.centerX() ?: 0,
-                hostWidth = host.width,
-            )
-        ) {
-            Side.RIGHT_EDGE -> {
-                lp.gravity = Gravity.END or Gravity.CENTER_VERTICAL
-                lp.marginEnd = dp(88)
-            }
+        // Absolute LEFT/RIGHT rather than START/END: every input here is an absolute pixel
+        // coordinate, and the manifest declares supportsRtl, so a direction-resolved gravity would
+        // mirror the margins out from under coordinates that had not mirrored with them.
+        val pill = toolbar() ?: return lp.apply {
+            gravity = Gravity.RIGHT or Gravity.CENTER_VERTICAL
+            rightMargin = Ink.sdp(FALLBACK_INSET)
+        }
+        val gap = Ink.dp(GAP)
+        when (sideFor(pill, host.width, host.height)) {
             Side.BELOW_PILL -> {
-                lp.gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
-                lp.topMargin = pill!!.bottom + gap
+                lp.gravity = Gravity.TOP or dockedEdge(pill)
+                lp.topMargin = pill.bottom + gap
+                alignToDockedEdge(lp, pill)
+            }
+            Side.ABOVE_PILL -> {
+                lp.gravity = Gravity.BOTTOM or dockedEdge(pill)
+                lp.bottomMargin = (host.height - pill.top) + gap
+                alignToDockedEdge(lp, pill)
             }
             Side.LEFT_OF_PILL -> {
-                lp.gravity = Gravity.END or Gravity.CENTER_VERTICAL
-                lp.marginEnd = (host.width - pill!!.left) + gap
+                lp.gravity = Gravity.RIGHT or Gravity.CENTER_VERTICAL
+                lp.rightMargin = (host.width - pill.left) + gap
             }
             Side.RIGHT_OF_PILL -> {
-                lp.gravity = Gravity.START or Gravity.CENTER_VERTICAL
-                lp.marginStart = pill!!.right + gap
+                lp.gravity = Gravity.LEFT or Gravity.CENTER_VERTICAL
+                lp.leftMargin = pill.right + gap
             }
         }
         return lp
     }
 
+    /** The horizontal edge a top/bottom-placed column lines up with — the one the bar docks to. */
+    private fun dockedEdge(pill: ToolPalette.Placement) =
+        if (pill.dockedStart) Gravity.LEFT else Gravity.RIGHT
+
+    /**
+     * Line the column up with the docked end of the bar rather than centring it on the page.
+     *
+     * Centring is safe from an overflow point of view but reproduces a milder form of the bug being
+     * fixed: the bar docks into a *corner*, so a centred column lands a long way from the button
+     * that summoned it. The bar's own docked edge is on screen by construction, so aligning to it
+     * cannot overflow either.
+     */
+    private fun alignToDockedEdge(lp: FrameLayout.LayoutParams, pill: ToolPalette.Placement) {
+        if (pill.dockedStart) lp.leftMargin = pill.left
+        else lp.rightMargin = host.width - pill.right
+    }
+
     /** Which side of the palette the options column opens on. */
-    enum class Side { RIGHT_EDGE, BELOW_PILL, LEFT_OF_PILL, RIGHT_OF_PILL }
+    enum class Side { BELOW_PILL, ABOVE_PILL, LEFT_OF_PILL, RIGHT_OF_PILL }
 
     companion object {
+        /** Spacing between the pill and the column, and the pre-layout fallback inset, in dp. */
+        const val GAP = 16
+        const val FALLBACK_INSET = 88
+
         /**
          * Pick the side the column opens on (#200).
          *
          * Pure, and tested on the JVM like the pill's own placement maths, because this is the
-         * decision that was wrong: the column used to be pinned to [Side.RIGHT_EDGE] unconditionally,
+         * decision that was wrong: the column used to be pinned to the right edge unconditionally,
          * so docking the bar on the left or across the top left it on the far side of the page.
+         *
+         * Both axes get a midline test. Orientation says which axis the column is displaced along;
+         * position says which way. A horizontal bar is not necessarily a *top* bar — it is dragged
+         * over the whole page, and assuming it stays near the top pushed the column off the bottom.
          */
-        fun sideFor(hasPill: Boolean, horizontal: Boolean, pillCenterX: Int, hostWidth: Int): Side =
-            when {
-                // Nothing laid out yet: the right edge is where the palette itself starts.
-                !hasPill -> Side.RIGHT_EDGE
-                // A bar across the top — the column drops beneath it.
-                horizontal -> Side.BELOW_PILL
-                // A vertical pill opens the column into the page, away from its own edge.
-                pillCenterX * 2 > hostWidth -> Side.LEFT_OF_PILL
-                else -> Side.RIGHT_OF_PILL
+        fun sideFor(pill: ToolPalette.Placement, hostWidth: Int, hostHeight: Int): Side =
+            if (pill.horizontal) {
+                if (pill.centerY * 2 > hostHeight) Side.ABOVE_PILL else Side.BELOW_PILL
+            } else {
+                if (pill.centerX * 2 > hostWidth) Side.LEFT_OF_PILL else Side.RIGHT_OF_PILL
             }
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/ToolOptions.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolOptions.kt
@@ -31,6 +31,15 @@ import android.widget.TextView
 class ToolOptions(
     private val activity: Activity,
     private val host: FrameLayout,
+    /**
+     * Where the tool palette currently sits, in host coordinates, or `null` before it has been laid
+     * out. The column opens beside the pill rather than at a fixed edge — it used to be pinned to
+     * the right whatever the reader had chosen, so docking the bar left or on top left the colours
+     * and thicknesses stranded on the far side of the page (#200).
+     */
+    private val paletteBounds: () -> android.graphics.Rect? = { null },
+    /** Whether that palette is the horizontal (top-docked) bar rather than a vertical pill. */
+    private val paletteIsHorizontal: () -> Boolean = { false },
 ) {
     private val density = activity.resources.displayMetrics.density
     private fun dp(v: Int) = (v * density).toInt()
@@ -105,12 +114,77 @@ class ToolOptions(
                 })
             }
         }
+        host.addView(col, placement())
+        panel = col
+    }
+
+    /**
+     * Lay the column out beside the palette.
+     *
+     * Only the axis the pill docks along is derived; the other stays centred. Centring cannot put
+     * the column off-screen, whereas aligning it to the pill's near edge could — the pill is
+     * free-dragged and can rest hard against a corner, and the column's own size is not known until
+     * it has been measured. Kept deliberately simple for that reason.
+     *
+     * With no palette laid out yet, this falls back to the right edge, which is where the palette
+     * itself starts.
+     */
+    private fun placement(): FrameLayout.LayoutParams {
         val lp = FrameLayout.LayoutParams(
             ViewGroup.LayoutParams.WRAP_CONTENT,
             ViewGroup.LayoutParams.WRAP_CONTENT,
-        ).apply { gravity = Gravity.END or Gravity.CENTER_VERTICAL; marginEnd = dp(88) }
-        host.addView(col, lp)
-        panel = col
+        )
+        val pill = paletteBounds()
+        val gap = dp(16)
+        when (
+            sideFor(
+                hasPill = pill != null,
+                horizontal = paletteIsHorizontal(),
+                pillCenterX = pill?.centerX() ?: 0,
+                hostWidth = host.width,
+            )
+        ) {
+            Side.RIGHT_EDGE -> {
+                lp.gravity = Gravity.END or Gravity.CENTER_VERTICAL
+                lp.marginEnd = dp(88)
+            }
+            Side.BELOW_PILL -> {
+                lp.gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                lp.topMargin = pill!!.bottom + gap
+            }
+            Side.LEFT_OF_PILL -> {
+                lp.gravity = Gravity.END or Gravity.CENTER_VERTICAL
+                lp.marginEnd = (host.width - pill!!.left) + gap
+            }
+            Side.RIGHT_OF_PILL -> {
+                lp.gravity = Gravity.START or Gravity.CENTER_VERTICAL
+                lp.marginStart = pill!!.right + gap
+            }
+        }
+        return lp
+    }
+
+    /** Which side of the palette the options column opens on. */
+    enum class Side { RIGHT_EDGE, BELOW_PILL, LEFT_OF_PILL, RIGHT_OF_PILL }
+
+    companion object {
+        /**
+         * Pick the side the column opens on (#200).
+         *
+         * Pure, and tested on the JVM like the pill's own placement maths, because this is the
+         * decision that was wrong: the column used to be pinned to [Side.RIGHT_EDGE] unconditionally,
+         * so docking the bar on the left or across the top left it on the far side of the page.
+         */
+        fun sideFor(hasPill: Boolean, horizontal: Boolean, pillCenterX: Int, hostWidth: Int): Side =
+            when {
+                // Nothing laid out yet: the right edge is where the palette itself starts.
+                !hasPill -> Side.RIGHT_EDGE
+                // A bar across the top — the column drops beneath it.
+                horizontal -> Side.BELOW_PILL
+                // A vertical pill opens the column into the page, away from its own edge.
+                pillCenterX * 2 > hostWidth -> Side.LEFT_OF_PILL
+                else -> Side.RIGHT_OF_PILL
+            }
     }
 
     /** Remove the column (only on a tool switch away from an inking tool). */

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -87,7 +87,19 @@ class ToolPalette(
         private set
 
     private val density = activity.resources.displayMetrics.density
+
+    /** An unscaled dimension — for geometry the reader's Menu Size must not move (drag insets). */
     private fun dp(v: Int) = (v * density).toInt()
+
+    /**
+     * A chrome dimension scaled by the reader's Menu Size preference (#133 / #200).
+     *
+     * The pill was the one piece of reader chrome that never adopted [Ink.sdp], so its buttons
+     * stayed a fixed 60dp however small the reader had asked their menus to be. Routing the button
+     * box, its glyph inset and the spacing between buttons through here puts the pill under the
+     * same control as every other menu.
+     */
+    private fun sdp(v: Int) = Ink.sdp(v)
     private val touchSlop = ViewConfiguration.get(activity).scaledTouchSlop
 
     /**
@@ -219,9 +231,9 @@ class ToolPalette(
         if (expanded) {
             container.background = pill()
             if (horizontal) {
-                container.setPadding(dp(7), dp(5), dp(7), dp(5))
+                container.setPadding(sdp(7), sdp(5), sdp(7), sdp(5))
             } else {
-                container.setPadding(dp(5), dp(7), dp(5), dp(7))
+                container.setPadding(sdp(5), sdp(7), sdp(5), sdp(7))
             }
             // The grip belongs on the docked edge, so the strip grows inward from it and the grip
             // itself never moves. Docked right, that means building the row back to front.
@@ -265,9 +277,9 @@ class ToolPalette(
     private fun collapsedPuck(): ImageView = ImageView(activity).apply {
         setImageResource(R.drawable.ic_inkwell)
         setColorFilter(Ink.ink)
-        val pad = dp(15)
+        val pad = sdp(TOOL_GLYPH_INSET + 1)
         setPadding(pad, pad, pad, pad)
-        val side = dp(60)
+        val side = sdp(TOOL_BOX)
         layoutParams = LinearLayout.LayoutParams(side, side)
         contentDescription = "Tools — tap to open, drag to move"
         applyDragToggle(this)
@@ -278,14 +290,14 @@ class ToolPalette(
         setBackgroundColor(Ink.hairline)
         // The separator runs across the strip, so it swaps axis with it.
         layoutParams = if (horizontal) {
-            LinearLayout.LayoutParams(Ink.hair(), dp(42)).apply {
+            LinearLayout.LayoutParams(Ink.hair(), sdp(DIVIDER_RUN)).apply {
                 gravity = Gravity.CENTER_VERTICAL
-                val h = dp(4); setMargins(h, 0, h, 0)
+                val h = sdp(4); setMargins(h, 0, h, 0)
             }
         } else {
-            LinearLayout.LayoutParams(dp(42), Ink.hair()).apply {
+            LinearLayout.LayoutParams(sdp(DIVIDER_RUN), Ink.hair()).apply {
                 gravity = Gravity.CENTER_HORIZONTAL
-                val v = dp(4); setMargins(0, v, 0, v)
+                val v = sdp(4); setMargins(0, v, 0, v)
             }
         }
     }
@@ -295,9 +307,9 @@ class ToolPalette(
         ImageView(activity).apply {
             setImageResource(iconRes)
             setColorFilter(Ink.ink)
-            val pad = dp(14); setPadding(pad, pad, pad, pad)
-            val side = dp(60)
-            layoutParams = LinearLayout.LayoutParams(side, side).apply { val m = dp(2); setMargins(m, m, m, m) }
+            val pad = sdp(TOOL_GLYPH_INSET); setPadding(pad, pad, pad, pad)
+            val side = sdp(TOOL_BOX)
+            layoutParams = LinearLayout.LayoutParams(side, side).apply { val m = sdp(TOOL_GAP); setMargins(m, m, m, m) }
             isClickable = true
             contentDescription = desc
             setOnClickListener { onTap() }
@@ -307,11 +319,11 @@ class ToolPalette(
     private fun handle(): ImageView = ImageView(activity).apply {
         setImageResource(R.drawable.ic_tool_handle)
         setColorFilter(Ink.ink)
-        val pad = dp(14)
+        val pad = sdp(TOOL_GLYPH_INSET)
         setPadding(pad, pad, pad, pad)
-        val side = dp(60)
+        val side = sdp(TOOL_BOX)
         layoutParams = LinearLayout.LayoutParams(side, side).apply {
-            val m = dp(2); setMargins(m, m, m, m)
+            val m = sdp(TOOL_GAP); setMargins(m, m, m, m)
         }
         contentDescription = "Collapse / move tools"
         applyDragToggle(this)
@@ -413,11 +425,11 @@ class ToolPalette(
         val active = tool == current
         setColorFilter(if (active) Ink.paper else Ink.ink)
         alpha = if (tool.phase2) 0.35f else 1f
-        val pad = dp(14)
+        val pad = sdp(TOOL_GLYPH_INSET)
         setPadding(pad, pad, pad, pad)
-        val side = dp(60)
+        val side = sdp(TOOL_BOX)
         layoutParams = LinearLayout.LayoutParams(side, side).apply {
-            val m = dp(2); setMargins(m, m, m, m)
+            val m = sdp(TOOL_GAP); setMargins(m, m, m, m)
         }
         if (active) {
             background = GradientDrawable().apply {
@@ -489,6 +501,23 @@ class ToolPalette(
     internal companion object {
         /** Resting opacity of the docked puck — translucent so the text behind it stays readable. */
         const val IDLE_ALPHA = 0.55f
+
+        /**
+         * Design sizes for one tool button, in dp before the Menu Size scale (#200).
+         *
+         * [TOOL_BOX] is the touch target and [TOOL_GLYPH_INSET] the padding around the icon inside
+         * it, so the glyph is `TOOL_BOX - 2 * TOOL_GLYPH_INSET` — 32dp in a 60dp target by default.
+         * Keeping them separate is what lets the icon shrink without the target shrinking with it,
+         * which is what was asked for: smaller icons, still comfortably far apart.
+         */
+        const val TOOL_BOX = 60
+        const val TOOL_GLYPH_INSET = 14
+
+        /** Space between adjacent buttons, on top of each one's own inset. */
+        const val TOOL_GAP = 2
+
+        /** How far the hairline separator runs across the strip. */
+        const val DIVIDER_RUN = 42
 
         /** Where the view's leading edge sits, given its anchor and offset. */
         fun edge(anchor: Anchor, offset: Float, host: Int, view: Int): Float {

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -86,20 +86,27 @@ class ToolPalette(
     var current: Tool = Tool.PEN
         private set
 
-    private val density = activity.resources.displayMetrics.density
-
-    /** An unscaled dimension — for geometry the reader's Menu Size must not move (drag insets). */
-    private fun dp(v: Int) = (v * density).toInt()
-
     /**
-     * A chrome dimension scaled by the reader's Menu Size preference (#133 / #200).
+     * The pill's sizing (#133 / #200). Menu Size scales the **glyph**; the spacing around it does
+     * not move.
      *
-     * The pill was the one piece of reader chrome that never adopted [Ink.sdp], so its buttons
-     * stayed a fixed 60dp however small the reader had asked their menus to be. Routing the button
-     * box, its glyph inset and the spacing between buttons through here puts the pill under the
-     * same control as every other menu.
+     * The reader asked for "smaller icons ... but with some margin to keep some distance between
+     * button for ease of activation". Scaling everything by one factor cannot deliver that — every
+     * ratio survives, so the buttons end up proportionally as crowded as they started. Scaling only
+     * the glyph and holding the inset and the gap at their design size means a smaller icon leaves
+     * *more* clearance around it, not the same.
+     *
+     * The box is derived rather than set, so the glyph is always exactly [TOOL_GLYPH] scaled and
+     * always centred, including when [TOOL_BOX_MIN] catches it.
      */
-    private fun sdp(v: Int) = Ink.sdp(v)
+    private fun glyphPx() = Ink.dp(glyphDp(Ink.uiScale))
+
+    private fun boxPx() = Ink.dp(boxDp(Ink.uiScale))
+
+    private fun insetPx() = (boxPx() - glyphPx()) / 2
+
+    /** The separator runs most of the way across the strip, so it tracks the button box. */
+    private fun dividerRunPx() = boxPx() * DIVIDER_RUN_PERCENT / 100
     private val touchSlop = ViewConfiguration.get(activity).scaledTouchSlop
 
     /**
@@ -142,7 +149,7 @@ class ToolPalette(
                 // right, a horizontal bar sits across the top, which is where it was asked for.
                 val sideGravity = if (side == Anchor.START) Gravity.START else Gravity.END
                 gravity = sideGravity or if (horizontal) Gravity.TOP else Gravity.CENTER_VERTICAL
-                val inset = dp(6)
+                val inset = Ink.dp(6)
                 // Clearance applies along the docked side, and only to the horizontal form: the
                 // vertical pill rides the middle of its edge and never reaches the corner.
                 val docked = inset + if (horizontal) dockClearance else 0
@@ -231,9 +238,9 @@ class ToolPalette(
         if (expanded) {
             container.background = pill()
             if (horizontal) {
-                container.setPadding(sdp(7), sdp(5), sdp(7), sdp(5))
+                container.setPadding(Ink.dp(7), Ink.dp(5), Ink.dp(7), Ink.dp(5))
             } else {
-                container.setPadding(sdp(5), sdp(7), sdp(5), sdp(7))
+                container.setPadding(Ink.dp(5), Ink.dp(7), Ink.dp(5), Ink.dp(7))
             }
             // The grip belongs on the docked edge, so the strip grows inward from it and the grip
             // itself never moves. Docked right, that means building the row back to front.
@@ -256,30 +263,35 @@ class ToolPalette(
     }
 
     /**
-     * Where the pill actually is, in host coordinates, drag translation included — `null` until the
-     * first layout has given it a size.
+     * Where the pill actually is, and how it is oriented — `null` until the first layout has given
+     * it a size.
      *
      * Satellite chrome (the tool-options column) has to open beside the pill wherever the reader
      * parked it, and only the pill knows where that is. Reported as geometry rather than as a
-     * placement so the caller keeps its own layout decisions (#200).
+     * placement so the caller keeps its own layout decisions (#200). Bounds and orientation travel
+     * together because they are one fact: there is no such thing as an orientation without a pill.
      */
-    fun boundsInHost(): android.graphics.Rect? {
+    fun placement(): Placement? {
         if (container.width == 0 || container.height == 0) return null
         val left = (container.left + container.translationX).toInt()
         val top = (container.top + container.translationY).toInt()
-        return android.graphics.Rect(left, top, left + container.width, top + container.height)
+        return Placement(
+            left = left,
+            top = top,
+            right = left + container.width,
+            bottom = top + container.height,
+            horizontal = horizontal,
+            dockedStart = side == Anchor.START,
+        )
     }
-
-    /** True when the strip runs across the screen (docked to the top) rather than down an edge. */
-    val isHorizontal: Boolean get() = horizontal
 
     /** The collapsed puck: the inkwell brand mark in the circle (tap = expand, drag = move). */
     private fun collapsedPuck(): ImageView = ImageView(activity).apply {
         setImageResource(R.drawable.ic_inkwell)
         setColorFilter(Ink.ink)
-        val pad = sdp(TOOL_GLYPH_INSET + 1)
+        val pad = insetPx()
         setPadding(pad, pad, pad, pad)
-        val side = sdp(TOOL_BOX)
+        val side = boxPx()
         layoutParams = LinearLayout.LayoutParams(side, side)
         contentDescription = "Tools — tap to open, drag to move"
         applyDragToggle(this)
@@ -290,14 +302,14 @@ class ToolPalette(
         setBackgroundColor(Ink.hairline)
         // The separator runs across the strip, so it swaps axis with it.
         layoutParams = if (horizontal) {
-            LinearLayout.LayoutParams(Ink.hair(), sdp(DIVIDER_RUN)).apply {
+            LinearLayout.LayoutParams(Ink.hair(), dividerRunPx()).apply {
                 gravity = Gravity.CENTER_VERTICAL
-                val h = sdp(4); setMargins(h, 0, h, 0)
+                val h = Ink.dp(DIVIDER_GAP); setMargins(h, 0, h, 0)
             }
         } else {
-            LinearLayout.LayoutParams(sdp(DIVIDER_RUN), Ink.hair()).apply {
+            LinearLayout.LayoutParams(dividerRunPx(), Ink.hair()).apply {
                 gravity = Gravity.CENTER_HORIZONTAL
-                val v = sdp(4); setMargins(0, v, 0, v)
+                val v = Ink.dp(DIVIDER_GAP); setMargins(0, v, 0, v)
             }
         }
     }
@@ -307,9 +319,9 @@ class ToolPalette(
         ImageView(activity).apply {
             setImageResource(iconRes)
             setColorFilter(Ink.ink)
-            val pad = sdp(TOOL_GLYPH_INSET); setPadding(pad, pad, pad, pad)
-            val side = sdp(TOOL_BOX)
-            layoutParams = LinearLayout.LayoutParams(side, side).apply { val m = sdp(TOOL_GAP); setMargins(m, m, m, m) }
+            val pad = insetPx(); setPadding(pad, pad, pad, pad)
+            val side = boxPx()
+            layoutParams = LinearLayout.LayoutParams(side, side).apply { val m = Ink.dp(TOOL_GAP); setMargins(m, m, m, m) }
             isClickable = true
             contentDescription = desc
             setOnClickListener { onTap() }
@@ -319,11 +331,11 @@ class ToolPalette(
     private fun handle(): ImageView = ImageView(activity).apply {
         setImageResource(R.drawable.ic_tool_handle)
         setColorFilter(Ink.ink)
-        val pad = sdp(TOOL_GLYPH_INSET)
+        val pad = insetPx()
         setPadding(pad, pad, pad, pad)
-        val side = sdp(TOOL_BOX)
+        val side = boxPx()
         layoutParams = LinearLayout.LayoutParams(side, side).apply {
-            val m = sdp(TOOL_GAP); setMargins(m, m, m, m)
+            val m = Ink.dp(TOOL_GAP); setMargins(m, m, m, m)
         }
         contentDescription = "Collapse / move tools"
         applyDragToggle(this)
@@ -362,6 +374,25 @@ class ToolPalette(
                 }
                 else -> false
             }
+        }
+    }
+
+    /**
+     * Rebuild the strip at the current [Ink.uiScale] (#133 / #200).
+     *
+     * The reader changes Menu Size in a sheet that sits over the pill; without this the pill keeps
+     * whatever size it was built at until something else happens to re-render it, so the setting
+     * looks as though it does not reach the toolbar at all. Re-anchored for the same reason a
+     * collapse is: the pill is centred on its axis, so changing its size moves the grip unless the
+     * offset compensates.
+     */
+    fun refreshChrome() {
+        val sizeBefore = if (horizontal) container.width else container.height
+        render()
+        reanchor(sizeBefore) {
+            reattach()
+            persist()
+            onChrome()
         }
     }
 
@@ -425,11 +456,11 @@ class ToolPalette(
         val active = tool == current
         setColorFilter(if (active) Ink.paper else Ink.ink)
         alpha = if (tool.phase2) 0.35f else 1f
-        val pad = sdp(TOOL_GLYPH_INSET)
+        val pad = insetPx()
         setPadding(pad, pad, pad, pad)
-        val side = sdp(TOOL_BOX)
+        val side = boxPx()
         layoutParams = LinearLayout.LayoutParams(side, side).apply {
-            val m = sdp(TOOL_GAP); setMargins(m, m, m, m)
+            val m = Ink.dp(TOOL_GAP); setMargins(m, m, m, m)
         }
         if (active) {
             background = GradientDrawable().apply {
@@ -481,6 +512,27 @@ class ToolPalette(
     enum class Orientation { VERTICAL, HORIZONTAL }
 
     /**
+     * Everything satellite chrome needs to sit beside the pill: where it is, which way it runs, and
+     * which edge it docks to (#200). One object rather than several accessors, so a caller cannot
+     * hold an orientation for a pill that is not laid out.
+     */
+    data class Placement(
+        val left: Int,
+        val top: Int,
+        val right: Int,
+        val bottom: Int,
+        /** The strip runs across the screen rather than down an edge. */
+        val horizontal: Boolean,
+        /** It docks to the left/top edge rather than the right. */
+        val dockedStart: Boolean,
+    ) {
+        // Plain Ints rather than a `Rect`: this is the input to placement decisions that are tested
+        // on the JVM, and an android.graphics.Rect is a stub there.
+        val centerX get() = (left + right) / 2
+        val centerY get() = (top + bottom) / 2
+    }
+
+    /**
      * A parked position for the pill, held as host-relative fractions (#200). Persisted by the
      * host so the toolbar reopens where the reader left it instead of back at the default dock.
      */
@@ -503,21 +555,44 @@ class ToolPalette(
         const val IDLE_ALPHA = 0.55f
 
         /**
-         * Design sizes for one tool button, in dp before the Menu Size scale (#200).
+         * Design sizes for one tool button, in dp (#200).
          *
-         * [TOOL_BOX] is the touch target and [TOOL_GLYPH_INSET] the padding around the icon inside
-         * it, so the glyph is `TOOL_BOX - 2 * TOOL_GLYPH_INSET` — 32dp in a 60dp target by default.
-         * Keeping them separate is what lets the icon shrink without the target shrinking with it,
-         * which is what was asked for: smaller icons, still comfortably far apart.
+         * Only [TOOL_GLYPH] answers to Menu Size. [TOOL_INSET] and [TOOL_GAP] are held at their
+         * design size, so shrinking the icon widens the clearance around it rather than closing it
+         * up — see the sizing helpers above for why one uniform factor cannot do that.
+         *
+         * At Menu Size M this reproduces the original 32dp glyph in a 60dp box exactly, so a reader
+         * who never touches the setting sees the toolbar they already had.
          */
-        const val TOOL_BOX = 60
-        const val TOOL_GLYPH_INSET = 14
-
-        /** Space between adjacent buttons, on top of each one's own inset. */
+        const val TOOL_GLYPH = 32
+        const val TOOL_INSET = 14
         const val TOOL_GAP = 2
 
-        /** How far the hairline separator runs across the strip. */
-        const val DIVIDER_RUN = 42
+        /**
+         * The smallest touch target the box may be derived down to, whatever the glyph does.
+         *
+         * 48dp is the platform's recommended minimum. It is a floor rather than the target itself
+         * because this is a stylus-first panel where the pen tip is under a millimetre — the floor
+         * is there for the finger, not the pen.
+         */
+        const val TOOL_BOX_MIN = 48
+
+        /** How far the hairline separator runs across the strip, as a percentage of the box. */
+        const val DIVIDER_RUN_PERCENT = 70
+
+        /** Clearance either side of a separator. Spacing, so it does not scale. */
+        const val DIVIDER_GAP = 4
+
+        /**
+         * The design sizes at a given Menu Size, in dp before density (#200).
+         *
+         * Resolved in dp and multiplied by density once, rather than scaling an already-converted
+         * pixel size: two truncations would leave the box a fraction under the [TOOL_BOX_MIN] floor
+         * the setting is chosen against.
+         */
+        fun glyphDp(uiScale: Float) = (TOOL_GLYPH * uiScale).toInt()
+
+        fun boxDp(uiScale: Float) = maxOf(TOOL_BOX_MIN, glyphDp(uiScale) + 2 * TOOL_INSET)
 
         /** Where the view's leading edge sits, given its anchor and offset. */
         fun edge(anchor: Anchor, offset: Float, host: Int, view: Int): Float {

--- a/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/ToolPalette.kt
@@ -243,6 +243,24 @@ class ToolPalette(
         }
     }
 
+    /**
+     * Where the pill actually is, in host coordinates, drag translation included — `null` until the
+     * first layout has given it a size.
+     *
+     * Satellite chrome (the tool-options column) has to open beside the pill wherever the reader
+     * parked it, and only the pill knows where that is. Reported as geometry rather than as a
+     * placement so the caller keeps its own layout decisions (#200).
+     */
+    fun boundsInHost(): android.graphics.Rect? {
+        if (container.width == 0 || container.height == 0) return null
+        val left = (container.left + container.translationX).toInt()
+        val top = (container.top + container.translationY).toInt()
+        return android.graphics.Rect(left, top, left + container.width, top + container.height)
+    }
+
+    /** True when the strip runs across the screen (docked to the top) rather than down an edge. */
+    val isHorizontal: Boolean get() = horizontal
+
     /** The collapsed puck: the inkwell brand mark in the circle (tap = expand, drag = move). */
     private fun collapsedPuck(): ImageView = ImageView(activity).apply {
         setImageResource(R.drawable.ic_inkwell)

--- a/app/src/test/java/dev/jraghavan/inkread/ToolOptionsPlacementTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolOptionsPlacementTest.kt
@@ -1,7 +1,7 @@
 package dev.jraghavan.inkread
 
-import dev.jraghavan.inkread.ToolOptions.Side
 import dev.jraghavan.inkread.ToolOptions.Companion.sideFor
+import dev.jraghavan.inkread.ToolOptions.Side
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -17,70 +17,73 @@ import org.junit.Test
 class ToolOptionsPlacementTest {
 
     private val hostW = 1920
+    private val hostH = 2560
 
-    /** A vertical pill docked right — the default, and the one case the old code got right. */
+    private fun pill(
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+        horizontal: Boolean = false,
+        dockedStart: Boolean = false,
+    ) = ToolPalette.Placement(left, top, right, bottom, horizontal, dockedStart)
+
+    /** A vertical pill, centred at [centerX], the width the expanded strip actually is. */
+    private fun verticalPillAt(centerX: Int) = pill(centerX - 56, 900, centerX + 56, 1660)
+
+    /** A horizontal bar, centred at [centerY], spanning from the left dock. */
+    private fun horizontalBarAt(centerY: Int, dockedStart: Boolean = true) =
+        pill(20, centerY - 68, 1040, centerY + 68, horizontal = true, dockedStart = dockedStart)
+
     @Test
-    fun a_pill_on_the_right_opens_the_column_to_its_left() {
-        assertEquals(
-            Side.LEFT_OF_PILL,
-            sideFor(hasPill = true, horizontal = false, pillCenterX = 1830, hostWidth = hostW),
-        )
+    fun aPillOnTheRightOpensTheColumnToItsLeft() {
+        assertEquals(Side.LEFT_OF_PILL, sideFor(verticalPillAt(1830), hostW, hostH))
     }
 
     /** The regression: docked left, the column used to stay on the right regardless. */
     @Test
-    fun a_pill_on_the_left_opens_the_column_to_its_right() {
-        assertEquals(
-            Side.RIGHT_OF_PILL,
-            sideFor(hasPill = true, horizontal = false, pillCenterX = 90, hostWidth = hostW),
-        )
-    }
-
-    /** Docked across the top there is no side to open into, so it drops below the bar. */
-    @Test
-    fun a_bar_across_the_top_opens_the_column_beneath_it() {
-        assertEquals(
-            Side.BELOW_PILL,
-            sideFor(hasPill = true, horizontal = true, pillCenterX = 960, hostWidth = hostW),
-        )
-    }
-
-    /** Orientation wins over position: a top bar dropped below even when dragged to an edge. */
-    @Test
-    fun a_horizontal_bar_stays_below_wherever_it_is_dragged() {
-        for (x in intArrayOf(0, 90, 960, 1830, hostW)) {
-            assertEquals(
-                "dragged to x=$x",
-                Side.BELOW_PILL,
-                sideFor(hasPill = true, horizontal = true, pillCenterX = x, hostWidth = hostW),
-            )
-        }
-    }
-
-    /** Before the palette has been laid out there is nothing to sit beside. */
-    @Test
-    fun with_no_palette_yet_the_column_falls_back_to_the_right_edge() {
-        assertEquals(
-            Side.RIGHT_EDGE,
-            sideFor(hasPill = false, horizontal = false, pillCenterX = 0, hostWidth = hostW),
-        )
-    }
-
-    /** Dead centre counts as the left half, so the column opens into the wider space to the right. */
-    @Test
-    fun a_pill_at_the_exact_centre_opens_to_its_right() {
-        assertEquals(
-            Side.RIGHT_OF_PILL,
-            sideFor(hasPill = true, horizontal = false, pillCenterX = hostW / 2, hostWidth = hostW),
-        )
+    fun aPillOnTheLeftOpensTheColumnToItsRight() {
+        assertEquals(Side.RIGHT_OF_PILL, sideFor(verticalPillAt(90), hostW, hostH))
     }
 
     /** The pill is draggable, so the side must track it across the midline, not stay where it docked. */
     @Test
-    fun dragging_a_pill_across_the_midline_flips_the_side() {
-        val justLeft = sideFor(true, horizontal = false, pillCenterX = hostW / 2 - 1, hostWidth = hostW)
-        val justRight = sideFor(true, horizontal = false, pillCenterX = hostW / 2 + 1, hostWidth = hostW)
-        assertEquals(Side.RIGHT_OF_PILL, justLeft)
-        assertEquals(Side.LEFT_OF_PILL, justRight)
+    fun draggingAPillAcrossTheMidlineFlipsTheSide() {
+        assertEquals(Side.RIGHT_OF_PILL, sideFor(verticalPillAt(hostW / 2 - 1), hostW, hostH))
+        assertEquals(Side.LEFT_OF_PILL, sideFor(verticalPillAt(hostW / 2 + 1), hostW, hostH))
+    }
+
+    @Test
+    fun aBarNearTheTopOpensTheColumnBeneathIt() {
+        assertEquals(Side.BELOW_PILL, sideFor(horizontalBarAt(150), hostW, hostH))
+    }
+
+    /**
+     * The bug an earlier version of this test enshrined: `horizontal` is an orientation, not a
+     * position. The bar is dragged over the whole page, and assuming it stays near the top pushed
+     * the options column off the bottom of the screen, where it was silently clipped.
+     */
+    @Test
+    fun aBarDraggedDownThePageOpensTheColumnAboveIt() {
+        assertEquals(Side.ABOVE_PILL, sideFor(horizontalBarAt(hostH - 200), hostW, hostH))
+    }
+
+    @Test
+    fun aBarCrossingTheVerticalMidlineFlipsTheSide() {
+        assertEquals(Side.BELOW_PILL, sideFor(horizontalBarAt(hostH / 2 - 1), hostW, hostH))
+        assertEquals(Side.ABOVE_PILL, sideFor(horizontalBarAt(hostH / 2 + 1), hostW, hostH))
+    }
+
+    /** Orientation picks the axis; only position picks the direction along it. */
+    @Test
+    fun orientationDecidesTheAxisIndependentlyOfPosition() {
+        for (x in intArrayOf(0, 480, 960, 1440, hostW)) {
+            val bar = pill(x, 100, x + 400, 236, horizontal = true, dockedStart = true)
+            assertEquals("bar at x=$x", Side.BELOW_PILL, sideFor(bar, hostW, hostH))
+        }
+        for (y in intArrayOf(0, 640, 1280, 1920, hostH)) {
+            val column = pill(1700, y, 1812, y + 400, horizontal = false, dockedStart = false)
+            assertEquals("pill at y=$y", Side.LEFT_OF_PILL, sideFor(column, hostW, hostH))
+        }
     }
 }

--- a/app/src/test/java/dev/jraghavan/inkread/ToolOptionsPlacementTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/ToolOptionsPlacementTest.kt
@@ -1,0 +1,86 @@
+package dev.jraghavan.inkread
+
+import dev.jraghavan.inkread.ToolOptions.Side
+import dev.jraghavan.inkread.ToolOptions.Companion.sideFor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Host JVM tests for where the tool-options column opens (#200).
+ *
+ * The reported bug: the colour and thickness choices always appeared on the right, as though the
+ * palette were still docked there. Moving the bar to the left edge or across the top left the
+ * column stranded on the far side of the page from the tool that opened it.
+ *
+ * A 1920x2560 Manta panel stands in below.
+ */
+class ToolOptionsPlacementTest {
+
+    private val hostW = 1920
+
+    /** A vertical pill docked right — the default, and the one case the old code got right. */
+    @Test
+    fun a_pill_on_the_right_opens_the_column_to_its_left() {
+        assertEquals(
+            Side.LEFT_OF_PILL,
+            sideFor(hasPill = true, horizontal = false, pillCenterX = 1830, hostWidth = hostW),
+        )
+    }
+
+    /** The regression: docked left, the column used to stay on the right regardless. */
+    @Test
+    fun a_pill_on_the_left_opens_the_column_to_its_right() {
+        assertEquals(
+            Side.RIGHT_OF_PILL,
+            sideFor(hasPill = true, horizontal = false, pillCenterX = 90, hostWidth = hostW),
+        )
+    }
+
+    /** Docked across the top there is no side to open into, so it drops below the bar. */
+    @Test
+    fun a_bar_across_the_top_opens_the_column_beneath_it() {
+        assertEquals(
+            Side.BELOW_PILL,
+            sideFor(hasPill = true, horizontal = true, pillCenterX = 960, hostWidth = hostW),
+        )
+    }
+
+    /** Orientation wins over position: a top bar dropped below even when dragged to an edge. */
+    @Test
+    fun a_horizontal_bar_stays_below_wherever_it_is_dragged() {
+        for (x in intArrayOf(0, 90, 960, 1830, hostW)) {
+            assertEquals(
+                "dragged to x=$x",
+                Side.BELOW_PILL,
+                sideFor(hasPill = true, horizontal = true, pillCenterX = x, hostWidth = hostW),
+            )
+        }
+    }
+
+    /** Before the palette has been laid out there is nothing to sit beside. */
+    @Test
+    fun with_no_palette_yet_the_column_falls_back_to_the_right_edge() {
+        assertEquals(
+            Side.RIGHT_EDGE,
+            sideFor(hasPill = false, horizontal = false, pillCenterX = 0, hostWidth = hostW),
+        )
+    }
+
+    /** Dead centre counts as the left half, so the column opens into the wider space to the right. */
+    @Test
+    fun a_pill_at_the_exact_centre_opens_to_its_right() {
+        assertEquals(
+            Side.RIGHT_OF_PILL,
+            sideFor(hasPill = true, horizontal = false, pillCenterX = hostW / 2, hostWidth = hostW),
+        )
+    }
+
+    /** The pill is draggable, so the side must track it across the midline, not stay where it docked. */
+    @Test
+    fun dragging_a_pill_across_the_midline_flips_the_side() {
+        val justLeft = sideFor(true, horizontal = false, pillCenterX = hostW / 2 - 1, hostWidth = hostW)
+        val justRight = sideFor(true, horizontal = false, pillCenterX = hostW / 2 + 1, hostWidth = hostW)
+        assertEquals(Side.RIGHT_OF_PILL, justLeft)
+        assertEquals(Side.LEFT_OF_PILL, justRight)
+    }
+}

--- a/app/src/test/java/dev/jraghavan/inkread/UiScaleTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/UiScaleTest.kt
@@ -26,10 +26,15 @@ class UiScaleTest {
 
     @Test
     fun nearestUiScaleIndexSnapsToTheClosestStep() {
-        assertEquals(0, DisplayPrefs.nearestUiScaleIndex(0.9f)) // exact min
+        assertEquals(0, DisplayPrefs.nearestUiScaleIndex(0.8f)) // exact min
         assertEquals(DisplayPrefs.UI_SCALES.size - 1, DisplayPrefs.nearestUiScaleIndex(1.5f)) // exact max
         // Off-grid inputs snap to the nearest step, and out-of-range clamps to an end.
-        assertEquals(1, DisplayPrefs.nearestUiScaleIndex(1.02f)) // nearest 1.0
+        // Named by value, not index: adding a step shifts every index but not what 1.02 snaps to.
+        assertEquals(
+            1.0,
+            DisplayPrefs.UI_SCALES[DisplayPrefs.nearestUiScaleIndex(1.02f)].toDouble(),
+            0.0,
+        )
         assertEquals(0, DisplayPrefs.nearestUiScaleIndex(0.1f)) // below range -> min
         assertEquals(DisplayPrefs.UI_SCALES.size - 1, DisplayPrefs.nearestUiScaleIndex(9f)) // above range -> max
     }
@@ -39,5 +44,26 @@ class UiScaleTest {
         // The DRY nearestIndex refactor must not conflate the two scales' arrays.
         assertEquals(1.0, DisplayPrefs.TEXT_SCALES[DisplayPrefs.nearestScaleIndex(1.0f)].toDouble(), 0.0)
         assertEquals(3.0, DisplayPrefs.TEXT_SCALES[DisplayPrefs.nearestScaleIndex(9f)].toDouble(), 0.0) // TEXT max 3.0
+    }
+
+    /**
+     * #200: the smallest menu size must leave the palette's tool buttons on a target the platform
+     * still calls tappable. XS exists so the pill can shrink; it must not shrink past 48dp.
+     */
+    @Test
+    fun the_smallest_menu_size_keeps_a_48dp_tool_target() {
+        val smallest = DisplayPrefs.UI_SCALES.min()
+        val target = ToolPalette.TOOL_BOX * smallest
+        assertEquals(48.0, target.toDouble(), 0.01)
+        assertTrue("no step may take the tool button below 48dp", target >= 48f)
+    }
+
+    /** The glyph stays inside its target at every step, or the icon would overflow the button. */
+    @Test
+    fun the_glyph_always_fits_inside_the_tool_target() {
+        assertTrue(
+            "glyph inset must leave a glyph",
+            ToolPalette.TOOL_BOX - 2 * ToolPalette.TOOL_GLYPH_INSET > 0,
+        )
     }
 }

--- a/app/src/test/java/dev/jraghavan/inkread/UiScaleTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/UiScaleTest.kt
@@ -47,23 +47,55 @@ class UiScaleTest {
     }
 
     /**
-     * #200: the smallest menu size must leave the palette's tool buttons on a target the platform
-     * still calls tappable. XS exists so the pill can shrink; it must not shrink past 48dp.
+     * #200. The reader asked for smaller icons "but with some margin to keep some distance between
+     * button for ease of activation". Uniform scaling cannot do that — it preserves every ratio, so
+     * the buttons stay exactly as crowded. Only the glyph scales, so a smaller Menu Size must leave
+     * proportionally MORE clearance around each icon, not the same.
+     *
+     * This is the assertion that fails against a uniform-scaling implementation.
      */
     @Test
-    fun the_smallest_menu_size_keeps_a_48dp_tool_target() {
-        val smallest = DisplayPrefs.UI_SCALES.min()
-        val target = ToolPalette.TOOL_BOX * smallest
-        assertEquals(48.0, target.toDouble(), 0.01)
-        assertTrue("no step may take the tool button below 48dp", target >= 48f)
+    fun aSmallerMenuSizeWidensTheClearanceAroundEachIcon() {
+        val steps = DisplayPrefs.UI_SCALES.sorted()
+        val clearance = steps.map { scale ->
+            val box = ToolPalette.boxDp(scale)
+            (box - ToolPalette.glyphDp(scale)).toDouble() / box
+        }
+        for (i in 1 until clearance.size) {
+            assertTrue(
+                "clearance share must fall as the scale grows: ${clearance[i - 1]} -> ${clearance[i]}",
+                clearance[i] < clearance[i - 1],
+            )
+        }
     }
 
-    /** The glyph stays inside its target at every step, or the icon would overflow the button. */
+    /** Menu Size M must reproduce the toolbar exactly as it was, or every reader's pill moves. */
     @Test
-    fun the_glyph_always_fits_inside_the_tool_target() {
-        assertTrue(
-            "glyph inset must leave a glyph",
-            ToolPalette.TOOL_BOX - 2 * ToolPalette.TOOL_GLYPH_INSET > 0,
-        )
+    fun theDefaultMenuSizeReproducesTheOriginalButton() {
+        assertEquals(32, ToolPalette.glyphDp(1.0f))
+        assertEquals(60, ToolPalette.boxDp(1.0f))
+    }
+
+    /**
+     * No offered step may take the touch target under the platform floor. Asserted across every
+     * step rather than the smallest, so adding one cannot quietly slip beneath it.
+     */
+    @Test
+    fun noMenuSizeTakesTheToolTargetBelowTheFloor() {
+        for (scale in DisplayPrefs.UI_SCALES) {
+            assertTrue(
+                "scale $scale gives ${ToolPalette.boxDp(scale)}dp",
+                ToolPalette.boxDp(scale) >= ToolPalette.TOOL_BOX_MIN,
+            )
+        }
+    }
+
+    /** The glyph must stay strictly inside its target at every step, with room to read as an icon. */
+    @Test
+    fun theGlyphFitsItsTargetAtEveryStep() {
+        for (scale in DisplayPrefs.UI_SCALES) {
+            val slack = ToolPalette.boxDp(scale) - ToolPalette.glyphDp(scale)
+            assertTrue("scale $scale leaves ${slack}dp around the glyph", slack >= 2 * ToolPalette.TOOL_INSET)
+        }
     }
 }


### PR DESCRIPTION
Two things alioth9 reported on #200: the tool options column always opened on the right whatever the
toolbar was doing, and the tool buttons read as too big.

## The options column now opens beside the toolbar

It was laid out with a fixed `Gravity.END or Gravity.CENTER_VERTICAL` and an 88dp inset, so it
always hugged the right edge. That was right only for the default dock — with the bar on the left
edge or across the top, the colours and thicknesses sat on the far side of the page from the tool
that opened them.

`ToolOptions` had no way to know better; it takes the root frame and nothing else. `ToolPalette` now
reports a `Placement` — where it is in host coordinates with drag translation included, which way it
runs, and which edge it docks to — and the column places itself against that. Geometry rather than a
placement, so the palette does not acquire opinions about the column's layout. Read at show time
rather than captured, because the pill is draggable.

The column is displaced from the pill along one axis and lines up with the pill's docked edge on the
other. Both midlines matter:

- vertical pill on the right half → column to its left, and to its right on the left half
- horizontal bar in the top half → column below it, above it in the bottom half

Orientation picks the axis; position picks the direction along it. A horizontal bar is not
necessarily a *top* bar — it is dragged over the whole page, and treating it as one pushed the
column off the bottom, where a WRAP_CONTENT child is silently clipped rather than repositioned. On a
Nomad that starts at 43% down the page.

Lining up with the docked edge rather than centring matters for the same reason the bug did: the bar
docks into a corner, so a centred column lands a long way from the button that summoned it — the
same complaint in milder form. The pill's drag is clamped to keep it fully within the host, so a
margin measured from one of its edges can be neither negative nor past the far side.

Placement uses absolute `LEFT`/`RIGHT` gravity. The manifest declares `supportsRtl` and every input
here is an absolute pixel coordinate, so a direction-resolved `START`/`END` would mirror the margins
out from under coordinates that had not mirrored with them.

The side decision is a pure `sideFor` tested on the JVM, the same shape as the pill's own placement
maths in `ToolPalettePlacementTest`. `Placement` carries plain `Int`s rather than a `Rect` so that
stays possible — `android.graphics.Rect` is a stub in a unit test.

Known limit: the column does not follow a drag that happens while it is already open. Re-placing a
mounted view costs an EPD repaint, and the pill moving out from under its own options is rare next
to that. Stated in the KDoc.

## Menu Size now reaches the palette, and scales the icon rather than the spacing

The palette's buttons were a fixed 60dp through a private `dp()` that ignored `Ink.sdp`, so it was
the one piece of reader chrome that did not answer to the reader's Menu Size preference. That looks
like an omission: #133 set `Ink.uiScale` in `ReaderActivity` "before any chrome is built" and said
applying it across the controllers would follow, and the palette's later rework reintroduced
unscaled sizing.

Scaling everything by one factor would not have answered the report. alioth9 asked for smaller icons
"but with some margin to keep some distance between button for ease of activation", and a single
factor preserves every ratio — at XS the dead space between two adjacent targets falls from 0.51mm
to 0.34mm and the buttons end up as crowded as they started.

So the glyph scales, the inset and the gap hold at their design size, and the box is derived:

| Menu Size | glyph | box | strip |
|---|---|---|---|
| XS (0.8) | 25dp | 53dp | 493dp |
| M (1.0) | 32dp | 60dp | 544dp |
| 2XL (1.5) | 48dp | 76dp | 672dp |

At M that is exactly the 32dp glyph in a 60dp box it always was, so a reader who never touches the
setting sees the toolbar they already had, and no pagination or layout shifts under them. At XS the
icon loses 20% while the clearance around it grows.

Deriving the box also keeps the expanded horizontal strip on the panel. Scaling the box directly
would have made it 815dp at 2XL against a Nomad's 749dp, and `clamp` returns 0 when slack is
negative, so the overhanging end could not be dragged back — undo and redo would leave the screen
permanently.

Sizes resolve in dp and multiply by density once. Scaling an already-converted pixel size truncates
twice and leaves the box a fraction under the 48dp floor the setting is chosen against.

`UI_SCALES` gains an XS step at 0.8. `uiScale` persists as a float rather than an index, so
prepending a step changes no existing install's setting.

**Changing Menu Size now visibly changes the toolbar.** The palette is built once and stays on
screen, so it kept its old size while the toast said to reopen a menu — the setting looked as though
it did not cover the toolbar at all. `refreshChrome` rebuilds it, re-anchored so the grip does not
drift, which is the same correction a collapse already needs.

## Scope

The default is unchanged: this makes the palette *adjustable*, it does not make it smaller. Answering
the report requires the reader to set Adjust → Menu Size → XS, and that shrinks all reader chrome by
20%, not only the toolbar. Reusing the existing control rather than adding a toolbar-specific one is
deliberate — a second size knob in that sheet is real clutter — but it is a trade.

Not addressed here, both raised separately by the reporter: colour distinguishability, and the table
rendering bugs.

## Tests

Host only. `sideFor` is covered across both midlines, a bar dragged down the page, and orientation
holding the axis independently of position. The sizing is covered by the properties that matter: a
smaller Menu Size widens the clearance share around each icon, M reproduces 32dp-in-60dp exactly, no
offered step takes the target under the 48dp floor, and the glyph fits at every step.

The two sizing tests fail against a uniform-scaling implementation and the above/below tests fail
against a single-axis one — checked by mutating each and re-running, not assumed.

`cargo fmt --all --check`, `cargo clippy --all --all-targets -- -D warnings`, `cargo test --workspace`
(678), `:app:compileDebugKotlin` and `:app:testDebugUnitTest` (269) are green.

I have not run this on a device. Worth a look on a Nomad, where the strip is tightest: whether XS
reads as enough of a reduction, and whether the options column lines up sensibly with a top-docked
bar in both corners.
