### PR TITLE
feat(epub): honour CSS font-style, so a stylesheet italic renders italic

### DIFF
--- a/inkread-epub/src/css.rs
+++ b/inkread-epub/src/css.rs
@@ -33,13 +33,21 @@ pub struct BlockStyle {
     /// `font-weight`: `Some(true)` for bold-ish (`bold`/`bolder`/`600`+), `Some(false)` for
     /// normal-ish (`normal`/`lighter`/`500`-).
     pub bold: Option<bool>,
+    /// `font-style`: `Some(true)` for `italic`/`oblique`, `Some(false)` for `normal` (#170).
+    ///
+    /// Italic already rendered from `<i>`, `<em>` and `<cite>`; what was missing was the CSS. A book
+    /// that italicises through its stylesheet rather than a tag rendered upright.
+    pub italic: Option<bool>,
 }
 
 impl BlockStyle {
-    /// True when the book declared none of the three properties.
+    /// True when the book declared none of the properties.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.align.is_none() && self.indent.is_none() && self.bold.is_none()
+        self.align.is_none()
+            && self.indent.is_none()
+            && self.bold.is_none()
+            && self.italic.is_none()
     }
 
     /// Return `self` with every property `higher` declares overridden — the inheritance step, used
@@ -54,6 +62,9 @@ impl BlockStyle {
         }
         if higher.bold.is_some() {
             self.bold = higher.bold;
+        }
+        if higher.italic.is_some() {
+            self.italic = higher.italic;
         }
         self
     }
@@ -77,6 +88,11 @@ impl BlockStyle {
             "font-weight" => {
                 if let Some(b) = parse_font_weight(&value) {
                     self.bold = Some(b);
+                }
+            }
+            "font-style" => {
+                if let Some(i) = parse_font_style(&value) {
+                    self.italic = Some(i);
                 }
             }
             _ => {}
@@ -240,6 +256,20 @@ fn is_zero_length(value: &str) -> bool {
         .take_while(|c| c.is_ascii_digit() || *c == '.' || *c == '-' || *c == '+')
         .collect();
     num.parse::<f32>().is_ok_and(|n| n == 0.0)
+}
+
+/// `font-style` → italic or upright (#170).
+///
+/// `oblique` counts as italic: it is a slant request, and the renderer already falls back to
+/// shearing a regular face for a family that bundles no italic, which is exactly what oblique asks
+/// for. An unrecognised value declares nothing rather than guessing upright, so a reader's own
+/// setting is not overridden by a keyword we failed to understand.
+fn parse_font_style(value: &str) -> Option<bool> {
+    match value {
+        "normal" => Some(false),
+        "italic" | "oblique" => Some(true),
+        _ => None,
+    }
 }
 
 /// `font-weight` → bold-ish or normal-ish. Numeric weights split at 600, as CSS does.

--- a/inkread-epub/src/css_tests.rs
+++ b/inkread-epub/src/css_tests.rs
@@ -240,6 +240,63 @@ fn font_weight_splits_at_600_like_css() {
     );
 }
 
+/// #170. Italic already came from `<i>`, `<em>` and `<cite>`; a book that italicises through its
+/// stylesheet instead rendered upright, which is the gap this closes.
+#[test]
+fn font_style_declares_italic_upright_or_nothing() {
+    for italic in ["italic", "oblique"] {
+        let css = format!("p {{ font-style: {italic} }}");
+        assert_eq!(
+            styled(&css, "<body><p data-t>x</p></body>").italic,
+            Some(true),
+            "{italic}"
+        );
+    }
+    assert_eq!(
+        styled("p { font-style: normal }", "<body><p data-t>x</p></body>").italic,
+        Some(false),
+        "font-style: normal was dropped"
+    );
+    assert_eq!(
+        styled("p { font-style: wat }", "<body><p data-t>x</p></body>").italic,
+        None,
+        "an unparseable style declares nothing rather than forcing upright"
+    );
+    assert_eq!(
+        styled("p { text-align: left }", "<body><p data-t>x</p></body>").italic,
+        None,
+        "a book that says nothing about style declares nothing"
+    );
+}
+
+/// A container's declared style folds into the block nested inside it through `overlaid_with`, and
+/// style has to travel that step the same way weight does — otherwise an italicised `<div>` would
+/// leave its paragraphs upright.
+#[test]
+fn font_style_travels_the_container_overlay() {
+    let container = BlockStyle {
+        italic: Some(true),
+        ..BlockStyle::default()
+    };
+    assert_eq!(
+        BlockStyle::default().overlaid_with(&container).italic,
+        Some(true)
+    );
+
+    // A block that declares its own style keeps it: the overlay is the container's, applied first.
+    let upright = BlockStyle {
+        italic: Some(false),
+        ..BlockStyle::default()
+    };
+    assert_eq!(
+        upright.overlaid_with(&BlockStyle::default()).italic,
+        Some(false)
+    );
+
+    // And a style-only declaration is not "empty", or the whole block would be discarded.
+    assert!(!container.is_empty());
+}
+
 #[test]
 fn important_is_stripped_and_alignment_keywords_map() {
     assert_eq!(

--- a/inkread-epub/src/layout.rs
+++ b/inkread-epub/src/layout.rs
@@ -482,6 +482,7 @@ pub fn paginate_upto(
                     0.0,
                     0.0,
                     bold,
+                    style.italic.unwrap_or(false),
                     effective_align(style, opts.align),
                     block_index,
                     &mut cursor,
@@ -512,6 +513,7 @@ pub fn paginate_upto(
                     first_indent,
                     0.0,
                     style.bold.unwrap_or(false),
+                    style.italic.unwrap_or(false),
                     align,
                     block_index,
                     &mut cursor,
@@ -537,6 +539,7 @@ pub fn paginate_upto(
                     content,
                     opts.font_px,
                     style.bold.unwrap_or(false),
+                    style.italic.unwrap_or(false),
                     block_index,
                     &mut cursor,
                     m,
@@ -576,6 +579,7 @@ pub fn paginate_upto(
                     0.0,
                     0.0,
                     false,
+                    false,
                     opts.align,
                     block_index,
                     &mut cursor,
@@ -589,6 +593,7 @@ pub fn paginate_upto(
                     cells,
                     opts.font_px,
                     style.bold.unwrap_or(false),
+                    style.italic.unwrap_or(false),
                     effective_align(style, opts.align),
                     block_index,
                     &mut cursor,
@@ -733,6 +738,7 @@ impl<'o> Pager<'o> {
         first_indent: f32,
         rest_indent: f32,
         bold_all: bool,
+        italic_all: bool,
         align: Align,
         block: usize,
         cursor: &mut usize,
@@ -745,6 +751,7 @@ impl<'o> Pager<'o> {
             rest_indent,
             self.opts.content_w(),
             bold_all,
+            italic_all,
             block,
             cursor,
             m,
@@ -777,6 +784,7 @@ impl<'o> Pager<'o> {
         cells: &[Vec<Inline>],
         size: f32,
         bold_all: bool,
+        italic_all: bool,
         align: Align,
         block: usize,
         cursor: &mut usize,
@@ -794,14 +802,16 @@ impl<'o> Pager<'o> {
         let cell_w = ((measure - gutter * (n - 1.0)) / n).max(1.0);
         if cell_w < MIN_CELL_EM * size {
             for cell in cells {
-                self.add_paragraph(cell, size, 0.0, 0.0, bold_all, align, block, cursor, m);
+                self.add_paragraph(
+                    cell, size, 0.0, 0.0, bold_all, italic_all, align, block, cursor, m,
+                );
             }
             return;
         }
         let mut columns: Vec<Vec<Vec<PlacedRun>>> = Vec::with_capacity(cells.len());
         for (index, cell) in cells.iter().enumerate() {
             let mut lines = break_lines(
-                cell, size, 0.0, 0.0, cell_w, bold_all, block, cursor, m, self.hyph,
+                cell, size, 0.0, 0.0, cell_w, bold_all, italic_all, block, cursor, m, self.hyph,
             );
             let last = lines.len();
             let dx = index as f32 * (cell_w + gutter);
@@ -833,6 +843,7 @@ impl<'o> Pager<'o> {
         inlines: &[Inline],
         size: f32,
         bold: bool,
+        italic: bool,
         block: usize,
         cursor: &mut usize,
         m: &dyn Metrics,
@@ -854,6 +865,7 @@ impl<'o> Pager<'o> {
             indent,
             self.opts.content_w(),
             bold,
+            italic,
             block,
             cursor,
             m,
@@ -939,6 +951,7 @@ enum Tok<'a> {
 fn tokenize<'a>(
     inlines: &'a [Inline],
     bold_all: bool,
+    italic_all: bool,
     block: usize,
     cursor: &mut usize,
 ) -> Vec<Tok<'a>> {
@@ -973,7 +986,7 @@ fn tokenize<'a>(
                         toks.push(Tok::Word {
                             text: part,
                             bold: r.bold || bold_all,
-                            italic: r.italic,
+                            italic: r.italic || italic_all,
                             href: r.href.as_deref(),
                             anchor: SourceAnchor {
                                 block,
@@ -1040,6 +1053,7 @@ fn break_lines(
     rest_indent: f32,
     content_w: f32,
     bold_all: bool,
+    italic_all: bool,
     block: usize,
     cursor: &mut usize,
     m: &dyn Metrics,
@@ -1051,7 +1065,7 @@ fn break_lines(
     let mut x = 0.0f32; // offset within the body column (excludes indent)
     let mut need_space = false;
 
-    for tok in tokenize(inlines, bold_all, block, cursor) {
+    for tok in tokenize(inlines, bold_all, italic_all, block, cursor) {
         match tok {
             Tok::Break => {
                 if !cur.is_empty() {

--- a/inkread-epub/src/layout_tests.rs
+++ b/inkread-epub/src/layout_tests.rs
@@ -302,6 +302,53 @@ fn a_declared_normal_font_weight_unbolds_a_heading() {
     assert!(p[0].lines[0].runs[0].bold);
 }
 
+/// #170: a declared `font-style` has to reach the placed run, or the renderer never learns to set
+/// it in an italic face. Italic already arrived from `<i>`/`<em>`/`<cite>`; a stylesheet saying so
+/// was parsed and then dropped on the floor between `BlockStyle` and the run.
+#[test]
+fn a_declared_font_style_reaches_the_placed_runs() {
+    let opts = style_opts();
+
+    let plain = paginate(&[styled_para("x", BlockStyle::default())], &opts, &Mono);
+    assert!(!plain[0].lines[0].runs[0].italic, "prose defaults upright");
+
+    let style = BlockStyle {
+        italic: Some(true),
+        ..Default::default()
+    };
+    let italic = paginate(&[styled_para("x", style)], &opts, &Mono);
+    assert!(
+        italic[0].lines[0].runs[0].italic,
+        "font-style: italic was ignored"
+    );
+
+    // It applies to a heading too, which carries its own default weight but no default slant.
+    let head = paginate(&[styled_heading("Title", style)], &opts, &Mono);
+    assert!(head[0].lines[0].runs[0].italic);
+    assert!(
+        head[0].lines[0].runs[0].bold,
+        "and does not disturb the weight"
+    );
+}
+
+/// A block-level italic covers every run in the block, including ones the markup did not italicise,
+/// exactly as a block-level weight covers every run.
+#[test]
+fn a_block_italic_covers_runs_the_markup_left_upright() {
+    let opts = style_opts();
+    let style = BlockStyle {
+        italic: Some(true),
+        ..Default::default()
+    };
+    let laid = paginate(&[styled_para("one two three", style)], &opts, &Mono);
+    let runs = &laid[0].lines[0].runs;
+    assert!(!runs.is_empty());
+    assert!(
+        runs.iter().all(|r| r.italic),
+        "a run escaped the block style"
+    );
+}
+
 #[test]
 fn long_paragraph_wraps_to_multiple_lines() {
     // 10px font → 5px/char. content_w = 100 → 20 chars/line. 60-char paragraph → 3 lines.

--- a/reader-core/src/document/reflow.rs
+++ b/reader-core/src/document/reflow.rs
@@ -1031,8 +1031,16 @@ pub(crate) fn reset_layout_passes() {
 ///   `v4` index describes boundaries this engine no longer produces — and because a stored index is
 ///   trusted verbatim, that mismatch surfaces as a page the index counts and the layout lacks
 ///   (#215) rather than as anything obviously font-related.
+/// - `v5` → `v6`: CSS `font-style: italic` is honoured (#170). A book that italicises through its
+///   stylesheet rather than an `<i>` tag now sets those runs in an italic face, which measures
+///   differently and moves the line breaks a `v5` index recorded.
+///
+/// Note the tripwire in the tests pins *measurement* — what `advance()` returns for a given style —
+/// so it does not fire for a change like `v6`, which alters **which style a run gets** rather than
+/// how a style measures. Both invalidate a stored index. A change to run styling has to bump this
+/// by hand.
 fn layout_key(opts: &LayoutOpts, font_id: usize, chapters: usize) -> String {
-    format!("v5|{:016x}|{font_id}|{chapters}", opts.layout_digest())
+    format!("v6|{:016x}|{font_id}|{chapters}", opts.layout_digest())
 }
 
 /// A materialized chapter: the pages laid out so far, and whether that is all of them (#186).

--- a/reader-core/src/document/reflow_tests.rs
+++ b/reader-core/src/document/reflow_tests.rs
@@ -1099,7 +1099,7 @@ fn a_books_declared_styles_reach_the_laid_out_page() {
 
 /// The pagination cache key must move whenever anything changes how much content fits on a page,
 /// or a cache written by an older build is replayed against a layout it does not describe and the
-/// reader lands on stale page boundaries. #163 bumped it to v2, #188 to v3, #187 to v4, #239 to v5.
+/// reader lands on stale page boundaries. #163 bumped it to v2, #188 to v3, #187 to v4, #239 to v5, #170 to v6.
 ///
 /// This test used to assert only the key's prefix, which made it a tautology dressed as a tripwire:
 /// it could not fail for the thing it was written to catch. #239 taught `advance()` to pay for a
@@ -1119,7 +1119,7 @@ fn a_books_declared_styles_reach_the_laid_out_page() {
 fn the_pagination_cache_version_tracks_changes_to_line_fitting() {
     let opts = LayoutOpts::new(600.0, 800.0, 16.0);
     assert!(
-        layout_key(&opts, 0, 1).starts_with("v5|"),
+        layout_key(&opts, 0, 1).starts_with("v6|"),
         "{}",
         layout_key(&opts, 0, 1)
     );


### PR DESCRIPTION
Closes #170.

The weight half of this landed with the CSS work in #188/#201, and the real bold and italic faces
landed in #239. What was left, and what your comment on the issue scoped precisely, is `font-style`:
italic came from `<i>`, `<em>` and `<cite>`, but a book that italicises through its stylesheet
rendered upright.

## The change

`font-style` is parsed beside `parse_font_weight`, carried on `BlockStyle` as an `Option` the way
`bold` is, and threaded to the runs along the same path `bold_all` already took (`add_paragraph` →
`break_lines` → `tokenize`, where a run becomes italic if the markup said so **or** the block did).
The layout's `italic` flag on every run was already there waiting for it.

`oblique` counts as italic. It is a slant request, and the renderer already shears a regular face for
a family that bundles no italic, which is exactly what oblique asks for.

An unrecognised value declares nothing rather than forcing upright, so a keyword we failed to
understand cannot override the reader's own setting. That mirrors `font-weight`.

## Cache key to v6

A book that italicises via CSS now sets those runs in an italic face, which measures differently and
moves the line breaks a `v5` index recorded.

**Worth knowing for the next bump:** the tripwire pins what `advance()` returns for a given style, so
it does **not** fire for a change like this one, which alters *which style a run gets* rather than
*how a style measures*. Both invalidate a stored index. A change to run styling has to bump the key
by hand. I have written that into the version list in `layout_key` so it is not rediscovered the hard
way, the way #239 was.

I deliberately did not try to extend the tripwire to catch this. The obvious way is pinning a
fixture's pagination, and I already established in #240 that page counts are too slack to be a
reliable probe.

## Tests

Five new cases.

`css`: `italic` and `oblique` both declare italic; `normal` declares upright; an unparseable value and
a silent stylesheet both declare nothing; and style travels the container overlay, so an italicised
`<div>` carries into its paragraphs.

`layout`: a declared style reaches the placed runs without disturbing a heading's default weight, and
a block italic covers runs the markup left upright.

`cargo fmt --check`, `cargo clippy --all -D warnings`, `cargo test --workspace`, the
`aarch64-linux-android` JNI cross-check, `:app:testReleaseUnitTest` and the licence manifest check all
pass.

## Note on my own first test

My first inheritance test asserted `div { font-style: italic }` reaches a nested `<p>` through
`styled()`. It failed, and the code was right: `styled()` resolves selectors against the target node
only, and container inheritance happens in `overlaid_with`, a different layer. The test now exercises
that mechanism directly.

## On device

An EPUB whose stylesheet italicises a block (a dedication or epigraph is the usual case) should now
render in italic letterforms. Books already read will re-paginate once on first open, from the v6
bump.
