### PR TITLE
feat(daily): let a feed's URL be edited

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyActivity.kt
@@ -493,8 +493,40 @@ class DailyActivity : Activity() {
             .show()
     }
 
+    /**
+     * Prompt for a replacement feed URL, pre-filled with the current one (#166).
+     *
+     * A feed URL could be added and removed but never corrected, so a typo or a publisher moving
+     * their feed meant losing the row and its per-source article limit and re-adding it from
+     * scratch. [onAccept] receives the new URL only when it is worth applying: blank input is a
+     * slip rather than an instruction, and a URL already followed by another row would otherwise
+     * produce two entries fetching the same feed.
+     */
+    private fun editSourceUrlDialog(current: String, others: List<String>, onAccept: (String) -> Unit) {
+        val input = EditText(this).apply {
+            setText(current)
+            setSelection(current.length)
+            setSingleLine()
+        }
+        AlertDialog.Builder(this, R.style.InkDialog)
+            .setTitle("Edit feed URL")
+            .setMessage("The byline follows the address when it was taken from one.")
+            .setView(input)
+            .setPositiveButton("Save") { _, _ ->
+                val u = input.text.toString().trim()
+                when {
+                    u.isEmpty() -> Unit
+                    u in others -> Toast.makeText(this, "Already following that feed", Toast.LENGTH_SHORT).show()
+                    else -> onAccept(u)
+                }
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
     /** Edit sources: a checklist (uncheck a row to mute it without losing it — e.g. disable NPR) with
-     *  a per-row Remove to drop it entirely. Saving applies mutes + removals in one pass. */
+     *  a per-row Edit to correct its URL and a per-row Remove to drop it entirely. Saving applies
+     *  URL edits, mutes and removals in one pass. */
     private fun sourcesDialog() {
         val sources = daily.sources()
         if (sources.isEmpty()) {
@@ -504,6 +536,10 @@ class DailyActivity : Activity() {
         val enabled = sources.map { it.enabled }.toBooleanArray()
         val removed = BooleanArray(sources.size)
         val limits = sources.map { it.limit }.toIntArray()
+        // Edited URLs are staged like the limits and mutes, and committed by the same Save, so the
+        // dialog keeps one way of working rather than a per-row action that writes behind the
+        // reader's back while their other edits are still pending (#166).
+        val urls = sources.map { it.url }.toTypedArray()
 
         val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
         sources.forEachIndexed { i, s ->
@@ -519,6 +555,16 @@ class DailyActivity : Activity() {
             val info = TextView(this).apply {
                 text = "${s.name}\n${s.url}"; setTextColor(ink); textSize = fs(13f); typeface = serif
             }
+            val edit = TextView(this).apply {
+                text = "Edit"; setTextColor(ink); textSize = fs(11f); typeface = mono
+                letterSpacing = 0.1f; setPadding(dim(12), dim(6), dim(2), dim(6)); isClickable = true
+                setOnClickListener {
+                    editSourceUrlDialog(urls[i], others = urls.filterIndexed { j, _ -> j != i }) { u ->
+                        urls[i] = u
+                        info.text = "${s.name}\n$u"
+                    }
+                }
+            }
             val remove = TextView(this).apply {
                 text = "Remove"; setTextColor(ink); textSize = fs(11f); typeface = mono
                 letterSpacing = 0.1f; setPadding(dim(12), dim(6), dim(2), dim(6)); isClickable = true
@@ -528,6 +574,7 @@ class DailyActivity : Activity() {
             row.addView(info, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
                 .apply { marginStart = dim(8) })
             row.addView(limitStepper(limits, i))
+            row.addView(edit)
             row.addView(remove)
             list.addView(row)
             if (i < sources.size - 1) list.addView(blackRule(Ink.hair()))
@@ -537,11 +584,12 @@ class DailyActivity : Activity() {
             addView(list)
         }
         AlertDialog.Builder(this, R.style.InkDialog)
-            .setTitle("Sources — uncheck to mute, ± sets articles per issue")
+            .setTitle("Sources — uncheck to mute, ± sets articles per issue, Edit changes the URL")
             .setView(scroll)
             .setPositiveButton("Save") { _, _ ->
                 val updated = sources.mapIndexedNotNull { i, s ->
-                    if (removed[i]) null else s.copy(enabled = enabled[i], limit = limits[i])
+                    if (removed[i]) null
+                    else DailyController.withUrl(s, urls[i]).copy(enabled = enabled[i], limit = limits[i])
                 }
                 daily.setSources(updated)
                 setContentView(buildView())

--- a/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/DailyController.kt
@@ -69,8 +69,7 @@ class DailyController(private val context: Context) {
     fun addSource(url: String) {
         val u = url.trim()
         if (u.isEmpty()) return
-        val name = runCatching { URL(u).host.removePrefix("www.") }.getOrDefault(u).ifBlank { u }
-        val updated = sources().filterNot { it.url == u } + Source(name, u)
+        val updated = sources().filterNot { it.url == u } + Source(bylineFor(u), u)
         save(updated)
     }
 
@@ -82,6 +81,7 @@ class DailyController(private val context: Context) {
 
     /** Persist an edited source list wholesale (enable/disable + removals from the Sources editor). */
     fun setSources(list: List<Source>) = save(list)
+
 
     /** The sources a compile actually fetches (muted ones excluded). */
     fun enabledSources(): List<Source> = sources().filter { it.enabled }
@@ -365,6 +365,32 @@ class DailyController(private val context: Context) {
         const val TAG = "DailyController"
 
         /** Curated popular feeds for the suggested-sources picker (stable, well-known RSS/Atom). */
+        /**
+         * Point [source] at [newUrl], keeping everything else about it (#166).
+         *
+         * The byline follows the URL only when it was derived from one. A source added by pasting a URL
+         * is bylined with its host, so moving it to another host should move the byline too; a curated
+         * source is bylined "BBC News", and re-deriving would rename it to `feeds.bbci.co.uk` for the
+         * sake of a URL correction. Comparing the stored name against what [bylineFor] would have
+         * produced for the *old* URL is what tells the two apart.
+         *
+         * A blank [newUrl] leaves the source alone: an emptied field is a slip, not an instruction.
+         */
+        fun withUrl(source: Source, newUrl: String): Source {
+            val u = newUrl.trim()
+            if (u.isEmpty() || u == source.url) return source
+            val wasDerived = source.name == bylineFor(source.url)
+            return source.copy(name = if (wasDerived) bylineFor(u) else source.name, url = u)
+        }
+
+        /**
+         * The byline shown for a feed added by URL: its host, minus `www.`. Falls back to the whole
+         * string when it does not parse as a URL, so a mistyped entry still shows the reader something
+         * they recognise rather than a blank row.
+         */
+        fun bylineFor(url: String): String =
+            runCatching { URL(url).host.removePrefix("www.") }.getOrDefault(url).ifBlank { url }
+
         val SUGGESTED = listOf(
             Source("Hacker News", "https://hnrss.org/frontpage"),
             Source("Lobsters", "https://lobste.rs/rss"),

--- a/app/src/test/java/dev/jraghavan/inkread/DailyFeedUrlTest.kt
+++ b/app/src/test/java/dev/jraghavan/inkread/DailyFeedUrlTest.kt
@@ -1,0 +1,67 @@
+package dev.jraghavan.inkread
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Host JVM tests for re-pointing a followed feed at a new URL (#166).
+ *
+ * The interesting part is the byline. A feed added by pasting a URL is bylined with its host, so it
+ * should follow the URL; a curated feed is bylined "BBC News", and re-deriving would rename it to
+ * `feeds.bbci.co.uk` for the sake of a URL correction.
+ */
+class DailyFeedUrlTest {
+
+    private fun added(url: String) = DailyController.Source(DailyController.bylineFor(url), url)
+
+    @Test
+    fun bylineIsTheHostWithoutWww() {
+        assertEquals("example.com", DailyController.bylineFor("https://www.example.com/feed.xml"))
+        assertEquals("hnrss.org", DailyController.bylineFor("https://hnrss.org/frontpage"))
+    }
+
+    /** A mistyped entry still shows something recognisable rather than an empty row. */
+    @Test
+    fun anUnparseableUrlFallsBackToItself() {
+        assertEquals("not a url", DailyController.bylineFor("not a url"))
+    }
+
+    @Test
+    fun editingTheUrlMovesTheBylineWhenItCameFromOne() {
+        val s = added("https://example.com/feed.xml")
+        val moved = DailyController.withUrl(s, "https://other.org/rss")
+        assertEquals("https://other.org/rss", moved.url)
+        assertEquals("other.org", moved.name)
+    }
+
+    /** The case that stops a URL fix from renaming a curated feed to its host. */
+    @Test
+    fun aCuratedBylineSurvivesAUrlEdit() {
+        val bbc = DailyController.Source("BBC News", "https://feeds.bbci.co.uk/news/rss.xml")
+        val moved = DailyController.withUrl(bbc, "https://feeds.bbci.co.uk/news/world/rss.xml")
+        assertEquals("https://feeds.bbci.co.uk/news/world/rss.xml", moved.url)
+        assertEquals("BBC News", moved.name)
+    }
+
+    /** An emptied field is a slip, not an instruction to blank the feed. */
+    @Test
+    fun aBlankUrlLeavesTheSourceAlone() {
+        val s = added("https://example.com/feed.xml")
+        assertEquals(s, DailyController.withUrl(s, "   "))
+    }
+
+    /** Everything else about a source survives being re-pointed. */
+    @Test
+    fun mutingAndTheArticleLimitSurviveAUrlEdit() {
+        val s = DailyController.Source("example.com", "https://example.com/feed.xml", enabled = false, limit = 12)
+        val moved = DailyController.withUrl(s, "https://example.com/atom.xml")
+        assertEquals(false, moved.enabled)
+        assertEquals(12, moved.limit)
+    }
+
+    @Test
+    fun anUnchangedUrlIsANoOp() {
+        val s = added("https://example.com/feed.xml")
+        assertEquals(s, DailyController.withUrl(s, "https://example.com/feed.xml"))
+    }
+}


### PR DESCRIPTION
Closes #166.

A followed feed could be added and removed but never corrected. A typo, or a publisher moving their
feed, meant dropping the row and re-adding it from scratch, losing its mute state and its per-source
article limit on the way.

## The change

The Sources editor gains a per-row **Edit** that prompts for a replacement URL, pre-filled with the
current one.

Edits stage into an array alongside the existing mutes and limits and commit with the same **Save**,
rather than writing immediately. A per-row action that saved on its own would write behind the
reader's back while their other pending edits sat unsaved in the same dialog.

## The byline follows the URL only when it came from one

A feed added by pasting a URL is bylined with its host, so moving it to another host should move the
byline too. A curated feed is bylined `BBC News`, and re-deriving would rename it to
`feeds.bbci.co.uk` for the sake of a URL correction.

Comparing the stored name against what `bylineFor` would have produced for the **old** URL is what
tells those two cases apart.

## Two rejections at the prompt

A blank field is a slip rather than an instruction to blank the feed, so it leaves the source alone.
A URL another row already follows is refused with a toast, since accepting it would leave two entries
fetching the same feed.

## Tests

`bylineFor` and `withUrl` are pure, so they moved to the companion where the host JVM can reach them
without a `Context`. `addSource` now calls `bylineFor` instead of carrying its own inline copy of the
same derivation.

`DailyFeedUrlTest`, seven cases: host derivation, an unparseable URL falling back to itself, a
derived byline following an edit, a curated byline surviving one, a blank and an unchanged URL both
being no-ops, and mute plus article limit surviving a re-point.

`cargo fmt --check`, `cargo clippy --all -D warnings`, `cargo test --workspace`, the
`aarch64-linux-android` JNI cross-check and `:app:testReleaseUnitTest` all pass.

## Worth a look on device

Daily → Sources → Edit on a curated feed such as BBC News: change the path, save, and the byline
should still read "BBC News". Then Edit a feed you added by URL and point it at another host: that
byline should change. Confirm a row's article limit and mute survive both.
