### PR TITLE
fix(reflow): invalidate paginations #239 made stale, and stop mis-reporting the fallout

### DIFF
--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -706,15 +706,29 @@ impl Document for EpubBackend {
     fn render_page(&self, index: usize, buf: &mut PixelBuffer<'_>) -> CoreResult<()> {
         self.viewport.set((buf.width(), buf.height()));
         let (w, h) = (buf.width(), buf.height());
+        // Range-checked here rather than left to `with_page`, so the two ways it can decline are
+        // told apart (#215). Past the end is the reader's fault and says so; anything else is the
+        // pagination index claiming a page the layout does not have, which is our fault and a
+        // different bug entirely — reporting it as out-of-range sends the next person hunting for
+        // a page number that was never wrong.
+        let available = self.laid().total_pages;
+        if index >= available {
+            return Err(CoreError::PageOutOfRange {
+                requested: index,
+                available,
+            });
+        }
         let canvas = self
             .with_page(index, |page, opts| {
                 let mut canvas = GrayCanvas::new(w, h);
                 raster_page(page, opts, &self.font.borrow(), self, &mut canvas);
                 canvas
             })
-            .ok_or(CoreError::PageOutOfRange {
-                requested: index,
-                available: self.laid().total_pages,
+            .ok_or_else(|| {
+                CoreError::RenderBackend(format!(
+                    "pagination index and layout disagree: page {index} of {available} is counted \
+                     by the index but its chapter did not lay it out"
+                ))
             })?;
         buf.fill_white();
         // Expand 8-bit grayscale → opaque RGBA (CHANNEL_ORDER r,g,b,a). One byte → three equal.
@@ -1011,8 +1025,14 @@ pub(crate) fn reset_layout_passes() {
 ///   centred block, drops the first-line indent, so lines fit differently than a `v2` pass assumed.
 /// - `v3` → `v4`: illustrations occupy a real box instead of one line of `[image]` text (#187),
 ///   which changes the page count of every illustrated chapter.
+/// - `v4` → `v5`: bold and italic runs are measured as themselves (#239). `advance()` had ignored
+///   the bold flag, so a bold line was measured narrower than it was inked, and three families now
+///   set their emphasis in real faces rather than a smear and a shear. Both move line breaks, so a
+///   `v4` index describes boundaries this engine no longer produces — and because a stored index is
+///   trusted verbatim, that mismatch surfaces as a page the index counts and the layout lacks
+///   (#215) rather than as anything obviously font-related.
 fn layout_key(opts: &LayoutOpts, font_id: usize, chapters: usize) -> String {
-    format!("v4|{:016x}|{font_id}|{chapters}", opts.layout_digest())
+    format!("v5|{:016x}|{font_id}|{chapters}", opts.layout_digest())
 }
 
 /// A materialized chapter: the pages laid out so far, and whether that is all of them (#186).

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -814,6 +814,47 @@ fn a_page_past_the_end_is_a_typed_error_not_a_panic() {
     assert!(b.page_pin(count).is_none());
 }
 
+/// #215: a page the pagination index counts but the layout does not have must not be reported as
+/// out of range. It is not — the index believes it exists, and that disagreement is the fault.
+///
+/// This is what a stale persisted pagination does: it is trusted verbatim (see
+/// `a_stored_pagination_of_the_right_shape_is_used_verbatim`), so an index written by a build that
+/// measured text differently claims pages the current layout never produces. The device report had
+/// no reproduction; planting an inflated index is that reproduction, and it separates the two
+/// faults the one message used to blur together.
+#[test]
+fn a_page_the_index_claims_but_the_layout_lacks_is_not_reported_as_out_of_range() {
+    let b = synthetic_book();
+    let chapters = b.chapter_count();
+    // Every chapter is short of this, so the index counts pages no chapter can lay out.
+    b.set_pagination_cache(fake(Some(vec![40; chapters])).0);
+    let inflated = b.page_count();
+    assert_eq!(inflated, 40 * chapters, "the planted index is in force");
+
+    let mut bytes = vec![0u8; 400 * 600 * 4];
+    let mut buf = PixelBuffer::from_rgba(&mut bytes, 400, 600).unwrap();
+
+    // Well inside the index, far past what chapter 0 actually lays out.
+    let err = b
+        .render_page(30, &mut buf)
+        .expect_err("a claimed-but-unlaid page must fail");
+    assert!(
+        !matches!(err, CoreError::PageOutOfRange { .. }),
+        "divergence reported as a plain out-of-range page: {err}"
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("index and layout disagree"),
+        "the message does not say what actually went wrong: {message}"
+    );
+
+    // A genuinely out-of-range page still reports as one, so the new path did not swallow the old.
+    assert!(matches!(
+        b.render_page(inflated, &mut buf),
+        Err(CoreError::PageOutOfRange { .. })
+    ));
+}
+
 /// An empty chapter still occupies exactly one page, so the chapter -> page mapping stays 1:1 and
 /// a TOC entry pointing at it lands somewhere real. Front matter and section dividers produce these
 /// in real books, and the index build, the materialization path and the persisted counts each have
@@ -1058,18 +1099,51 @@ fn a_books_declared_styles_reach_the_laid_out_page() {
 
 /// The pagination cache key must move whenever anything changes how much content fits on a page,
 /// or a cache written by an older build is replayed against a layout it does not describe and the
-/// reader lands on stale page boundaries. #163 bumped it to v2, #188 to v3, #187 to v4.
+/// reader lands on stale page boundaries. #163 bumped it to v2, #188 to v3, #187 to v4, #239 to v5.
 ///
-/// This is a tripwire, not a tautology: it fails until whoever changed line fitting bumps the key.
+/// This test used to assert only the key's prefix, which made it a tautology dressed as a tripwire:
+/// it could not fail for the thing it was written to catch. #239 taught `advance()` to pay for a
+/// synthesized bold's smear and gave three families real bold and italic faces — both of which move
+/// line breaks — and this test stayed green while every persisted pagination on disk went stale.
+/// That is #215.
+///
+/// It pins **measurement** rather than the page count it produces. Pinning pages looked like the
+/// stronger check and is in fact the weaker one: line breaking has slack, so a small width change
+/// is absorbed without moving a break, and the test goes green for a layout that no longer matches
+/// the cache. Advance widths have no slack — every change to face selection, synthesis or metrics
+/// moves them.
+///
+/// When these move, bump the version in `layout_key` **and** update them in the same commit.
+/// Updating them alone re-arms the bug.
 #[test]
 fn the_pagination_cache_version_tracks_changes_to_line_fitting() {
     let opts = LayoutOpts::new(600.0, 800.0, 16.0);
     assert!(
-        layout_key(&opts, 0, 1).starts_with("v4|"),
+        layout_key(&opts, 0, 1).starts_with("v5|"),
         "{}",
         layout_key(&opts, 0, 1)
     );
+
+    // All four styles: a family's real faces and the synthesis that stands in for the ones it
+    // does not bundle both feed line breaking, so both have to be pinned.
+    use inkread_epub::Metrics as _;
+    let font = AbFont::default_font();
+    let sample = "The morning was wholly unremarkable";
+    let measured: Vec<u32> = [(false, false), (true, false), (false, true), (true, true)]
+        .iter()
+        .map(|&(bold, italic)| font.advance(sample, 16.0, bold, italic).to_bits())
+        .collect();
+
+    assert_eq!(
+        measured, PINNED_ADVANCES,
+        "text measurement changed — bump the version in layout_key with this update"
+    );
 }
+
+/// Advance widths (f32 bit patterns) of the sample in regular, bold, italic and bold-italic,
+/// pinned by [`the_pagination_cache_version_tracks_changes_to_line_fitting`]. Bit patterns rather
+/// than a rounded comparison, so a sub-pixel drift that would accumulate across a line still fails.
+const PINNED_ADVANCES: [u32; 4] = [1_127_625_679, 1_128_079_691, 1_126_559_188, 1_127_093_121];
 
 /// #187 end to end: an illustration has to survive the whole path — out of the container, through
 /// layout as a box with real height, and onto the rasterized page as pixels.


### PR DESCRIPTION
Closes #215.

## What #215 turned out to be

A stored pagination is trusted verbatim: matching chapter count, no layout pass at all. There is a
test asserting exactly that —

```rust
b.set_pagination_cache(fake(Some(vec![7; chapters])).0);
assert_eq!(b.page_count(), 7 * chapters);
assert_eq!(layout_passes(), 0, "served from the cache, not laid out");
```

So the only thing between a stale index and a reader on wrong page boundaries is the version prefix
in `layout_key`.

**#239 changed text measurement and did not bump it.** `advance()` had ignored the bold flag
entirely — that was the bug #239 fixed — and Spectral, Noto Serif and Noto Sans now set their
emphasis in real faces rather than a smear and a shear. Both move line breaks.

Every `v4` index already on disk therefore describes boundaries this engine no longer produces. The
first upgraded open of an already-read book replays one, and where it counts a page the layout does
not produce, the divergence guard fires. That is the reported error.

This makes #215 reachable for **every existing reader on upgrade**, which is why it is in v1.3.0
rather than sitting at Medium.

## Bumped to v5

Existing indexes are discarded, so the first open of each already-read book pays for one re-index.
That is the intended cost and the same one #163, #188 and #187 each paid.

## The tripwire was a tautology

```rust
/// This is a tripwire, not a tautology: it fails until whoever changed line fitting bumps the key.
fn the_pagination_cache_version_tracks_changes_to_line_fitting() {
    assert!(layout_key(&opts, 0, 1).starts_with("v4|"));
}
```

It asserts the key's own prefix, so it can only fail for someone editing the key — never for someone
changing line fitting. #239 walked past it green. Bumping the version alone just resets that clock.

It now pins measurement. **Pinning the resulting page count was the obvious choice and is the weaker
one:** line breaking has slack, so a small width change gets absorbed without moving a break. I
wrote that version first, then probed it by widening every bold glyph half a pixel — the page count
did not move and the test stayed green, exactly the failure it is meant to catch. Advance widths
have no slack. The same probe fails the pinned version and passes again when reverted.

## The error told the wrong story

`with_page` declines for two reasons and `render_page` reported both as `PageOutOfRange`, so an
index/layout disagreement surfaced as `page 3 out of range (have 6)` — self-contradictory, and it
sends whoever reads the log after a page number that was never wrong.

The range check moves up into `render_page`: past-the-end still reports as out of range, and
anything else now says what it is. No new error code, so the JNI contract is unchanged.

## Reproduction

The device report had none. Planting an inflated index is one, and
`a_page_the_index_claims_but_the_layout_lacks_is_not_reported_as_out_of_range` does it. Reverting
`reflow.rs` to master fails it with the issue's exact message:

```
divergence reported as a plain out-of-range page: page 30 out of range (have 480)
```

## Tests

`cargo fmt --check`, `cargo clippy --all -D warnings`, `cargo test --workspace`, the
`aarch64-linux-android` JNI cross-check, `:app:testReleaseUnitTest` and the licence manifest check
all pass.

## Device check — could you confirm on the Manta?

The host cannot show the upgrade path, because it has no `v4` index written by an older build.

1. Open a book you have already read on the current release, in two-column mode, and page through
   the whole thing. The first open should re-index (a progress pass); no page should fail to render.
2. Confirm reading position still lands sensibly after the re-index.
