### PR TITLE
feat(settings): add an explicit Quit

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/SettingsActivity.kt
@@ -171,6 +171,18 @@ class SettingsActivity : Activity() {
         column.addView(spacer(dp(8)))
         for ((title, desc) in HELP) column.addView(helpRow(title, desc))
 
+        // ── Quit (#168) ────────────────────────────────────────────────────────────
+        column.addView(spacer(dp(34)))
+        column.addView(eyebrow("Quit"))
+        column.addView(spacer(dp(12)))
+        column.addView(actionRow("Quit inkread") { quit() })
+        column.addView(TextView(this).apply {
+            text = "Closes inkread and clears it from recent apps. Your place in the book and any " +
+                "handwriting are saved first."
+            setTextColor(inkSoft); textSize = 14f; typeface = serif
+            setPadding(0, dp(6), 0, 0); setLineSpacing(0f, 1.2f)
+        })
+
         // ── About ──────────────────────────────────────────────────────────────────
         column.addView(spacer(dp(34)))
         column.addView(eyebrow("About"))
@@ -195,6 +207,21 @@ class SettingsActivity : Activity() {
             addView(column)
         }
     }
+
+    /**
+     * Close inkread outright (#168).
+     *
+     * There was no way to do this short of force-stop, which readers were resorting to. The device
+     * has no system Back and the launcher leaves the task resident, so leaving the app is not the
+     * same as closing it.
+     *
+     * [finishAndRemoveTask] rather than [finish]: it ends every activity in the task and drops it
+     * from recents, which is what "closed" has to mean here. Nothing is confirmed and nothing is
+     * lost by it — the reader's position and any ink are written in `ReaderActivity.onPause`, which
+     * has already run by the time Settings is on screen, and the document is closed in `onDestroy`
+     * as the task tears down.
+     */
+    private fun quit() = finishAndRemoveTask()
 
     /** Turning overwrite ON is destructive, so confirm; turning it OFF is immediate. */
     private fun onExportOverwriteTapped() {


### PR DESCRIPTION
Closes #168.

Readers could not close inkread short of force-stop. The device has no system Back, and the launcher
leaves the task resident, so leaving the app is not the same as closing it.

## Where it lives

Settings, under its own "Quit" heading, above About. Not the reading bottom bar: Settings is where an
app-level action gets looked for, it is one tap from the Home gear, and it cannot be hit by accident
mid-page the way a control sitting next to the page-turn could be.

## What it does

`finishAndRemoveTask()` rather than `finish()`. It ends every activity in the task and drops it from
recents, which is what "closed" has to mean for this complaint. `finish()` would only pop Settings
and leave the reader behind it.

## Nothing is lost, and nothing is confirmed

The reading position and any handwriting are written in `ReaderActivity.onPause` (`nativeInkSave`
plus `savePosition` on the engine thread), which has already run by the time Settings is on screen.
`onDestroy` closes the document and shuts the engine down, letting the queued close drain. So the
action destroys nothing, and a confirmation dialog would be a full EPD refresh guarding a safe
action.

This was also listed as making #157 worse, since a resident process kept intercepting the pen. #157
is closed, but the gap this fixes stands on its own.

## Tests

`cargo fmt --check`, `cargo clippy --all -D warnings`, `cargo test --workspace`, the
`aarch64-linux-android` JNI cross-check and `:app:testReleaseUnitTest` all pass.

No unit test: the change is one lifecycle call on an Activity, with no logic to assert, and this
project has no instrumentation or Robolectric harness to drive it.

## Worth a look on device

Quit from Settings, then confirm inkread is gone from recent apps, and that reopening a book returns
you to the page you were on.
