### PR TITLE
feat(digest): offer to open the Digest app after adding a selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,16 @@
     <uses-permission android:name="com.ratta.supernote.knowledge.permission.READ_KNOWLEDGE" />
     <uses-permission android:name="com.ratta.supernote.knowledge.permission.WRITE_KNOWLEDGE" />
 
+    <!-- Package visibility (Android 11+): the post-add jump into the Digest app (#124) resolves an
+         explicit component before offering it, and from targetSdk 30 onward another package is
+         invisible to that check unless declared here. Without this the offer would silently never
+         appear on device, which is exactly the kind of failure that looks like the feature was never
+         built. Narrow by design: one package, not QUERY_ALL_PACKAGES. -->
+    <queries>
+        <package android:name="com.ratta.supernote.knowledge" />
+    </queries>
+
+
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/dev/jraghavan/inkread/DigestController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DigestController.kt
@@ -1,8 +1,12 @@
 package dev.jraghavan.inkread
 
 import android.app.Activity
+import android.app.AlertDialog
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
 import android.content.ContentUris
 import android.content.ContentValues
+import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import android.widget.Toast
@@ -70,8 +74,7 @@ class DigestController(private val host: Host) {
                 toast("No selectable text under the selection")
                 return@engineExecute
             }
-            val ok = insertDigest(path, page, text, selectionAnchor(page, boundsNorm))
-            toast(if (ok) "Added to Digest" else "Couldn't add to Digest")
+            reportAdded(insertDigest(path, page, text, selectionAnchor(page, boundsNorm)))
         }
     }
 
@@ -88,8 +91,7 @@ class DigestController(private val host: Host) {
             return
         }
         host.engineExecute {
-            val ok = insertDigest(path, page, text, boundsNorm?.let { selectionAnchor(page, it) })
-            toast(if (ok) "Added to Digest" else "Couldn't add to Digest")
+            reportAdded(insertDigest(path, page, text, boundsNorm?.let { selectionAnchor(page, it) }))
         }
     }
 
@@ -165,6 +167,63 @@ class DigestController(private val host: Host) {
         return metadata.toString()
     }
 
+    /**
+     * Report the outcome of an insert, offering the jump into the Digest app on success (#124).
+     *
+     * The native reader lets you carry straight on into Digest to annotate what you just saved, and
+     * that is the whole point of the ask: the entry is only half-made until you have written your
+     * note against it. Digest exposes no deep link (its only activity filter is MAIN/LAUNCHER, no
+     * data actions), so this opens the app and no further — the reader lands on the entry list with
+     * their new entry at the top.
+     *
+     * A device that does not have the Digest app falls back to the plain toast, so this stays
+     * useful on anything the APK is sideloaded onto.
+     */
+    private fun reportAdded(ok: Boolean) {
+        if (!ok) {
+            toast("Couldn't add to Digest")
+            return
+        }
+        val intent = digestIntent()
+        if (intent == null) {
+            toast("Added to Digest")
+            return
+        }
+        activity.runOnUiThread {
+            AlertDialog.Builder(activity, R.style.InkDialog)
+                .setTitle("Added to Digest")
+                .setMessage("Open Digest to write a note against it?")
+                .setPositiveButton("Open Digest") { _, _ ->
+                    try {
+                        activity.startActivity(intent)
+                    } catch (e: ActivityNotFoundException) {
+                        // Resolved a moment ago; it can still be gone (uninstalled, or disabled for
+                        // this user). Never let a convenience action take the reader down.
+                        Log.e(TAG, "Digest launch failed: ${e.message}")
+                        toast("Couldn't open Digest")
+                    }
+                }
+                .setNegativeButton("Not now", null)
+                .show()
+        }
+    }
+
+    /**
+     * An explicit intent for the Digest app's entry screen, or null when it is not installed.
+     *
+     * Explicit rather than by action: Digest declares only MAIN/LAUNCHER, so there is no action or
+     * data URI to aim at, and an implicit MAIN/LAUNCHER intent would offer the reader a chooser of
+     * every launcher activity on the device. NEW_TASK because Digest is a separate app and belongs
+     * in its own task, not pushed onto inkread's back stack.
+     */
+    private fun digestIntent(): Intent? {
+        val intent = Intent(Intent.ACTION_MAIN)
+            .setComponent(ComponentName(DIGEST_PACKAGE, DIGEST_ACTIVITY))
+            .addCategory(Intent.CATEGORY_LAUNCHER)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return intent.takeIf { activity.packageManager.resolveActivity(it, 0) != null }
+    }
+
     private fun toast(msg: String) =
         activity.runOnUiThread { Toast.makeText(activity, msg, Toast.LENGTH_SHORT).show() }
 
@@ -173,6 +232,12 @@ class DigestController(private val host: Host) {
 
         // --- Supernote "Knowledge" provider contract (the only vendor-named surface; IR-7). ---
         const val INSERT_URI = "content://com.ratta.supernote.knowledge.provider/knowledge/insert"
+
+        // The Digest app itself, for the post-add jump (#124). Device-verified on a Manta: this is
+        // its only launchable activity, it carries no data filter (so there is nothing to deep-link
+        // to), and a sideloaded app can start it with no permission.
+        const val DIGEST_PACKAGE = "com.ratta.supernote.knowledge"
+        const val DIGEST_ACTIVITY = "com.ratta.supernote.knowledge.activity.KnowledgeActivity"
 
         const val SOURCE_TYPE_DOCUMENT = 1 // 1=DOCUMENT(PDF), 2=NOTE, 3=PASTEBOARD, 4=SELF_ADD
 


### PR DESCRIPTION
Closes #124.

## What this issue was blocked on

It needed the Digest app's launchable component and whether it can deep-link to the entry just
inserted. Pulled from a connected Manta:

| | |
|---|---|
| package | `com.ratta.supernote.knowledge` |
| launchable activity | `.activity.KnowledgeActivity` |
| intent filters | `MAIN` / `LAUNCHER` only, no action, no data |
| deep link to an entry | none available |
| startable by a sideloaded app | yes, no permission required |

So this opens the app and no further. The reader lands on the entry list with their new entry at
the top, which is enough for the ask, since the note gets written natively in Digest either way.

## The change

A successful add offers a dialog with "Open Digest" instead of stopping at a toast. Failure still
toasts as before, and a device without the Digest app falls back to the toast rather than offering
an action that would fail.

The intent is explicit. With only `MAIN`/`LAUNCHER` to aim at, an implicit intent would hand the
reader a chooser listing every launcher activity on the device. `NEW_TASK` because Digest is a
separate app and belongs in its own task rather than pushed onto inkread's back stack.

## The manifest change is load-bearing

From targetSdk 30 onward another package is invisible to `resolveActivity` unless declared, and this
app targets 34. There was no `queries` element, so without one the offer would never have appeared
on device and it would have looked like the feature was simply never built. Declared narrowly for
the one package rather than `QUERY_ALL_PACKAGES`.

## Tests

`cargo fmt --check`, `cargo clippy --all -D warnings`, `cargo test --workspace`, the
`aarch64-linux-android` JNI cross-check, `:app:testReleaseUnitTest` and the licence manifest check
all pass.

No host test was added. `digestIntent()` needs a real `PackageManager`, and this project runs plain
JUnit with no Robolectric, so there is nothing to assert without inventing an abstraction purely to
satisfy a test. Verified on device instead.

## Device-verified on a Manta

```
DigestController: DIAG digest insert -> id=17 page=44 len=307
ActivityTaskManager: START u0 {act=MAIN cat=[LAUNCHER] flg=0x10000000
                     cmp=com.ratta.supernote.knowledge/.activity.KnowledgeActivity} from uid 10132
Knowledge: DigestHandWriteClient: disableHandWrite Main Activity onResume
```

`uid 10132` is inkread, so that launch is the in-app path and not an `adb` test (`uid 2000`).
`flg=0x10000000` is `NEW_TASK`. Insert, offer, launch and Digest resuming, end to end.
