### PR TITLE
feat(ui): let Menu Size scale the bottom bar and its panels, not just their text

### DIFF
--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -92,8 +92,6 @@ class AdjustSheetController(private val host: Host) {
      */
     fun show() {
         if (host.docHandle == 0L) { host.openPicker(); return }
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         val dialog = Dialog(activity).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
         val content = android.widget.FrameLayout(activity)
 
@@ -132,15 +130,15 @@ class AdjustSheetController(private val host: Host) {
         panels.forEachIndexed { i, (label, icon, _) ->
             val cell = LinearLayout(activity).apply {
                 orientation = LinearLayout.VERTICAL; gravity = Gravity.CENTER
-                setPadding(dp(4), dp(10), dp(4), dp(10)); isClickable = true
+                setPadding(Ink.sdp(4), Ink.sdp(10), Ink.sdp(4), Ink.sdp(10)); isClickable = true
                 setOnClickListener { select(i) }
                 addView(
                     ImageView(activity).apply { setImageResource(icon); setColorFilter(Ink.ink) },
-                    LinearLayout.LayoutParams(dp(24), dp(24)),
+                    LinearLayout.LayoutParams(Ink.sdp(24), Ink.sdp(24)),
                 )
                 addView(TextView(activity).apply {
                     text = label; textSize = Ink.sp(10f); setTextColor(Ink.inkSoft); typeface = Ink.mono
-                    gravity = Gravity.CENTER; setPadding(0, dp(3), 0, 0)
+                    gravity = Gravity.CENTER; setPadding(0, Ink.sdp(3), 0, 0)
                 })
             }
             cells.add(cell)
@@ -179,9 +177,7 @@ class AdjustSheetController(private val host: Host) {
     /** A KOReader-style **segmented control**: a rounded pill of [options] with the [selected]
      *  segment filled dark. Updates its own highlight on tap, then calls [onSelect]. */
     private fun segmented(options: List<String>, selected: Int, onSelect: (Int) -> Unit): View {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
-        val radius = dp(20).toFloat()
+        val radius = Ink.sdp(20).toFloat()
         var sel = selected
         val segs = ArrayList<TextView>()
         fun style(tv: TextView, on: Boolean) {
@@ -201,11 +197,11 @@ class AdjustSheetController(private val host: Host) {
                 setColor(Ink.paper); cornerRadius = radius
                 setStroke(Ink.hair(), Ink.ringSoft)
             }
-            val p = dp(3); setPadding(p, p, p, p)
+            val p = Ink.sdp(3); setPadding(p, p, p, p)
             options.forEachIndexed { i, opt ->
                 val tv = TextView(activity).apply {
                     text = opt; textSize = Ink.sp(15f); gravity = Gravity.CENTER
-                    setPadding(dp(6), dp(10), dp(6), dp(10)); isClickable = true
+                    setPadding(Ink.sdp(6), Ink.sdp(10), Ink.sdp(6), Ink.sdp(10)); isClickable = true
                     setOnClickListener { sel = i; segs.forEachIndexed { j, t -> style(t, j == sel) }; onSelect(i) }
                 }
                 style(tv, i == sel)
@@ -218,8 +214,6 @@ class AdjustSheetController(private val host: Host) {
     /** A KOReader-style **cell bar**: [count] boxes filled up to the current level; tapping box i
      *  sets level i+1 (tapping the current top cell turns it off → 0). Repaints on tap. */
     private fun cellBar(count: Int, initial: Int, onSet: (Int) -> Unit): View {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         var filled = initial
         val draws = ArrayList<GradientDrawable>()
         fun repaint() = draws.forEachIndexed { i, g ->
@@ -237,7 +231,7 @@ class AdjustSheetController(private val host: Host) {
                         repaint(); invalidate()
                         onSet(filled)
                     }
-                }, LinearLayout.LayoutParams(0, dp(30), 1f).apply { val m = dp(2); setMargins(m, 0, m, 0) })
+                }, LinearLayout.LayoutParams(0, Ink.sdp(30), 1f).apply { val m = Ink.sdp(2); setMargins(m, 0, m, 0) })
             }
             repaint()
         }
@@ -256,8 +250,6 @@ class AdjustSheetController(private val host: Host) {
 
     /** "Add…" / "Remove…" for the reader's imported faces (RR28-FR3). */
     private fun fontLibraryControls(): View {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         return LinearLayout(activity).apply {
             orientation = LinearLayout.HORIZONTAL
             addView(pill("Add…") { host.openFontPicker() })
@@ -266,7 +258,7 @@ class AdjustSheetController(private val host: Host) {
                     pill("Remove…") { showRemoveFontDialog() },
                     LinearLayout.LayoutParams(
                         ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ).apply { leftMargin = dp(8) },
+                    ).apply { leftMargin = Ink.sdp(8) },
                 )
             }
         }
@@ -301,16 +293,14 @@ class AdjustSheetController(private val host: Host) {
     }
 
     private fun settingRow(label: String, control: View): View {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         return LinearLayout(activity).apply {
             orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
-            setPadding(dp(16), dp(14), dp(16), dp(14))
+            setPadding(Ink.sdp(16), Ink.sdp(14), Ink.sdp(16), Ink.sdp(14))
             addView(TextView(activity).apply {
                 text = label; textSize = Ink.sp(16f); setTextColor(Color.BLACK); gravity = Gravity.END
-            }, LinearLayout.LayoutParams(dp(96), ViewGroup.LayoutParams.WRAP_CONTENT))
+            }, LinearLayout.LayoutParams(Ink.sdp(96), ViewGroup.LayoutParams.WRAP_CONTENT))
             addView(control, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
-                marginStart = dp(14)
+                marginStart = Ink.sdp(14)
             })
         }
     }
@@ -428,13 +418,11 @@ class AdjustSheetController(private val host: Host) {
 
     /** A white rounded stepper pill (shared by the Zoom and Font tabs). */
     private fun pill(t: String, on: () -> Unit): TextView {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         return TextView(activity).apply {
             text = t; textSize = Ink.sp(16f); gravity = Gravity.CENTER; setTextColor(Color.BLACK)
-            setPadding(dp(18), dp(10), dp(18), dp(10)); isClickable = true
+            setPadding(Ink.sdp(18), Ink.sdp(10), Ink.sdp(18), Ink.sdp(10)); isClickable = true
             background = GradientDrawable().apply {
-                setColor(Color.WHITE); cornerRadius = dp(20).toFloat(); setStroke(maxOf(1, dp(1)), Color.parseColor("#9E9E9E"))
+                setColor(Color.WHITE); cornerRadius = Ink.sdp(20).toFloat(); setStroke(Ink.hair(), Color.parseColor("#9E9E9E"))
             }
             setOnClickListener { on() }
         }
@@ -442,10 +430,8 @@ class AdjustSheetController(private val host: Host) {
 
     /** The "Zoom" tab: the Fit segmented row + a live zoom −/+ stepper (zoom moved off the bar). */
     private fun zoomPanel(): View {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         val zlabel = TextView(activity).apply {
-            textSize = Ink.sp(16f); setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
+            textSize = Ink.sp(16f); setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = Ink.sdp(64)
         }
         fun refresh() { zlabel.text = "${host.zoomPercent}%" }
         refresh()
@@ -453,7 +439,7 @@ class AdjustSheetController(private val host: Host) {
             orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
             addView(pill("−") { host.zoomOut(); refresh() })
             addView(zlabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
-                val m = dp(10); setMargins(m, 0, m, 0)
+                val m = Ink.sdp(10); setMargins(m, 0, m, 0)
             })
             addView(pill("+") { host.zoomIn(); refresh() })
         }
@@ -558,11 +544,9 @@ class AdjustSheetController(private val host: Host) {
     }
 
     private fun fontPanel(): View {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         var idx = DisplayPrefs.nearestScaleIndex(prefs.textScale)
         val value = TextView(activity).apply {
-            textSize = Ink.sp(16f); setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = dp(64)
+            textSize = Ink.sp(16f); setTextColor(Color.BLACK); gravity = Gravity.CENTER; minWidth = Ink.sdp(64)
         }
         fun refresh() { value.text = "${(DisplayPrefs.TEXT_SCALES[idx] * 100).toInt()}%" }
         refresh()
@@ -571,13 +555,13 @@ class AdjustSheetController(private val host: Host) {
             orientation = LinearLayout.HORIZONTAL; gravity = Gravity.CENTER_VERTICAL
             addView(pill("A−") { if (idx > 0) { idx--; apply() } })
             addView(value, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
-                val m = dp(10); setMargins(m, 0, m, 0)
+                val m = Ink.sdp(10); setMargins(m, 0, m, 0)
             })
             addView(pill("A+") { if (idx < DisplayPrefs.TEXT_SCALES.size - 1) { idx++; apply() } })
             // Quick presets next to the steppers: jump straight to default / largest (#55).
             fun preset(p: View) = addView(p, LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
-            ).apply { leftMargin = dp(8) })
+            ).apply { leftMargin = Ink.sdp(8) })
             preset(pill("100%") { idx = DisplayPrefs.nearestScaleIndex(1.0f); apply() })
             preset(pill("XL") { idx = DisplayPrefs.TEXT_SCALES.size - 1; apply() })
         }

--- a/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/AdjustSheetController.kt
@@ -131,6 +131,7 @@ class AdjustSheetController(private val host: Host) {
             val cell = LinearLayout(activity).apply {
                 orientation = LinearLayout.VERTICAL; gravity = Gravity.CENTER
                 setPadding(Ink.sdp(4), Ink.sdp(10), Ink.sdp(4), Ink.sdp(10)); isClickable = true
+                minimumHeight = Ink.tap() // #245: 47.5dp at XS
                 setOnClickListener { select(i) }
                 addView(
                     ImageView(activity).apply { setImageResource(icon); setColorFilter(Ink.ink) },
@@ -202,6 +203,7 @@ class AdjustSheetController(private val host: Host) {
                 val tv = TextView(activity).apply {
                     text = opt; textSize = Ink.sp(15f); gravity = Gravity.CENTER
                     setPadding(Ink.sdp(6), Ink.sdp(10), Ink.sdp(6), Ink.sdp(10)); isClickable = true
+                    minHeight = Ink.tap() // #245: 31.5dp at XS, incl. the Menu Size selector itself
                     setOnClickListener { sel = i; segs.forEachIndexed { j, t -> style(t, j == sel) }; onSelect(i) }
                 }
                 style(tv, i == sel)
@@ -231,6 +233,10 @@ class AdjustSheetController(private val host: Host) {
                         repaint(); invalidate()
                         onSet(filled)
                     }
+                    // Deliberately NOT floored to Ink.tap() (#245). This is a level indicator drawn
+                    // as a row of segments, not a row of buttons: each cell is ~111dp wide, so it is
+                    // a forgiving target despite its height, and forcing 48dp would turn a thin bar
+                    // into a chunky one at every menu size including the default.
                 }, LinearLayout.LayoutParams(0, Ink.sdp(30), 1f).apply { val m = Ink.sdp(2); setMargins(m, 0, m, 0) })
             }
             repaint()
@@ -421,6 +427,7 @@ class AdjustSheetController(private val host: Host) {
         return TextView(activity).apply {
             text = t; textSize = Ink.sp(16f); gravity = Gravity.CENTER; setTextColor(Color.BLACK)
             setPadding(Ink.sdp(18), Ink.sdp(10), Ink.sdp(18), Ink.sdp(10)); isClickable = true
+            minHeight = Ink.tap() // #245
             background = GradientDrawable().apply {
                 setColor(Color.WHITE); cornerRadius = Ink.sdp(20).toFloat(); setStroke(Ink.hair(), Color.parseColor("#9E9E9E"))
             }

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -129,6 +129,7 @@ class BottomBarController(private val host: Host) {
             typeface = Ink.mono
             letterSpacing = 0.04f
             gravity = Gravity.CENTER
+            minHeight = Ink.tap() // #245: 21.9dp at XS before this
             setPadding(Ink.sdp(12), Ink.sdp(6), Ink.sdp(12), Ink.sdp(6))
             background = GradientDrawable().apply {
                 setColor(Ink.fill)
@@ -166,6 +167,7 @@ class BottomBarController(private val host: Host) {
         fun chapterBtn(glyph: String, dir: Int) = TextView(activity).apply {
             text = glyph; setTextColor(Ink.ink); textSize = Ink.sp(20f); typeface = Ink.serifBold
             gravity = Gravity.CENTER; setPadding(Ink.sdp(8), Ink.sdp(2), Ink.sdp(8), Ink.sdp(2)); isClickable = true
+            minHeight = Ink.tap(); minWidth = Ink.tap() // #245: 24.0dp at XS, 44.8dp even at 2XL
             setOnClickListener { dialog.dismiss(); chapterJump(dir) }
         }
         fileNameLine()?.let(container::addView)
@@ -189,6 +191,7 @@ class BottomBarController(private val host: Host) {
                 gravity = Gravity.CENTER_VERTICAL
                 setPadding(Ink.sdp(24), 0, Ink.sdp(24), Ink.sdp(8))
                 isClickable = true
+                minimumHeight = Ink.tapRow() // #245: 19.7dp at XS before this
                 setOnClickListener { dialog.dismiss(); showContentsLazy() }
                 addView(TextView(activity).apply {
                     text = lbl; setTextColor(Ink.inkSoft); textSize = Ink.sp(12f); typeface = Ink.serif
@@ -443,6 +446,7 @@ class BottomBarController(private val host: Host) {
                 gravity = Gravity.CENTER_VERTICAL
                 setPadding(Ink.sdp(4), Ink.sdp(14), Ink.sdp(4), Ink.sdp(14))
                 isClickable = true
+                minimumHeight = Ink.tapRow() // #245: list rows must stay tappable at any menu size
                 setOnClickListener { dialog.dismiss(); host.postJump(page) }
                 addView(TextView(activity).apply {
                     text = "Page ${page + 1}"
@@ -486,6 +490,7 @@ class BottomBarController(private val host: Host) {
                 gravity = Gravity.CENTER_VERTICAL
                 setPadding(Ink.sdp(4) + item.depth * Ink.sdp(18), Ink.sdp(14), Ink.sdp(4), Ink.sdp(14))
                 isClickable = true
+                minimumHeight = Ink.tapRow() // #245: list rows must stay tappable at any menu size
                 setOnClickListener { dialog.dismiss(); item.targetPage?.let { host.postJump(it) } }
                 addView(TextView(activity).apply {
                     text = item.title

--- a/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/BottomBarController.kt
@@ -109,8 +109,6 @@ class BottomBarController(private val host: Host) {
         }
         val total = host.pageCount.coerceAtLeast(1)
         val cur = host.currentPage.coerceIn(0, total - 1)
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
 
         val dialog = Dialog(activity).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
         val container = LinearLayout(activity).apply {
@@ -131,7 +129,7 @@ class BottomBarController(private val host: Host) {
             typeface = Ink.mono
             letterSpacing = 0.04f
             gravity = Gravity.CENTER
-            setPadding(dp(12), dp(6), dp(12), dp(6))
+            setPadding(Ink.sdp(12), Ink.sdp(6), Ink.sdp(12), Ink.sdp(6))
             background = GradientDrawable().apply {
                 setColor(Ink.fill)
                 cornerRadius = Ink.dpf(40)
@@ -139,7 +137,7 @@ class BottomBarController(private val host: Host) {
             setOnClickListener { dialog.dismiss(); showPageEntry(total) }
         }
         // A refined, thin grayscale track + small round thumb (the default SeekBar reads clunky).
-        val trackH = dp(3).coerceAtLeast(2)
+        val trackH = Ink.sdp(3).coerceAtLeast(2)
         fun bar(c: Int) = GradientDrawable().apply { setColor(c); cornerRadius = trackH.toFloat(); setSize(0, trackH) }
         val track = android.graphics.drawable.LayerDrawable(
             arrayOf(
@@ -147,14 +145,14 @@ class BottomBarController(private val host: Host) {
                 android.graphics.drawable.ClipDrawable(bar(Ink.ink), Gravity.START, android.graphics.drawable.ClipDrawable.HORIZONTAL),
             ),
         ).apply { setId(0, android.R.id.background); setId(1, android.R.id.progress) }
-        val knob = GradientDrawable().apply { shape = GradientDrawable.OVAL; setColor(Ink.ink); setSize(dp(16), dp(16)) }
+        val knob = GradientDrawable().apply { shape = GradientDrawable.OVAL; setColor(Ink.ink); setSize(Ink.sdp(16), Ink.sdp(16)) }
         val seek = SeekBar(activity).apply {
             max = total - 1
             progress = cur
             progressDrawable = track
             thumb = knob
             splitTrack = false
-            setPadding(dp(10), dp(4), dp(10), dp(4))
+            setPadding(Ink.sdp(10), Ink.sdp(4), Ink.sdp(10), Ink.sdp(4))
             setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
                 override fun onProgressChanged(sb: SeekBar, p: Int, fromUser: Boolean) {
                     if (fromUser) pageLabel.text = "${p + 1} / $total"
@@ -167,7 +165,7 @@ class BottomBarController(private val host: Host) {
         // shown only when the document has a table of contents (1.7).
         fun chapterBtn(glyph: String, dir: Int) = TextView(activity).apply {
             text = glyph; setTextColor(Ink.ink); textSize = Ink.sp(20f); typeface = Ink.serifBold
-            gravity = Gravity.CENTER; setPadding(dp(8), dp(2), dp(8), dp(2)); isClickable = true
+            gravity = Gravity.CENTER; setPadding(Ink.sdp(8), Ink.sdp(2), Ink.sdp(8), Ink.sdp(2)); isClickable = true
             setOnClickListener { dialog.dismiss(); chapterJump(dir) }
         }
         fileNameLine()?.let(container::addView)
@@ -175,11 +173,11 @@ class BottomBarController(private val host: Host) {
             LinearLayout(activity).apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
-                setPadding(dp(16), dp(12), dp(16), dp(6))
+                setPadding(Ink.sdp(16), Ink.sdp(12), Ink.sdp(16), Ink.sdp(6))
                 if (host.chapters.isNotEmpty()) addView(chapterBtn("‹‹", -1))
                 addView(seek, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
                 if (host.chapters.isNotEmpty()) addView(chapterBtn("››", +1))
-                addView(pageLabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply { marginStart = dp(12) })
+                addView(pageLabel, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply { marginStart = Ink.sdp(12) })
             },
         )
         // Current-chapter line under the scrubber: orients the reader and makes the ‹‹/›› obvious.
@@ -189,7 +187,7 @@ class BottomBarController(private val host: Host) {
             container.addView(LinearLayout(activity).apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
-                setPadding(dp(24), 0, dp(24), dp(8))
+                setPadding(Ink.sdp(24), 0, Ink.sdp(24), Ink.sdp(8))
                 isClickable = true
                 setOnClickListener { dialog.dismiss(); showContentsLazy() }
                 addView(TextView(activity).apply {
@@ -199,7 +197,7 @@ class BottomBarController(private val host: Host) {
                 inChapterPosition()?.let { pos ->
                     addView(TextView(activity).apply {
                         text = pos; setTextColor(Ink.muted); textSize = Ink.sp(12f); typeface = Ink.mono
-                        setPadding(dp(10), 0, 0, 0)
+                        setPadding(Ink.sdp(10), 0, 0, 0)
                     })
                 }
             })
@@ -208,7 +206,7 @@ class BottomBarController(private val host: Host) {
         // Control row: flat, evenly-weighted icon+label cells.
         val controls = LinearLayout(activity).apply {
             orientation = LinearLayout.HORIZONTAL
-            setPadding(dp(2), dp(6), dp(2), dp(12))
+            setPadding(Ink.sdp(2), Ink.sdp(6), Ink.sdp(2), Ink.sdp(12))
         }
         // One control = a line icon over a small label (Boox/NeoReader bottom-bar style, frame 069).
         //
@@ -219,7 +217,7 @@ class BottomBarController(private val host: Host) {
             val cell = LinearLayout(activity).apply {
                 orientation = LinearLayout.VERTICAL
                 gravity = Gravity.CENTER
-                setPadding(dp(2), dp(8), dp(2), dp(8))
+                setPadding(Ink.sdp(2), Ink.sdp(8), Ink.sdp(2), Ink.sdp(8))
                 isClickable = true
                 setOnClickListener {
                     if (!staysOpen) dialog.dismiss()
@@ -427,12 +425,10 @@ class BottomBarController(private val host: Host) {
 
     /** The inked pages as a scrollable "Page N · M notes" list; tap a row to jump there. */
     private fun showAnnotationsList(items: List<Pair<Int, Int>>) {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         val dialog = Dialog(activity).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
         val outer = LinearLayout(activity).apply {
             orientation = LinearLayout.VERTICAL
-            setPadding(dp(24), dp(22), dp(24), dp(14))
+            setPadding(Ink.sdp(24), Ink.sdp(22), Ink.sdp(24), Ink.sdp(14))
         }
         outer.addView(Ink.eyebrow(activity, "Annotations"))
         outer.addView(Ink.gap(activity, 10))
@@ -445,7 +441,7 @@ class BottomBarController(private val host: Host) {
             list.addView(LinearLayout(activity).apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
-                setPadding(dp(4), dp(14), dp(4), dp(14))
+                setPadding(Ink.sdp(4), Ink.sdp(14), Ink.sdp(4), Ink.sdp(14))
                 isClickable = true
                 setOnClickListener { dialog.dismiss(); host.postJump(page) }
                 addView(TextView(activity).apply {
@@ -471,13 +467,11 @@ class BottomBarController(private val host: Host) {
     /** The document's table of contents (RR11-FR2), shown as a scrollable list from the popup. */
     private fun showContents(toc: List<TocItem>) {
         if (toc.isEmpty()) return
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         val dialog = Dialog(activity).apply { requestWindowFeature(Window.FEATURE_NO_TITLE) }
 
         val outer = LinearLayout(activity).apply {
             orientation = LinearLayout.VERTICAL
-            setPadding(dp(24), dp(22), dp(24), dp(14))
+            setPadding(Ink.sdp(24), Ink.sdp(22), Ink.sdp(24), Ink.sdp(14))
         }
         outer.addView(Ink.eyebrow(activity, "Contents"))
         outer.addView(Ink.gap(activity, 10))
@@ -490,7 +484,7 @@ class BottomBarController(private val host: Host) {
             list.addView(LinearLayout(activity).apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
-                setPadding(dp(4) + item.depth * dp(18), dp(14), dp(4), dp(14))
+                setPadding(Ink.sdp(4) + item.depth * Ink.sdp(18), Ink.sdp(14), Ink.sdp(4), Ink.sdp(14))
                 isClickable = true
                 setOnClickListener { dialog.dismiss(); item.targetPage?.let { host.postJump(it) } }
                 addView(TextView(activity).apply {
@@ -503,7 +497,7 @@ class BottomBarController(private val host: Host) {
                 item.targetPage?.let { p ->
                     addView(TextView(activity).apply {
                         text = "${p + 1}"; setTextColor(Ink.muted); textSize = Ink.sp(12f); typeface = Ink.mono
-                        setPadding(dp(12), 0, 0, 0)
+                        setPadding(Ink.sdp(12), 0, 0, 0)
                     })
                 }
             })
@@ -540,8 +534,6 @@ class BottomBarController(private val host: Host) {
      * here rather than behind a twelfth control in a row that is already full on a small panel.
      */
     private fun fileNameLine(): View? {
-        val d = activity.resources.displayMetrics.density
-        fun dp(v: Int) = (v * d).toInt()
         val file = java.io.File(host.requestedPath ?: return null)
         val title = Books.metaTitle(activity, file.name) ?: Books.title(file)
         val name = Books.disambiguatingFileName(title, file.name)
@@ -556,7 +548,7 @@ class BottomBarController(private val host: Host) {
             typeface = Ink.mono
             maxLines = 1
             ellipsize = android.text.TextUtils.TruncateAt.MIDDLE
-            setPadding(dp(24), dp(12), dp(24), 0)
+            setPadding(Ink.sdp(24), Ink.sdp(12), Ink.sdp(24), 0)
         }
     }
 

--- a/app/src/main/java/dev/jraghavan/inkread/Ink.kt
+++ b/app/src/main/java/dev/jraghavan/inkread/Ink.kt
@@ -62,6 +62,34 @@ object Ink {
 
     fun dpf(v: Int): Float = v * density
 
+    /**
+     * Minimum extent for a **compact** tappable control (#245) — a button or an option cell, where
+     * the target is roughly as wide as it is tall.
+     *
+     * Deliberately **not** scaled by [uiScale]. Menu Size changes how big the chrome looks; it does
+     * not change how big a fingertip is, and the smaller steps were putting clickable cells at
+     * 20-32dp. Measured on a Manta at XS: the page label 21.9dp, the chapter buttons 24.0dp, the
+     * Adjust sheet's segmented options 31.5dp — including the Menu Size selector itself, so the
+     * control that gets you back out of XS was among the hardest to hit.
+     *
+     * 44 rather than the 48 the platform recommends. 48 was tried first and made the reading bar
+     * 26% taller at the default, which reads as a bar that has taken over the page. 44 keeps every
+     * control comfortably hittable while giving that back. Applied as a minimum, so a control
+     * already larger is untouched.
+     */
+    fun tap(): Int = dp(44)
+
+    /**
+     * Minimum height for a **full-width row** (#245) — a list row or the chapter line, spanning the
+     * whole panel.
+     *
+     * Lower than [tap] on purpose. A row 1920px wide is a far more forgiving target than a 90px
+     * button of the same height: the hard part of hitting a control is its smaller dimension, and
+     * these have none. Trading 4dp of height per row back to the page is worth more here than the
+     * margin it buys.
+     */
+    fun tapRow(): Int = dp(40)
+
     /** A hairline that never collapses to 0 px. */
     fun hair(): Int = maxOf(1, dp(1))
 


### PR DESCRIPTION
Closes #245.

Menu Size reached the chrome text and the control icon, but not the geometry around them. Raising it
grew the glyphs inside a bar whose padding, slider and list rows stayed put, so it read as oversized
text in a small menu rather than a larger menu. This is the other half of #133.

Two commits: the scaling, then a touch-target floor that scaling exposed.

## 1. Scale the geometry

The bottom bar's and the Adjust sheet's dimensions go through `Ink.sdp` instead of their own local
density helpers, which also removes nine duplicated copies of the same two-line
`fun dp(v: Int) = (v * d).toInt()`.

Hairlines were already on `Ink.hair()` and are untouched. One 1dp **border stroke** the sweep caught
is back on `Ink.hair()` too: a keyline is a keyline at any menu size, and scaling it would have
thickened the stepper outline at 2XL.

No new setting. The control already exists at bottom bar → Adjust → Display → **Menu Size**.

### Measured, 2XL against XS

`adb screencap` is black on this panel, so everything here was measured with `uiautomator dump`,
which reports real view bounds. The setting ratio is 0.8/1.5 = **0.533**:

| element | 2XL | XS | ratio |
|---|---|---|---|
| control cell | 110.9dp | 59.7dp | 0.538 |
| control icon | 58.1dp | 30.9dp | 0.532 |
| ‹‹ / ›› chapter button | 44.8dp | 24.0dp | 0.536 |
| page label | 41.6dp | 21.9dp | 0.526 |
| chapter row | 36.3dp | 19.7dp | 0.543 |
| **whole bar** | **244.8dp** | **132.3dp** | 0.540 |

Every element within 0.526 to 0.543 of the setting ratio, so the surface moves as one. Before, only
the text and the icon moved.

The **SeekBar is the exception at 0.738** (34.7dp → 25.6dp): its thumb scales but the widget has an
intrinsic minimum height. A floor rather than a defect, noted so nobody chases it.

## 2. Floor the touch targets

Those same measurements showed the controls were too small, and not only at XS. At XS the chapter row
was 19.7dp, the page label 21.9dp, the chapter buttons 24.0dp; every Adjust sheet control sat between
23.5 and 47.5dp, the Menu Size selector among them at 31.5dp, so the control that gets you back out
of XS was one of the hardest to hit. The scrubber row's controls were under 48dp **even at 2XL**, so
no menu size fixed them.

Two floors, neither scaled by `uiScale`, because Menu Size changes how big the chrome looks and not
how big a fingertip is:

- **`Ink.tap()` = 44dp** for compact controls. The platform recommends 48 and I tried that first; it
  made the bar 26% taller at the default, which reads as a bar taking over the page. 44 is the iOS
  standard and gives most of that back.
- **`Ink.tapRow()` = 40dp** for full-width rows. Lower on purpose: a 1920px-wide row is far more
  forgiving than a 90px button of the same height, because the hard part of hitting a control is its
  smaller dimension and these have none.

Applied as minimums, so anything already larger is untouched — the bar's control cells are 74.7dp and
did not move.

### Measured at M, with the 48dp attempt for comparison

| control | 48dp floor | shipped (44/40) |
|---|---|---|
| chapter buttons | 48.0dp | 43.7dp |
| page label | 48.0dp | 43.7dp |
| chapter row | 48.0dp | 40.0dp |
| scrubber row | 65.6dp | 61.3dp |
| **whole bar** | **206.4dp** | **194.1dp** |

43.7 rather than 44.0 because `dp(44)` is 82.5px at this density and views take integer pixels.
Against roughly 164dp unfloored, so the floors cost about 30dp at the default.

**Correcting something I wrote in the first version of this description:** M is *not* pixel-identical
to before. `Ink.sdp` does return exactly `Ink.dp` at scale 1.0, so the scaling commit alone left M
untouched — but the floors change it, because several controls sat under 40dp at M as well. The bar
is about 30dp taller at the default than it was, deliberately.

### One control deliberately left alone

The contrast cell-bar. It is a level indicator drawn as segments rather than a row of buttons, each
cell is about 111dp wide, and forcing a height floor would turn a thin bar into a chunky one at every
menu size including the default. Recorded in the code as a decision, not an oversight.

## Tests

`cargo fmt --check`, `cargo clippy --all -D warnings`, `cargo test --workspace`, the
`aarch64-linux-android` JNI cross-check, `:app:testReleaseUnitTest` and the licence manifest check all
pass.

No unit test. These are view dimensions assembled at runtime with no logic to assert, and there is no
instrumentation harness here to measure a laid-out view. The `uiautomator` figures above are the
verification, and they are measurements rather than impressions.
